### PR TITLE
Resolve #74: Build LunaSpinner primitive

### DIFF
--- a/.changeset/luna-spinner-issue-74.md
+++ b/.changeset/luna-spinner-issue-74.md
@@ -1,0 +1,3 @@
+"@liketysplit/react-luna": minor
+
+Add the new `LunaSpinner` primitive with theme-driven sizing, color, motion defaults, Storybook coverage, tests, and public docs.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,7 @@ The current shipped base already includes:
 - `LunaRow`
 - `LunaSelect`
 - `LunaSlider`
+- `LunaSpinner`
 - `LunaSwitch`
 - `LunaText`
 - `LunaTextarea`
@@ -78,7 +79,6 @@ The following still appear missing from the base roadmap and should be added wit
 
 - `LunaSkeleton`
 - `LunaProgress`
-- `LunaSpinner`
 - `LunaEmptyState`
 - `LunaAlert`
 

--- a/docs/v1/components/LunaSpinner.md
+++ b/docs/v1/components/LunaSpinner.md
@@ -1,0 +1,48 @@
+# LunaSpinner
+
+`LunaSpinner` is the standard standalone loading indicator primitive for `react-luna`.
+
+It owns:
+- a compact reusable loading indicator for inline or block composition
+- theme-driven size, color, track, and motion defaults
+- decorative and semantic loading usage without coupling to buttons or form controls
+
+It does not own:
+- layout composition around loading states
+- disabling or gating interactivity
+- loading message copy outside its own accessible label
+
+## Props
+
+- `as?: React.ElementType`
+- `size?: string`
+- `color?: string`
+- `decorative?: boolean`
+- `label?: string`
+
+## Contract
+
+- `LunaSpinner` renders as `span` by default and supports `as` for alternate host elements
+- `size` resolves through `theme.components.spinner.sizes` first, then theme spacing, then raw CSS values
+- `color` resolves as raw CSS, custom theme color, or theme scale token
+- motion duration resolves from `theme.components.spinner.duration`, which may reference shared theme motion tokens
+- `decorative` defaults to `true`, which hides the spinner from assistive technology
+- when `decorative={false}`, the spinner exposes `role="status"` and uses `label`, then the theme default label, then `"Loading"`
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaSpinner` consumes the existing `ThemeProvider` for:
+- default size
+- per-size dimension and stroke-width profiles
+- mode-aware spinner color
+- mode-aware track color
+- default accessible label
+- shared motion timing
+
+## Accessibility
+
+- decorative spinners render with `aria-hidden="true"` by default
+- semantic spinners can opt into `role="status"` with `decorative={false}`
+- `label` lets consumers set the spoken loading message when the spinner participates in a semantic loading pattern
+- `LunaSpinner` does not manage surrounding content announcements or focus behavior

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,6 +14,7 @@ export * from "./luna-select";
 export * from "./luna-multiselect";
 export * from "./luna-autocomplete";
 export * from "./luna-skeleton";
+export * from "./luna-spinner";
 export * from "./luna-switch";
 export * from "./luna-text";
 export * from "./luna-row";

--- a/src/components/luna-spinner/LunaSpinner.css
+++ b/src/components/luna-spinner/LunaSpinner.css
@@ -1,0 +1,46 @@
+.luna-spinner {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: var(--luna-spinner-current-size, var(--luna-spinner-size-medium, 1.25rem));
+  block-size: var(--luna-spinner-current-size, var(--luna-spinner-size-medium, 1.25rem));
+  color: var(--luna-spinner-current-color, var(--luna-spinner-color, var(--luna-foreground)));
+  flex: 0 0 auto;
+  vertical-align: middle;
+}
+
+.luna-spinner__track,
+.luna-spinner__indicator {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  border-style: solid;
+  border-width: var(
+    --luna-spinner-current-stroke-width,
+    var(--luna-spinner-size-medium-stroke-width, 0.1875rem)
+  );
+}
+
+.luna-spinner__track {
+  border-color: var(--luna-spinner-current-track, var(--luna-spinner-track, var(--luna-border)));
+}
+
+.luna-spinner__indicator {
+  border-color: transparent;
+  border-top-color: currentColor;
+  border-right-color: color-mix(in srgb, currentColor 72%, transparent);
+  animation: luna-spinner-rotate
+    var(--luna-spinner-current-duration, var(--luna-spinner-duration, 900ms)) linear infinite;
+  will-change: transform;
+}
+
+@keyframes luna-spinner-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/luna-spinner/LunaSpinner.props.ts
+++ b/src/components/luna-spinner/LunaSpinner.props.ts
@@ -1,0 +1,12 @@
+import type React from "react";
+
+export type LunaSpinnerProps = Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "children" | "color"
+> & {
+  as?: React.ElementType;
+  size?: string;
+  color?: string;
+  decorative?: boolean;
+  label?: string;
+};

--- a/src/components/luna-spinner/LunaSpinner.stories.tsx
+++ b/src/components/luna-spinner/LunaSpinner.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ThemeProvider } from "../../theme";
+import { LunaSpinner } from "./LunaSpinner";
+
+const meta = {
+  title: "Components/LunaSpinner",
+  component: LunaSpinner,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    decorative: true,
+    size: "medium"
+  }
+} satisfies Meta<typeof LunaSpinner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const SizeScale: Story = {
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <LunaSpinner size="x-small" />
+      <LunaSpinner size="small" />
+      <LunaSpinner size="medium" />
+      <LunaSpinner size="large" />
+      <LunaSpinner size="x-large" />
+    </div>
+  )
+};
+
+export const SurfaceModes: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+        gap: "1rem",
+        width: "min(30rem, 90vw)"
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          placeItems: "center",
+          minHeight: "8rem",
+          borderRadius: "var(--luna-radius-lg)",
+          border: "1px solid var(--luna-border)",
+          background: "var(--luna-background)"
+        }}
+      >
+        <LunaSpinner size="large" />
+      </div>
+      <ThemeProvider mode="dark">
+        <div
+          style={{
+            display: "grid",
+            placeItems: "center",
+            minHeight: "8rem",
+            borderRadius: "var(--luna-radius-lg)",
+            border: "1px solid var(--luna-border)",
+            background: "var(--luna-background)",
+            color: "var(--luna-foreground)"
+          }}
+        >
+          <LunaSpinner size="large" />
+        </div>
+      </ThemeProvider>
+    </div>
+  )
+};
+
+export const SemanticUsage: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.75rem",
+        padding: "1rem 1.25rem",
+        borderRadius: "var(--luna-radius-lg)",
+        border: "1px solid var(--luna-border)",
+        background: "var(--luna-surface)"
+      }}
+    >
+      <LunaSpinner decorative={false} label="Loading telemetry" />
+      <span>Loading telemetry</span>
+    </div>
+  )
+};
+
+export const ThemeOverride: Story = {
+  render: () => (
+    <ThemeProvider
+      theme={{
+        components: {
+          spinner: {
+            defaultSize: "large",
+            duration: "slow",
+            sizes: {
+              large: {
+                size: "2.5rem",
+                strokeWidth: "0.3125rem"
+              }
+            },
+            modes: {
+              light: {
+                color: "accent.500",
+                track: "rgba(139, 92, 246, 0.18)"
+              }
+            }
+          }
+        }
+      }}
+    >
+      <LunaSpinner />
+    </ThemeProvider>
+  )
+};

--- a/src/components/luna-spinner/LunaSpinner.test.tsx
+++ b/src/components/luna-spinner/LunaSpinner.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaSpinner } from "./LunaSpinner";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaSpinner", () => {
+  it("renders a decorative spinner by default", () => {
+    renderWithTheme(<LunaSpinner data-testid="spinner" />);
+
+    const spinner = screen.getByTestId("spinner");
+
+    expect(spinner).toHaveAttribute("aria-hidden", "true");
+    expect(spinner).not.toHaveAttribute("role");
+    expect(spinner).toHaveAttribute("data-size", "medium");
+    expect(spinner.querySelectorAll(".luna-spinner__track")).toHaveLength(1);
+    expect(spinner.querySelectorAll(".luna-spinner__indicator")).toHaveLength(1);
+  });
+
+  it("uses status semantics and the default loading label when decorative is false", () => {
+    renderWithTheme(<LunaSpinner decorative={false} />);
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("prefers the explicit label for semantic usage", () => {
+    renderWithTheme(<LunaSpinner decorative={false} label="Loading navigation" />);
+
+    expect(screen.getByRole("status", { name: "Loading navigation" })).toBeInTheDocument();
+  });
+
+  it("resolves size tokens and theme color values", () => {
+    renderWithTheme(<LunaSpinner data-testid="spinner" size="large" color="accent.500" />);
+
+    expect(screen.getByTestId("spinner")).toHaveStyle({
+      "--luna-spinner-current-size": "1.5rem",
+      "--luna-spinner-current-color": "#8b5cf6"
+    });
+  });
+
+  it("uses user theme spinner defaults when provided", () => {
+    renderWithTheme(<LunaSpinner data-testid="spinner" />, {
+      theme: {
+        components: {
+          spinner: {
+            defaultSize: "large",
+            duration: "slow",
+            defaultLabel: "Syncing orbit",
+            sizes: {
+              large: {
+                size: "2.25rem",
+                strokeWidth: "0.3125rem"
+              }
+            },
+            modes: {
+              light: {
+                color: "success.500",
+                track: "rgba(16, 185, 129, 0.2)"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(screen.getByTestId("spinner")).toHaveStyle({
+      "--luna-spinner-current-size": "2.25rem",
+      "--luna-spinner-current-color": "#10b981",
+      "--luna-spinner-current-track": "rgba(16, 185, 129, 0.2)",
+      "--luna-spinner-current-stroke-width": "0.3125rem",
+      "--luna-spinner-current-duration": "260ms"
+    });
+
+    cleanup();
+    renderWithTheme(
+      <LunaSpinner decorative={false} />,
+      {
+        theme: {
+          components: {
+            spinner: {
+              defaultLabel: "Syncing orbit"
+            }
+          }
+        }
+      }
+    );
+
+    expect(screen.getByRole("status", { name: "Syncing orbit" })).toBeInTheDocument();
+  });
+
+  it("supports custom element rendering", () => {
+    renderWithTheme(<LunaSpinner as="div" data-testid="spinner" />);
+
+    expect(screen.getByTestId("spinner").tagName).toBe("DIV");
+  });
+});

--- a/src/components/luna-spinner/LunaSpinner.tsx
+++ b/src/components/luna-spinner/LunaSpinner.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveModeTokens, resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import type { LunaSpinnerProps } from "./LunaSpinner.props";
+import "./LunaSpinner.css";
+
+type SpinnerCssVariable =
+  | "--luna-spinner-current-size"
+  | "--luna-spinner-current-color"
+  | "--luna-spinner-current-track"
+  | "--luna-spinner-current-stroke-width"
+  | "--luna-spinner-current-duration";
+
+type LunaSpinnerStyle = React.CSSProperties &
+  Partial<Record<SpinnerCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpinnerSize(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  const profile = theme.components.spinner?.sizes?.[value];
+  if (profile?.size) {
+    return resolveScaleValue(theme.spacing, profile.size) ?? profile.size;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveSpinnerStrokeWidth(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  const profile = theme.components.spinner?.sizes?.[value];
+  if (profile?.strokeWidth) {
+    return resolveScaleValue(theme.spacing, profile.strokeWidth) ?? profile.strokeWidth;
+  }
+
+  return undefined;
+}
+
+export const LunaSpinner = React.forwardRef<HTMLElement, LunaSpinnerProps>(function LunaSpinner(
+  { as, className, color, decorative = true, label, size, style, ...spinnerProps },
+  ref
+) {
+  const { mode, theme } = useTheme();
+  const Component = (as ?? "span") as React.ElementType;
+  const resolvedSize = size ?? theme.components.spinner?.defaultSize ?? "medium";
+  const modeTokens = resolveModeTokens(theme, mode);
+  const spinnerModeTokens = theme.components.spinner?.modes?.[mode];
+  const accessibleLabel = label ?? theme.components.spinner?.defaultLabel ?? "Loading";
+  const spinnerStyle: LunaSpinnerStyle = {
+    ["--luna-spinner-current-size" as const]: resolveSpinnerSize(resolvedSize, theme),
+    ["--luna-spinner-current-color" as const]: color
+      ? resolveTokenValue(theme, color)
+      : spinnerModeTokens?.color
+        ? resolveTokenValue(theme, spinnerModeTokens.color)
+        : modeTokens.foreground,
+    ["--luna-spinner-current-track" as const]: spinnerModeTokens?.track
+      ? resolveTokenValue(theme, spinnerModeTokens.track)
+      : modeTokens.border,
+    ["--luna-spinner-current-stroke-width" as const]: resolveSpinnerStrokeWidth(
+      resolvedSize,
+      theme
+    ),
+    ["--luna-spinner-current-duration" as const]:
+      resolveScaleValue(theme.motion, theme.components.spinner?.duration) ??
+      theme.components.spinner?.duration,
+    ...style
+  };
+
+  return (
+    <Component
+      {...spinnerProps}
+      ref={ref}
+      className={toClassName(["luna-spinner", className])}
+      data-size={resolvedSize}
+      role={decorative ? spinnerProps.role : spinnerProps.role ?? "status"}
+      aria-hidden={decorative ? true : spinnerProps["aria-hidden"]}
+      aria-label={!decorative ? spinnerProps["aria-label"] ?? accessibleLabel : spinnerProps["aria-label"]}
+      style={spinnerStyle}
+    >
+      <span aria-hidden="true" className="luna-spinner__track" />
+      <span aria-hidden="true" className="luna-spinner__indicator" />
+    </Component>
+  );
+});

--- a/src/components/luna-spinner/index.ts
+++ b/src/components/luna-spinner/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaSpinner";
+export * from "./LunaSpinner.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -393,6 +393,43 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    spinner: {
+      defaultSize: "medium",
+      duration: "900ms",
+      defaultLabel: "Loading",
+      sizes: {
+        "x-small": {
+          size: "3",
+          strokeWidth: "0.125rem"
+        },
+        small: {
+          size: "4",
+          strokeWidth: "0.125rem"
+        },
+        medium: {
+          size: "5",
+          strokeWidth: "0.1875rem"
+        },
+        large: {
+          size: "6",
+          strokeWidth: "0.1875rem"
+        },
+        "x-large": {
+          size: "8",
+          strokeWidth: "0.25rem"
+        }
+      },
+      modes: {
+        light: {
+          color: "primary.600",
+          track: "rgba(148, 163, 184, 0.24)"
+        },
+        dark: {
+          color: "primary.300",
+          track: "rgba(226, 232, 240, 0.22)"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -115,6 +115,16 @@ export type ThemeSkeletonModeTokens = {
   highlight?: string;
 };
 
+export type ThemeSpinnerSizeProfile = {
+  size?: string;
+  strokeWidth?: string;
+};
+
+export type ThemeSpinnerModeTokens = {
+  color?: string;
+  track?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -201,6 +211,13 @@ export type ThemeComponents = {
     textRadius?: string;
     sizes?: Record<string, ThemeSkeletonSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeSkeletonModeTokens>>;
+  };
+  spinner?: {
+    defaultSize?: string;
+    duration?: string;
+    defaultLabel?: string;
+    sizes?: Record<string, ThemeSpinnerSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemeSpinnerModeTokens>>;
   };
   input?: {
     defaultSize?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -258,6 +258,37 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     }
   }
 
+  const spinner = theme.components.spinner;
+  if (spinner?.defaultSize) {
+    vars["--luna-spinner-size-default"] = spinner.defaultSize;
+  }
+  if (spinner?.duration) {
+    vars["--luna-spinner-duration"] =
+      resolveScaleValue(theme.motion, spinner.duration) ?? spinner.duration;
+  }
+  if (spinner?.defaultLabel) {
+    vars["--luna-spinner-label-default"] = spinner.defaultLabel;
+  }
+  const spinnerMode = spinner?.modes?.[mode];
+  if (spinnerMode?.color) {
+    vars["--luna-spinner-color"] = resolveTokenValue(theme, spinnerMode.color);
+  }
+  if (spinnerMode?.track) {
+    vars["--luna-spinner-track"] = resolveTokenValue(theme, spinnerMode.track);
+  }
+  if (spinner?.sizes) {
+    for (const [name, profile] of Object.entries(spinner.sizes)) {
+      if (profile.size) {
+        vars[`--luna-spinner-size-${name}`] =
+          resolveScaleValue(theme.spacing, profile.size) ?? profile.size;
+      }
+      if (profile.strokeWidth) {
+        vars[`--luna-spinner-size-${name}-stroke-width`] =
+          resolveScaleValue(theme.spacing, profile.strokeWidth) ?? profile.strokeWidth;
+      }
+    }
+  }
+
   const input = theme.components.input;
   if (input?.defaultSize) {
     vars["--luna-input-size-default"] = input.defaultSize;


### PR DESCRIPTION
Closes #74

## Summary
Implemented `LunaSpinner` as a new standalone primitive with a small public contract: `as`, `size`, `color`, `decorative`, and `label`. The component is exported from [src/components/index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts), implemented in [src/components/luna-spinner/LunaSpinner.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-spinner/LunaSpinner.tsx), styled in [src/components/luna-spinner/LunaSpinner.css](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-spinner/LunaSpinner.css), and documented in [docs/v1/components/LunaSpinner.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaSpinner.md). Theme support was added in [src/theme/types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts), [src/theme/base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts), and [src/theme/vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts), and the roadmap now reflects that `LunaSpinner` is shipped in [docs/ROADMAP.md](/Users/jordanb/Documents/workspace/react-luna/docs/ROADMAP.md). Storybook coverage and tests were added in [src/components/luna-spinner/LunaSpinner.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-spinner/LunaSpinner.stories.tsx) and [src/components/luna-spinner/LunaSpinner.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-spinner/LunaSpinner.test.tsx), plus a release changeset in [.changeset/luna-spinner-issue-74.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-spinner-issue-74.md).

Verification ran successfully:
- `npm test -- LunaSpinner`
- `npm run build`
- `npm run storybook:build`

`storybook build` passed, with existing dependency/build warnings about Storybook runtime `eval` usage and large preview chunks. I could not create the requested workflow commit from this environment because the sandbox denied writing `.git/index.lock`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`