### PR TITLE
Resolve #73: Build LunaProgress primitive

### DIFF
--- a/.changeset/luna-progress-issue-73.md
+++ b/.changeset/luna-progress-issue-73.md
@@ -1,0 +1,3 @@
+"@liketysplit/react-luna": minor
+
+Add the new `LunaProgress` primitive with determinate and indeterminate modes, theme-driven sizing and tone, Storybook coverage, tests, and public docs.

--- a/docs/v1/components/LunaProgress.md
+++ b/docs/v1/components/LunaProgress.md
@@ -1,0 +1,58 @@
+# LunaProgress
+
+`LunaProgress` is the standard progress primitive for `react-luna`.
+
+It owns:
+- determinate and indeterminate progress presentation
+- theme-driven track sizing, tone, radius, and motion
+- visible label, description, and value text hooks
+- accessible `progressbar` semantics
+
+It does not own:
+- task orchestration
+- cancellation or retry controls
+- application-specific status layouts
+
+## Props
+
+- `label?: React.ReactNode`
+- `description?: React.ReactNode`
+- `value?: number`
+- `min?: number`
+- `max?: number`
+- `indeterminate?: boolean`
+- `size?: string`
+- `tone?: string`
+- `showValue?: boolean`
+- `valueLabel?: React.ReactNode`
+
+## Contract
+
+- `LunaProgress` renders a themed container with an internal element using `role="progressbar"`
+- `indeterminate` defaults to `false`
+- determinate mode uses `value`, `min`, and `max`, clamping `value` into the provided range
+- indeterminate mode omits numeric progress attributes and animates the indicator instead
+- `size` resolves through `theme.components.progress.sizes` first, then theme spacing, then raw CSS values
+- `tone` resolves through `theme.components.progress.tones`
+- `showValue` formats the current determinate progress as a percentage when `valueLabel` is not provided
+- `valueLabel` overrides the default visible percentage text
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaProgress` consumes the existing `ThemeProvider` for:
+- default progress size
+- default tone
+- track radius
+- indeterminate animation duration
+- size profiles
+- mode-aware track and text colors
+- tone-specific fill and glow colors
+
+## Accessibility
+
+- the progress indicator uses `role="progressbar"`
+- determinate mode sets `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`
+- indeterminate mode omits numeric value attributes
+- visible labels are linked with `aria-labelledby`
+- visible descriptions are linked with `aria-describedby`

--- a/docs/v1/design/LunaProgress.md
+++ b/docs/v1/design/LunaProgress.md
@@ -1,0 +1,49 @@
+# Progress Design
+
+This document records the initial design direction for `LunaProgress`.
+
+## Design Stance
+
+- keep the contract small and reusable
+- support determinate and indeterminate work without splitting the primitive
+- keep sizing, tone, radius, and motion theme-driven
+- avoid baking workflow-specific copy or controls into the primitive
+- preserve room for downstream theme overrides without changing the API
+
+## Decisions So Far
+
+- render a semantic `progressbar`
+- use `value`, `min`, and `max` for determinate progress
+- use `indeterminate` as the explicit non-numeric mode switch
+- support `label`, `description`, and visible value text
+- use `size` and `tone` as the public styling hooks
+
+## Current Intent Notes
+
+### Progress Model
+
+- determinate mode is the default
+- values clamp into the provided range
+- indeterminate mode suppresses numeric progress semantics
+
+### Visual Model
+
+- the track and fill remain simple, durable primitives
+- the track color follows the current theme mode
+- the fill color follows the selected theme tone
+- motion stays theme-driven and only appears in indeterminate mode
+
+### Text
+
+- `label` is the primary visible identifier
+- `description` gives supporting context without changing progress semantics
+- `showValue` reveals the default percentage label
+- `valueLabel` allows task-specific value text such as completed batches or files
+
+## Build Order
+
+1. define the progress props
+2. implement the semantic shell and indicator
+3. wire theme size, tone, and motion tokens
+4. add Storybook coverage
+5. add tests and public docs

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./luna-radio";
 export * from "./luna-divider";
 export * from "./luna-header";
 export * from "./luna-input";
+export * from "./luna-progress";
 export * from "./luna-slider";
 export * from "./luna-textarea";
 export * from "./luna-select";

--- a/src/components/luna-progress/LunaProgress.css
+++ b/src/components/luna-progress/LunaProgress.css
@@ -1,0 +1,71 @@
+.luna-progress {
+  display: grid;
+  gap: var(--luna-space-2, 0.5rem);
+  width: 100%;
+}
+
+.luna-progress__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--luna-space-3, 0.75rem);
+}
+
+.luna-progress__label {
+  color: var(--luna-progress-label-fg, var(--luna-foreground));
+}
+
+.luna-progress__description {
+  color: var(--luna-progress-description-fg, var(--luna-muted));
+}
+
+.luna-progress__value {
+  color: var(--luna-progress-value-fg, var(--luna-muted));
+  white-space: nowrap;
+}
+
+.luna-progress__track {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  min-width: 0;
+  height: var(--luna-progress-current-height, 0.5rem);
+  border-radius: var(--luna-progress-current-radius, var(--luna-radius-pill));
+  background: var(--luna-progress-current-track-bg, var(--luna-border));
+}
+
+.luna-progress__indicator {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  width: var(--luna-progress-current-value, 0%);
+  max-width: 100%;
+  border-radius: inherit;
+  background: var(--luna-progress-current-fill, var(--luna-primary-600));
+  box-shadow: 0 0 0.75rem var(--luna-progress-current-glow, transparent);
+  transition:
+    width var(--luna-motion-base, 180ms) ease,
+    background-color var(--luna-motion-base, 180ms) ease;
+}
+
+.luna-progress[data-indeterminate="true"] .luna-progress__indicator {
+  inset: 0;
+  width: 45%;
+  min-width: 20%;
+  animation: luna-progress-indeterminate
+    var(--luna-progress-current-indeterminate-duration, 1.4s) ease-in-out infinite;
+}
+
+@keyframes luna-progress-indeterminate {
+  0% {
+    transform: translateX(-120%);
+  }
+
+  55% {
+    transform: translateX(110%);
+  }
+
+  100% {
+    transform: translateX(230%);
+  }
+}

--- a/src/components/luna-progress/LunaProgress.props.ts
+++ b/src/components/luna-progress/LunaProgress.props.ts
@@ -1,0 +1,17 @@
+import type React from "react";
+
+export type LunaProgressProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children" | "color"
+> & {
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  value?: number;
+  min?: number;
+  max?: number;
+  indeterminate?: boolean;
+  size?: string;
+  tone?: string;
+  showValue?: boolean;
+  valueLabel?: React.ReactNode;
+};

--- a/src/components/luna-progress/LunaProgress.stories.tsx
+++ b/src/components/luna-progress/LunaProgress.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaProgress } from "./LunaProgress";
+
+const meta = {
+  title: "Components/LunaProgress",
+  component: LunaProgress,
+  args: {
+    label: "Uploading release assets",
+    description: "Pushing the final files into the package pipeline.",
+    value: 64,
+    showValue: true
+  }
+} satisfies Meta<typeof LunaProgress>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const SizeScale: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", width: "min(28rem, 90vw)" }}>
+      <LunaProgress label="Extra small" size="x-small" value={28} showValue />
+      <LunaProgress label="Small" size="small" value={42} showValue />
+      <LunaProgress label="Medium" size="medium" value={56} showValue />
+      <LunaProgress label="Large" size="large" value={73} showValue />
+      <LunaProgress label="Extra large" size="x-large" value={88} showValue />
+    </div>
+  )
+};
+
+export const ToneMatrix: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", width: "min(28rem, 90vw)" }}>
+      <LunaProgress label="Primary" tone="primary" value={36} showValue />
+      <LunaProgress label="Success" tone="success" value={68} showValue />
+      <LunaProgress label="Warning" tone="warning" value={54} showValue />
+      <LunaProgress label="Danger" tone="danger" value={82} showValue />
+      <LunaProgress label="Neutral" tone="neutral" value={47} showValue />
+    </div>
+  )
+};
+
+export const Indeterminate: Story = {
+  args: {
+    label: "Provisioning environment",
+    description: "Waiting for the runtime to finish the remaining background work.",
+    indeterminate: true,
+    showValue: false
+  }
+};
+
+export const CustomValueLabel: Story = {
+  args: {
+    label: "Migrating data",
+    description: "The archive is being reshaped into the new storage layout.",
+    value: 45,
+    valueLabel: "9 of 20 batches"
+  }
+};

--- a/src/components/luna-progress/LunaProgress.test.tsx
+++ b/src/components/luna-progress/LunaProgress.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaProgress } from "./LunaProgress";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaProgress", () => {
+  it("renders determinate progress semantics and formatted value text", () => {
+    renderWithTheme(<LunaProgress label="Upload" value={32} showValue />);
+
+    const progressbar = screen.getByRole("progressbar", { name: "Upload" });
+
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "32");
+    expect(screen.getByText("32%")).toBeInTheDocument();
+  });
+
+  it("clamps determinate progress to the provided bounds", () => {
+    renderWithTheme(<LunaProgress label="Setup" min={10} max={30} value={90} showValue />);
+
+    const progressbar = screen.getByRole("progressbar", { name: "Setup" });
+
+    expect(progressbar).toHaveAttribute("aria-valuemin", "10");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "30");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "30");
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("omits numeric progress semantics in indeterminate mode", () => {
+    renderWithTheme(<LunaProgress label="Processing" indeterminate />);
+
+    const root = screen.getByText("Processing").closest(".luna-progress");
+    const progressbar = screen.getByRole("progressbar", { name: "Processing" });
+
+    expect(progressbar).not.toHaveAttribute("aria-valuemin");
+    expect(progressbar).not.toHaveAttribute("aria-valuemax");
+    expect(progressbar).not.toHaveAttribute("aria-valuenow");
+    expect(root).toHaveAttribute("data-indeterminate", "true");
+  });
+
+  it("supports custom visible value labels", () => {
+    renderWithTheme(<LunaProgress label="Upload" value={45} valueLabel="3 of 7 files" />);
+
+    expect(screen.getByText("3 of 7 files")).toBeInTheDocument();
+  });
+
+  it("resolves size and tone from the user theme", () => {
+    renderWithTheme(<LunaProgress data-testid="progress" size="roomy" tone="brand" />, {
+      theme: {
+        components: {
+          progress: {
+            defaultTone: "neutral",
+            radius: "md",
+            indeterminateDuration: "slow",
+            sizes: {
+              roomy: {
+                height: "1"
+              }
+            },
+            tones: {
+              brand: {
+                fill: "accent.500",
+                glow: "rgba(139, 92, 246, 0.3)"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(screen.getByTestId("progress")).toHaveStyle({
+      "--luna-progress-current-height": "0.25rem",
+      "--luna-progress-current-fill": "#8b5cf6",
+      "--luna-progress-current-radius": "0.5rem",
+      "--luna-progress-current-indeterminate-duration": "260ms"
+    });
+  });
+
+  it("links descriptions to the progressbar", () => {
+    renderWithTheme(<LunaProgress label="Sync" description="Preparing records" value={20} />);
+
+    const description = screen.getByText("Preparing records");
+    const progressbar = screen.getByRole("progressbar", { name: "Sync" });
+
+    expect(progressbar).toHaveAttribute("aria-describedby", description.id);
+  });
+});

--- a/src/components/luna-progress/LunaProgress.tsx
+++ b/src/components/luna-progress/LunaProgress.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import { LunaText } from "../luna-text";
+import type { LunaProgressProps } from "./LunaProgress.props";
+import "./LunaProgress.css";
+
+type ProgressCssVariable =
+  | "--luna-progress-current-height"
+  | "--luna-progress-current-radius"
+  | "--luna-progress-current-value"
+  | "--luna-progress-current-fill"
+  | "--luna-progress-current-glow"
+  | "--luna-progress-current-track-bg"
+  | "--luna-progress-current-indeterminate-duration"
+  | "--luna-progress-label-fg"
+  | "--luna-progress-description-fg"
+  | "--luna-progress-value-fg";
+
+type LunaProgressStyle = React.CSSProperties &
+  Partial<Record<ProgressCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveSizeHeight(
+  size: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!size) {
+    return undefined;
+  }
+
+  const profile = theme.components.progress?.sizes?.[size];
+  if (profile?.height) {
+    return resolveScaleValue(theme.spacing, profile.height) ?? profile.height;
+  }
+
+  return resolveScaleValue(theme.spacing, size) ?? size;
+}
+
+function resolveRadius(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function resolveMotionValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.motion, value) ?? value;
+}
+
+function formatPercent(percent: number) {
+  const rounded = Math.round(percent * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded.toFixed(0)}%` : `${rounded}%`;
+}
+
+export const LunaProgress = React.forwardRef<HTMLDivElement, LunaProgressProps>(
+  function LunaProgress(
+    {
+      className,
+      description,
+      id,
+      indeterminate = false,
+      label,
+      max = 100,
+      min = 0,
+      showValue = false,
+      size,
+      style,
+      tone,
+      value = 0,
+      valueLabel,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const baseId = id ?? `luna-progress-${reactId.replace(/:/g, "")}`;
+    const labelId = label !== undefined && label !== null ? `${baseId}-label` : undefined;
+    const descriptionId =
+      description !== undefined && description !== null ? `${baseId}-description` : undefined;
+    const { theme, mode } = useTheme();
+    const resolvedSize = size ?? theme.components.progress?.defaultSize ?? "medium";
+    const resolvedTone = tone ?? theme.components.progress?.defaultTone ?? "primary";
+    const resolvedHeight = resolveSizeHeight(resolvedSize, theme);
+    const resolvedRadius = resolveRadius(theme.components.progress?.radius, theme);
+    const resolvedDuration = resolveMotionValue(
+      theme.components.progress?.indeterminateDuration,
+      theme
+    );
+    const resolvedToneTokens = theme.components.progress?.tones?.[resolvedTone];
+    const resolvedFill = resolveTokenValue(theme, resolvedToneTokens?.fill ?? "primary.600");
+    const resolvedGlow = resolvedToneTokens?.glow
+      ? resolveTokenValue(theme, resolvedToneTokens.glow)
+      : undefined;
+    const resolvedModeTokens = theme.components.progress?.modes?.[mode];
+    const resolvedTrackBg = resolvedModeTokens?.trackBg
+      ? resolveTokenValue(theme, resolvedModeTokens.trackBg)
+      : undefined;
+    const resolvedLabelFg = resolvedModeTokens?.labelFg
+      ? resolveTokenValue(theme, resolvedModeTokens.labelFg)
+      : undefined;
+    const resolvedDescriptionFg = resolvedModeTokens?.descriptionFg
+      ? resolveTokenValue(theme, resolvedModeTokens.descriptionFg)
+      : undefined;
+    const resolvedValueFg = resolvedModeTokens?.valueFg
+      ? resolveTokenValue(theme, resolvedModeTokens.valueFg)
+      : undefined;
+
+    const boundedMax = Math.max(max, min);
+    const clampedValue = clamp(value, min, boundedMax);
+    const percent =
+      boundedMax === min ? 0 : ((clampedValue - min) / (boundedMax - min)) * 100;
+    const resolvedValueLabel =
+      valueLabel ?? (!indeterminate && showValue ? formatPercent(percent) : undefined);
+
+    const rootStyle: LunaProgressStyle = {
+      ["--luna-progress-current-height" as const]: resolvedHeight,
+      ["--luna-progress-current-radius" as const]: resolvedRadius,
+      ["--luna-progress-current-value" as const]: `${percent}%`,
+      ["--luna-progress-current-fill" as const]: resolvedFill,
+      ["--luna-progress-current-glow" as const]: resolvedGlow,
+      ["--luna-progress-current-track-bg" as const]: resolvedTrackBg,
+      ["--luna-progress-current-indeterminate-duration" as const]: resolvedDuration,
+      ["--luna-progress-label-fg" as const]: resolvedLabelFg,
+      ["--luna-progress-description-fg" as const]: resolvedDescriptionFg,
+      ["--luna-progress-value-fg" as const]: resolvedValueFg,
+      ...style
+    };
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-progress", className])}
+        data-indeterminate={indeterminate ? "true" : undefined}
+        data-size={resolvedSize}
+        data-tone={resolvedTone}
+        style={rootStyle}
+      >
+        {label || resolvedValueLabel ? (
+          <div className="luna-progress__header">
+            {label ? (
+              <LunaText
+                as="span"
+                id={labelId}
+                variant="label"
+                className="luna-progress__label"
+              >
+                {label}
+              </LunaText>
+            ) : (
+              <span />
+            )}
+            {resolvedValueLabel !== undefined && resolvedValueLabel !== null ? (
+              <LunaText
+                as="span"
+                variant="caption"
+                className="luna-progress__value"
+              >
+                {resolvedValueLabel}
+              </LunaText>
+            ) : null}
+          </div>
+        ) : null}
+        {description ? (
+          <LunaText
+            as="div"
+            id={descriptionId}
+            variant="body-small"
+            className="luna-progress__description"
+          >
+            {description}
+          </LunaText>
+        ) : null}
+        <div
+          aria-describedby={descriptionId}
+          aria-labelledby={labelId}
+          aria-valuemax={indeterminate ? undefined : boundedMax}
+          aria-valuemin={indeterminate ? undefined : min}
+          aria-valuenow={indeterminate ? undefined : clampedValue}
+          className="luna-progress__track"
+          role="progressbar"
+        >
+          <span aria-hidden="true" className="luna-progress__indicator" />
+        </div>
+      </div>
+    );
+  }
+);

