### PR TITLE
Resolve #72: Build LunaSkeleton primitive

### DIFF
--- a/.changeset/luna-skeleton-issue-72.md
+++ b/.changeset/luna-skeleton-issue-72.md
@@ -1,0 +1,3 @@
+"@liketysplit/react-luna": minor
+
+Add the new `LunaSkeleton` primitive with theme-driven shapes, sizing, animation, Storybook coverage, tests, and public docs.

--- a/docs/v1/components/LunaSkeleton.md
+++ b/docs/v1/components/LunaSkeleton.md
@@ -1,0 +1,58 @@
+# LunaSkeleton
+
+`LunaSkeleton` is the standard loading placeholder primitive for `react-luna`.
+
+It owns:
+- reusable loading placeholders for common shapes
+- theme-driven surface and animation treatment
+- text-line grouping for common content placeholders
+- width and height resolution through theme spacing or raw CSS values
+
+It does not own:
+- loading state orchestration
+- application-specific layout composition
+- announcements or status messaging
+
+## Props
+
+- `as?: React.ElementType`
+- `shape?: "text" | "block" | "pill" | "circle"`
+- `size?: string`
+- `width?: string`
+- `height?: string`
+- `lines?: number`
+- `lastLineWidth?: string`
+- `animation?: "pulse" | "wave" | "none"`
+- `inline?: boolean`
+- `decorative?: boolean`
+
+## Contract
+
+- `shape` defaults to `text`
+- `size` resolves through `theme.components.skeleton.sizes` first, then through theme spacing, then raw CSS values
+- `width`, `height`, and `lastLineWidth` resolve through theme spacing first, then raw CSS values
+- text, block, and pill shapes expand to `100%` width by default unless `inline` or `width` changes that
+- circle skeletons default to equal width and height when `width` is not provided
+- `lines` only affects the `text` shape and is clamped to at least one line
+- multi-line text skeletons shorten the last line to `72%` width by default unless `lastLineWidth` is provided
+- `animation` defaults from the theme and supports `wave`, `pulse`, or `none`
+- `decorative` defaults to `true` so the skeleton is hidden from assistive technology unless a consumer opts into a semantic use case
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaSkeleton` consumes the existing `ThemeProvider` for:
+- default skeleton size
+- default animation mode
+- default block radius
+- text-line radius
+- size profiles
+- mode-aware base surface color
+- mode-aware highlight treatment
+- shared motion timing tokens
+
+## Accessibility
+
+- skeleton placeholders are decorative by default and render with `aria-hidden="true"`
+- consumers can set `decorative={false}` when the placeholder must participate in a larger semantic pattern
+- `LunaSkeleton` does not announce loading state on its own; parent surfaces should own that decision

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export * from "./luna-textarea";
 export * from "./luna-select";
 export * from "./luna-multiselect";
 export * from "./luna-autocomplete";
+export * from "./luna-skeleton";
 export * from "./luna-switch";
 export * from "./luna-text";
 export * from "./luna-row";

--- a/src/components/luna-skeleton/LunaSkeleton.css
+++ b/src/components/luna-skeleton/LunaSkeleton.css
@@ -1,0 +1,77 @@
+.luna-skeleton {
+  display: grid;
+  gap: var(--luna-space-2);
+  width: var(--luna-skeleton-current-width, 100%);
+}
+
+.luna-skeleton[data-inline="true"] {
+  display: inline-grid;
+  vertical-align: middle;
+}
+
+.luna-skeleton__item {
+  position: relative;
+  display: block;
+  width: var(--luna-skeleton-current-width, 100%);
+  height: var(--luna-skeleton-current-height, 0.75rem);
+  overflow: hidden;
+  border-radius: var(--luna-skeleton-current-radius, var(--luna-radius-pill));
+  background: var(--luna-skeleton-bg, var(--luna-border));
+}
+
+.luna-skeleton__item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--luna-skeleton-highlight, rgba(255, 255, 255, 0.4)) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+}
+
+.luna-skeleton[data-shape="circle"] .luna-skeleton__item {
+  width: var(--luna-skeleton-current-width, var(--luna-skeleton-current-height, 0.75rem));
+  border-radius: var(--luna-radius-pill);
+  aspect-ratio: 1 / 1;
+}
+
+.luna-skeleton[data-shape="pill"] .luna-skeleton__item {
+  border-radius: var(--luna-radius-pill);
+}
+
+.luna-skeleton[data-animation="pulse"] .luna-skeleton__item {
+  animation: luna-skeleton-pulse calc(var(--luna-motion-slow) * 6) ease-in-out infinite;
+}
+
+.luna-skeleton[data-animation="pulse"] .luna-skeleton__item::after,
+.luna-skeleton[data-animation="none"] .luna-skeleton__item::after {
+  display: none;
+}
+
+.luna-skeleton[data-animation="wave"] .luna-skeleton__item::after {
+  animation: luna-skeleton-wave calc(var(--luna-motion-slow) * 7) linear infinite;
+}
+
+.luna-skeleton[data-animation="none"] .luna-skeleton__item {
+  animation: none;
+}
+
+@keyframes luna-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes luna-skeleton-wave {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/components/luna-skeleton/LunaSkeleton.props.ts
+++ b/src/components/luna-skeleton/LunaSkeleton.props.ts
@@ -1,0 +1,17 @@
+import type React from "react";
+
+export type LunaSkeletonAnimation = "pulse" | "wave" | "none";
+export type LunaSkeletonShape = "text" | "block" | "pill" | "circle";
+
+export type LunaSkeletonProps = Omit<React.HTMLAttributes<HTMLElement>, "children" | "color"> & {
+  as?: React.ElementType;
+  shape?: LunaSkeletonShape;
+  size?: string;
+  width?: string;
+  height?: string;
+  lines?: number;
+  lastLineWidth?: string;
+  animation?: LunaSkeletonAnimation;
+  inline?: boolean;
+  decorative?: boolean;
+};

--- a/src/components/luna-skeleton/LunaSkeleton.stories.tsx
+++ b/src/components/luna-skeleton/LunaSkeleton.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaSkeleton } from "./LunaSkeleton";
+
+const meta = {
+  title: "Components/LunaSkeleton",
+  component: LunaSkeleton,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    width: "16"
+  }
+} satisfies Meta<typeof LunaSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const ShapeMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gap: "1rem",
+        width: "min(36rem, 90vw)"
+      }}
+    >
+      <LunaSkeleton shape="text" lines={3} />
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+        <LunaSkeleton shape="circle" size="10" />
+        <LunaSkeleton shape="pill" width="8" size="4" />
+        <LunaSkeleton shape="block" width="12" height="6" />
+      </div>
+    </div>
+  )
+};
+
+export const SizeScale: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "0.75rem", width: "20rem" }}>
+      <LunaSkeleton size="x-small" />
+      <LunaSkeleton size="small" />
+      <LunaSkeleton size="medium" />
+      <LunaSkeleton size="large" />
+      <LunaSkeleton size="x-large" />
+    </div>
+  )
+};
+
+export const AnimationModes: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", width: "20rem" }}>
+      <LunaSkeleton animation="wave" />
+      <LunaSkeleton animation="pulse" />
+      <LunaSkeleton animation="none" />
+    </div>
+  )
+};
+
+export const SurfaceComposition: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gap: "1rem",
+        width: "min(28rem, 90vw)",
+        padding: "1.5rem",
+        border: "1px solid var(--luna-border)",
+        borderRadius: "var(--luna-radius-lg)",
+        background: "var(--luna-surface)"
+      }}
+    >
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+        <LunaSkeleton shape="circle" size="12" />
+        <div style={{ display: "grid", gap: "0.5rem", flex: 1 }}>
+          <LunaSkeleton shape="text" width="10" />
+          <LunaSkeleton shape="text" lines={2} lastLineWidth="6" />
+        </div>
+      </div>
+      <LunaSkeleton shape="block" height="12" />
+      <div style={{ display: "flex", gap: "0.75rem" }}>
+        <LunaSkeleton shape="pill" width="7" size="4" />
+        <LunaSkeleton shape="pill" width="5" size="4" />
+      </div>
+    </div>
+  )
+};

--- a/src/components/luna-skeleton/LunaSkeleton.test.tsx
+++ b/src/components/luna-skeleton/LunaSkeleton.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaSkeleton } from "./LunaSkeleton";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaSkeleton", () => {
+  it("renders a single decorative text skeleton by default", () => {
+    renderWithTheme(<LunaSkeleton data-testid="skeleton" />);
+
+    const skeleton = screen.getByTestId("skeleton");
+    const items = skeleton.querySelectorAll(".luna-skeleton__item");
+
+    expect(skeleton).toHaveAttribute("data-shape", "text");
+    expect(skeleton).toHaveAttribute("data-animation", "wave");
+    expect(skeleton).toHaveAttribute("aria-hidden", "true");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveStyle({ "--luna-skeleton-current-width": "100%" });
+  });
+
+  it("renders the requested number of text lines and shortens the final line", () => {
+    renderWithTheme(<LunaSkeleton data-testid="skeleton" lines={3} />);
+
+    const skeleton = screen.getByTestId("skeleton");
+    const items = skeleton.querySelectorAll(".luna-skeleton__item");
+
+    expect(items).toHaveLength(3);
+    expect(items[2]).toHaveStyle({ "--luna-skeleton-current-width": "72%" });
+  });
+
+  it("uses circle sizing when width is not provided", () => {
+    renderWithTheme(<LunaSkeleton data-testid="skeleton" shape="circle" size="10" />);
+
+    expect(screen.getByTestId("skeleton")).toHaveStyle({
+      "--luna-skeleton-current-height": "2.5rem",
+      "--luna-skeleton-current-width": "2.5rem"
+    });
+  });
+
+  it("resolves width, height, and last line width through theme spacing tokens", () => {
+    renderWithTheme(
+      <LunaSkeleton
+        data-testid="skeleton"
+        shape="text"
+        lines={2}
+        width="16"
+        height="3"
+        lastLineWidth="8"
+      />
+    );
+
+    const skeleton = screen.getByTestId("skeleton");
+    const items = skeleton.querySelectorAll(".luna-skeleton__item");
+
+    expect(skeleton).toHaveStyle({
+      "--luna-skeleton-current-width": "4rem",
+      "--luna-skeleton-current-height": "0.75rem"
+    });
+    expect(items[1]).toHaveStyle({ "--luna-skeleton-current-width": "2rem" });
+  });
+
+  it("uses user theme skeleton defaults when provided", () => {
+    renderWithTheme(<LunaSkeleton data-testid="skeleton" />, {
+      theme: {
+        components: {
+          skeleton: {
+            defaultSize: "large",
+            defaultAnimation: "pulse",
+            sizes: {
+              large: {
+                height: "1.125rem"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(screen.getByTestId("skeleton")).toHaveStyle({
+      "--luna-skeleton-current-height": "1.125rem"
+    });
+    expect(screen.getByTestId("skeleton")).toHaveAttribute("data-animation", "pulse");
+  });
+
+  it("allows non-decorative usage to opt out of aria-hidden", () => {
+    renderWithTheme(<LunaSkeleton data-testid="skeleton" decorative={false} />);
+
+    expect(screen.getByTestId("skeleton")).not.toHaveAttribute("aria-hidden");
+  });
+});

--- a/src/components/luna-skeleton/LunaSkeleton.tsx
+++ b/src/components/luna-skeleton/LunaSkeleton.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaSkeletonProps } from "./LunaSkeleton.props";
+import "./LunaSkeleton.css";
+
+type SkeletonCssVariable =
+  | "--luna-skeleton-current-height"
+  | "--luna-skeleton-current-width"
+  | "--luna-skeleton-current-radius";
+
+type LunaSkeletonStyle = React.CSSProperties &
+  Partial<Record<SkeletonCssVariable, string | number | undefined>>;
+
+type LunaSkeletonItemStyle = React.CSSProperties &
+  Partial<Record<"--luna-skeleton-current-width", string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveDimensionValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveSkeletonHeight(
+  size: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!size) {
+    return undefined;
+  }
+
+  const profile = theme.components.skeleton?.sizes?.[size];
+  if (profile?.height) {
+    return resolveDimensionValue(profile.height, theme);
+  }
+
+  return resolveDimensionValue(size, theme);
+}
+
+function resolveRadius(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function normalizeLineCount(value: number | undefined) {
+  if (!value || Number.isNaN(value)) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+export const LunaSkeleton = React.forwardRef<HTMLElement, LunaSkeletonProps>(
+  function LunaSkeleton(
+    {
+      animation,
+      as,
+      className,
+      decorative = true,
+      height,
+      inline,
+      lastLineWidth,
+      lines,
+      shape = "text",
+      size,
+      style,
+      width,
+      ...props
+    },
+    ref
+  ) {
+    const { theme } = useTheme();
+    const Component = (as ?? "div") as React.ElementType;
+    const resolvedSize = size ?? theme.components.skeleton?.defaultSize ?? "medium";
+    const resolvedAnimation =
+      animation ?? theme.components.skeleton?.defaultAnimation ?? "wave";
+    const resolvedHeight = resolveDimensionValue(height, theme) ?? resolveSkeletonHeight(resolvedSize, theme);
+    const resolvedWidth =
+      resolveDimensionValue(width, theme) ??
+      (shape === "circle" ? resolvedHeight : inline ? undefined : "100%");
+    const resolvedLineCount = shape === "text" ? normalizeLineCount(lines) : 1;
+    const resolvedLastLineWidth =
+      resolvedLineCount > 1
+        ? resolveDimensionValue(lastLineWidth, theme) ?? "72%"
+        : resolvedWidth;
+    const skeletonStyle: LunaSkeletonStyle = {
+      ["--luna-skeleton-current-height" as const]: resolvedHeight,
+      ["--luna-skeleton-current-width" as const]: resolvedWidth,
+      ["--luna-skeleton-current-radius" as const]:
+        shape === "pill" || shape === "circle"
+          ? resolveRadius("pill", theme)
+          : shape === "text"
+            ? resolveRadius(theme.components.skeleton?.textRadius, theme)
+            : resolveRadius(theme.components.skeleton?.radius, theme),
+      ...style
+    };
+
+    return (
+      <Component
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-skeleton", className])}
+        data-animation={resolvedAnimation}
+        data-inline={inline ? "true" : undefined}
+        data-lines={resolvedLineCount > 1 ? String(resolvedLineCount) : undefined}
+        data-shape={shape}
+        data-size={resolvedSize}
+        aria-hidden={decorative ? true : props["aria-hidden"]}
+        style={skeletonStyle}
+      >
+        {Array.from({ length: resolvedLineCount }).map((_, index) => {
+          const isLastLine = index === resolvedLineCount - 1;
+          return (
+            <span
+              aria-hidden="true"
+              className="luna-skeleton__item"
+              data-line={shape === "text" ? String(index + 1) : undefined}
+              key={index}
+              style={
+                shape === "text" && isLastLine
+                  ? ({
+                      ["--luna-skeleton-current-width" as const]: resolvedLastLineWidth
+                    } as LunaSkeletonItemStyle)
+                  : undefined
+              }
+            />
+          );
+        })}
+      </Component>
+    );
+  }
+);

--- a/src/components/luna-skeleton/index.ts
+++ b/src/components/luna-skeleton/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaSkeleton";
+export * from "./LunaSkeleton.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -360,6 +360,39 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    skeleton: {
+      defaultSize: "medium",
+      defaultAnimation: "wave",
+      radius: "md",
+      textRadius: "pill",
+      sizes: {
+        "x-small": {
+          height: "0.375rem"
+        },
+        small: {
+          height: "0.5rem"
+        },
+        medium: {
+          height: "0.75rem"
+        },
+        large: {
+          height: "1rem"
+        },
+        "x-large": {
+          height: "1.25rem"
+        }
+      },
+      modes: {
+        light: {
+          bg: "neutral.200",
+          highlight: "rgba(255, 255, 255, 0.55)"
+        },
+        dark: {
+          bg: "neutral.700",
+          highlight: "rgba(248, 250, 252, 0.16)"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -106,6 +106,15 @@ export type ThemeDividerModeTokens = {
   labelFg?: string;
 };
 
+export type ThemeSkeletonSizeProfile = {
+  height?: string;
+};
+
+export type ThemeSkeletonModeTokens = {
+  bg?: string;
+  highlight?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -184,6 +193,14 @@ export type ThemeComponents = {
     defaultSpacing?: string;
     defaultInset?: string;
     modes?: Partial<Record<ThemeMode, ThemeDividerModeTokens>>;
+  };
+  skeleton?: {
+    defaultSize?: string;
+    defaultAnimation?: "pulse" | "wave" | "none";
+    radius?: string;
+    textRadius?: string;
+    sizes?: Record<string, ThemeSkeletonSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemeSkeletonModeTokens>>;
   };
   input?: {
     defaultSize?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -227,6 +227,37 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     vars["--luna-divider-label-fg"] = resolveTokenValue(theme, dividerMode.labelFg);
   }
 
+  const skeleton = theme.components.skeleton;
+  if (skeleton?.defaultSize) {
+    vars["--luna-skeleton-size-default"] = skeleton.defaultSize;
+  }
+  if (skeleton?.defaultAnimation) {
+    vars["--luna-skeleton-animation-default"] = skeleton.defaultAnimation;
+  }
+  if (skeleton?.radius) {
+    vars["--luna-skeleton-radius"] =
+      resolveScaleValue(theme.radii, skeleton.radius) ?? skeleton.radius;
+  }
+  if (skeleton?.textRadius) {
+    vars["--luna-skeleton-text-radius"] =
+      resolveScaleValue(theme.radii, skeleton.textRadius) ?? skeleton.textRadius;
+  }
+  const skeletonMode = skeleton?.modes?.[mode];
+  if (skeletonMode?.bg) {
+    vars["--luna-skeleton-bg"] = resolveTokenValue(theme, skeletonMode.bg);
+  }
+  if (skeletonMode?.highlight) {
+    vars["--luna-skeleton-highlight"] = resolveTokenValue(theme, skeletonMode.highlight);
+  }
+  if (skeleton?.sizes) {
+    for (const [name, profile] of Object.entries(skeleton.sizes)) {
+      if (profile.height) {
+        vars[`--luna-skeleton-size-${name}-height`] =
+          resolveScaleValue(theme.spacing, profile.height) ?? profile.height;
+      }
+    }
+  }
+
   const input = theme.components.input;
   if (input?.defaultSize) {
     vars["--luna-input-size-default"] = input.defaultSize;


### PR DESCRIPTION
Closes #72

## Summary
Implemented `LunaSkeleton` as issue `#72`’s scoped primitive. The new contract covers shape, size, width, height, line grouping, animation, inline behavior, and decorative defaults in [LunaSkeleton.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-skeleton/LunaSkeleton.props.ts#L1) and [LunaSkeleton.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-skeleton/LunaSkeleton.tsx#L65). Theme support for skeleton size profiles, radius, mode-aware surface, and highlight tokens was added in [types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts#L109), [base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts#L363), and [vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts#L230). The package export was added in [index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts#L16).

Storybook coverage is in [LunaSkeleton.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-skeleton/LunaSkeleton.stories.tsx#L4), focused tests are in [LunaSkeleton.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-skeleton/LunaSkeleton.test.tsx#L19), public docs are in [LunaSkeleton.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaSkeleton.md#L1), and the release note is in [.changeset/luna-skeleton-issue-72.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-skeleton-issue-72.md#L1).

Verification run:
- `npx vitest run src/components/luna-skeleton/LunaSkeleton.test.tsx src/theme/base.test.ts` passed
- `npm run build` passed

I could not create the requested git commit because the sandbox denied writing `.git/index.lock`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`