--- a/src/components/luna-progress/index.ts
+++ b/src/components/luna-progress/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaProgress";
+export * from "./LunaProgress.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -611,6 +611,65 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    progress: {
+      defaultSize: "medium",
+      defaultTone: "primary",
+      radius: "pill",
+      indeterminateDuration: "1.4s",
+      sizes: {
+        "x-small": {
+          height: "0.25rem"
+        },
+        small: {
+          height: "0.375rem"
+        },
+        medium: {
+          height: "0.5rem"
+        },
+        large: {
+          height: "0.75rem"
+        },
+        "x-large": {
+          height: "1rem"
+        }
+      },
+      modes: {
+        light: {
+          trackBg: "neutral.200",
+          labelFg: "neutral.800",
+          descriptionFg: "neutral.500",
+          valueFg: "neutral.600"
+        },
+        dark: {
+          trackBg: "neutral.700",
+          labelFg: "neutral.100",
+          descriptionFg: "neutral.400",
+          valueFg: "neutral.300"
+        }
+      },
+      tones: {
+        primary: {
+          fill: "primary.600",
+          glow: "rgba(99, 102, 241, 0.32)"
+        },
+        success: {
+          fill: "success.500",
+          glow: "rgba(16, 185, 129, 0.28)"
+        },
+        warning: {
+          fill: "warning.500",
+          glow: "rgba(249, 115, 22, 0.28)"
+        },
+        danger: {
+          fill: "danger.500",
+          glow: "rgba(239, 68, 68, 0.28)"
+        },
+        neutral: {
+          fill: "neutral.500",
+          glow: "rgba(100, 116, 139, 0.28)"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -134,6 +134,22 @@ export type ThemeSpinnerModeTokens = {
   track?: string;
 };
 
+export type ThemeProgressSizeProfile = {
+  height?: string;
+};
+
+export type ThemeProgressModeTokens = {
+  trackBg?: string;
+  labelFg?: string;
+  descriptionFg?: string;
+  valueFg?: string;
+};
+
+export type ThemeProgressToneTokens = {
+  fill?: string;
+  glow?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -238,6 +254,15 @@ export type ThemeComponents = {
     defaultLabel?: string;
     sizes?: Record<string, ThemeSpinnerSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeSpinnerModeTokens>>;
+  };
+  progress?: {
+    defaultSize?: string;
+    defaultTone?: string;
+    radius?: string;
+    indeterminateDuration?: string;
+    sizes?: Record<string, ThemeProgressSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemeProgressModeTokens>>;
+    tones?: Record<string, ThemeProgressToneTokens>;
   };
   input?: {
     defaultSize?: string;


### PR DESCRIPTION
Closes #73

## Summary
Implemented `LunaProgress` as a scoped issue `#73` slice. The new primitive supports determinate and indeterminate modes, theme-driven `size` and `tone`, visible `label`/`description`/value text, Storybook coverage, tests, docs, exports, and a changeset. Core implementation is in [LunaProgress.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-progress/LunaProgress.tsx), with theme hooks added in [types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts) and [base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts).

Docs and stories were added in [LunaProgress.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaProgress.md), [LunaProgress.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaProgress.md), and [LunaProgress.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-progress/LunaProgress.stories.tsx). Tests are in [LunaProgress.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-progress/LunaProgress.test.tsx), and release metadata is in [.changeset/luna-progress-issue-73.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-progress-issue-73.md).

Verification run:
- `npm test -- src/components/luna-progress/LunaProgress.test.tsx`
- `npm run build`

Both passed.

I could not create the commit because the sandbox blocked `.git` writes with `fatal: Unable to create '.git/index.lock': Operation not permitted`. If you want, I can still give you the exact commit command to run locally: `git add src/components/index.ts src/theme/base.ts src/theme/types.ts src/components/luna-progress docs/v1/components/LunaProgress.md docs/v1/design/LunaProgress.md .changeset/luna-progress-issue-73.md && git commit -m "Add LunaProgress primitive for issue #73"`

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`