### PR TITLE
Resolve #76: Build LunaAlert primitive

### DIFF
--- a/.changeset/luna-alert-issue-76.md
+++ b/.changeset/luna-alert-issue-76.md
@@ -1,0 +1,3 @@
+"@liketysplit/react-luna": minor
+
+Add the new `LunaAlert` primitive with theme-driven tone and emphasis styling, Storybook coverage, tests, and public docs.

--- a/docs/v1/components/LunaAlert.md
+++ b/docs/v1/components/LunaAlert.md
@@ -1,0 +1,59 @@
+# LunaAlert
+
+`LunaAlert` is the inline status and warning surface primitive for `react-luna`.
+
+It owns:
+- inline emphasis for status messaging
+- tone-driven severity presentation
+- optional title and icon regions
+- theme-aware spacing and surface styling
+- native semantic passthrough
+
+It does not own:
+- dismissal logic
+- action layouts
+- toast or notification orchestration
+- application-specific message formatting
+
+## Props
+
+- `as?: React.ElementType`
+- `tone?: "neutral" | "info" | "success" | "warning" | "danger"`
+- `emphasis?: "soft" | "solid" | "outline"`
+- `title?: React.ReactNode`
+- `icon?: React.ReactNode`
+- `padding?: string`
+- `gap?: string`
+- `rounded?: boolean`
+
+Native `HTMLAttributes<HTMLElement>` continue to pass through to the root, including `role`, `aria-live`, and `aria-atomic`.
+
+## Contract
+
+- default element is `div`
+- `tone` controls the semantic color family
+- `emphasis` controls surface strength without changing the message structure
+- `title` renders a stronger heading line inside the alert
+- `children` render the supporting body content
+- `icon` is decorative by default and stays out of the accessibility tree
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaAlert` consumes the existing theme system for:
+- default padding
+- default gap
+- radius
+- per-tone surface colors for each emphasis level
+
+Spacing overrides resolve through theme spacing first, then raw CSS values.
+
+## Accessibility Notes
+
+`LunaAlert` does not force live-region behavior.
+
+Use explicit native semantics when the message should be announced:
+- `role="status"` for polite updates
+- `role="alert"` for urgent interruptions
+
+That keeps the component reusable for both passive inline context and active announcement cases.

--- a/docs/v1/components/LunaAlert.md
+++ b/docs/v1/components/LunaAlert.md
@@ -15,6 +15,16 @@ It does not own:
 - toast or notification orchestration
 - application-specific message formatting
 
+## Position In The Feedback Stack
+
+The intended split is:
+
+- `LunaAlert`: inline, persistent feedback inside normal content flow
+- `LunaNotification`: broader application-level notification surface
+- `LunaToast`: transient overlay feedback
+
+`LunaAlert` should stay focused on durable inline messaging instead of growing into toast or notification-center behavior.
+
 ## Props
 
 - `as?: React.ElementType`

--- a/docs/v1/design/LunaAlert.md
+++ b/docs/v1/design/LunaAlert.md
@@ -1,0 +1,33 @@
+# LunaAlert
+
+## Purpose
+
+`LunaAlert` provides one durable inline surface for status, warning, and error messaging without drifting into application-specific notification logic.
+
+It should be usable anywhere an interface needs a visible inline message that remains part of the normal document flow.
+
+## Design Rules
+
+- keep the contract smaller than a full notification system
+- separate severity presentation from announcement semantics
+- make tone and emphasis theme-driven so downstream applications can restyle the primitive cleanly
+- support title plus body composition without forcing a rigid content model
+- avoid embedded action behavior in the primitive itself
+
+## Contract Shape
+
+The primitive uses two visual controls:
+- `tone` chooses the message family
+- `emphasis` chooses how strong the surface should feel
+
+This keeps severity and weight explicit without creating a long list of one-off variant props.
+
+## Theme Expectations
+
+The alert theme slice should remain responsible for:
+- default padding
+- default gap
+- radius
+- light and dark color tokens for every built-in tone and emphasis combination
+
+If future work adds dismissible or actionable alerts, that should build on top of this primitive rather than expanding it into a message system.

--- a/docs/v1/design/LunaAlert.md
+++ b/docs/v1/design/LunaAlert.md
@@ -6,6 +6,16 @@
 
 It should be usable anywhere an interface needs a visible inline message that remains part of the normal document flow.
 
+## Distinction From Other Feedback Surfaces
+
+The intended split is:
+
+- `LunaAlert` handles inline page-flow messaging
+- `LunaNotification` can grow into a broader application-level notification surface
+- `LunaToast` remains the transient overlay channel
+
+That keeps inline status blocks from being overloaded with global or ephemeral notification concerns.
+
 ## Design Rules
 
 - keep the contract smaller than a full notification system

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./luna-avatar";
+export * from "./luna-alert";
 export * from "./luna-button";
 export * from "./luna-card";
 export * from "./luna-checkbox";

--- a/src/components/luna-alert/LunaAlert.css
+++ b/src/components/luna-alert/LunaAlert.css
@@ -1,0 +1,152 @@
+.luna-alert {
+  --luna-alert-current-bg: var(--luna-alert-neutral-soft-bg, var(--luna-surface));
+  --luna-alert-current-border: var(--luna-alert-neutral-soft-border, var(--luna-border));
+  --luna-alert-current-fg: var(--luna-alert-neutral-soft-fg, var(--luna-foreground));
+  display: flex;
+  align-items: flex-start;
+  gap: var(--luna-alert-gap, var(--luna-alert-gap-default, var(--luna-space-3)));
+  padding: var(--luna-alert-padding, var(--luna-alert-padding-default, var(--luna-space-4)));
+  border: 1px solid var(--luna-alert-current-border);
+  border-radius: var(--luna-alert-radius, var(--luna-radius-lg));
+  background: var(--luna-alert-current-bg);
+  color: var(--luna-alert-current-fg);
+}
+
+.luna-alert--rounded {
+  border-radius: calc(var(--luna-alert-radius, var(--luna-radius-lg)) * 1.5);
+}
+
+.luna-alert__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
+  color: inherit;
+}
+
+.luna-alert__content {
+  display: grid;
+  gap: calc(var(--luna-alert-gap, var(--luna-alert-gap-default, var(--luna-space-3))) * 0.5);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.luna-alert--title-only .luna-alert__content {
+  gap: 0;
+}
+
+.luna-alert__title {
+  margin: 0;
+  font-size: var(--luna-text-variant-label-font-size, 0.875rem);
+  font-weight: var(--luna-text-variant-label-font-weight, 600);
+  line-height: var(--luna-text-variant-label-line-height, 1.4);
+  letter-spacing: var(--luna-text-variant-label-letter-spacing, 0.01em);
+}
+
+.luna-alert__body {
+  margin: 0;
+  font-size: var(--luna-text-variant-body-small-font-size, 0.875rem);
+  line-height: var(--luna-text-variant-body-small-line-height, 1.6);
+}
+
+.luna-alert__body > :first-child,
+.luna-alert__title > :first-child {
+  margin-top: 0;
+}
+
+.luna-alert__body > :last-child,
+.luna-alert__title > :last-child {
+  margin-bottom: 0;
+}
+
+.luna-alert[data-tone="neutral"][data-emphasis="soft"] {
+  --luna-alert-current-bg: var(--luna-alert-neutral-soft-bg);
+  --luna-alert-current-border: var(--luna-alert-neutral-soft-border);
+  --luna-alert-current-fg: var(--luna-alert-neutral-soft-fg);
+}
+
+.luna-alert[data-tone="neutral"][data-emphasis="solid"] {
+  --luna-alert-current-bg: var(--luna-alert-neutral-solid-bg);
+  --luna-alert-current-border: var(--luna-alert-neutral-solid-border);
+  --luna-alert-current-fg: var(--luna-alert-neutral-solid-fg);
+}
+
+.luna-alert[data-tone="neutral"][data-emphasis="outline"] {
+  --luna-alert-current-bg: var(--luna-alert-neutral-outline-bg);
+  --luna-alert-current-border: var(--luna-alert-neutral-outline-border);
+  --luna-alert-current-fg: var(--luna-alert-neutral-outline-fg);
+}
+
+.luna-alert[data-tone="info"][data-emphasis="soft"] {
+  --luna-alert-current-bg: var(--luna-alert-info-soft-bg);
+  --luna-alert-current-border: var(--luna-alert-info-soft-border);
+  --luna-alert-current-fg: var(--luna-alert-info-soft-fg);
+}
+
+.luna-alert[data-tone="info"][data-emphasis="solid"] {
+  --luna-alert-current-bg: var(--luna-alert-info-solid-bg);
+  --luna-alert-current-border: var(--luna-alert-info-solid-border);
+  --luna-alert-current-fg: var(--luna-alert-info-solid-fg);
+}
+
+.luna-alert[data-tone="info"][data-emphasis="outline"] {
+  --luna-alert-current-bg: var(--luna-alert-info-outline-bg);
+  --luna-alert-current-border: var(--luna-alert-info-outline-border);
+  --luna-alert-current-fg: var(--luna-alert-info-outline-fg);
+}
+
+.luna-alert[data-tone="success"][data-emphasis="soft"] {
+  --luna-alert-current-bg: var(--luna-alert-success-soft-bg);
+  --luna-alert-current-border: var(--luna-alert-success-soft-border);
+  --luna-alert-current-fg: var(--luna-alert-success-soft-fg);
+}
+
+.luna-alert[data-tone="success"][data-emphasis="solid"] {
+  --luna-alert-current-bg: var(--luna-alert-success-solid-bg);
+  --luna-alert-current-border: var(--luna-alert-success-solid-border);
+  --luna-alert-current-fg: var(--luna-alert-success-solid-fg);
+}
+
+.luna-alert[data-tone="success"][data-emphasis="outline"] {
+  --luna-alert-current-bg: var(--luna-alert-success-outline-bg);
+  --luna-alert-current-border: var(--luna-alert-success-outline-border);
+  --luna-alert-current-fg: var(--luna-alert-success-outline-fg);
+}
+
+.luna-alert[data-tone="warning"][data-emphasis="soft"] {
+  --luna-alert-current-bg: var(--luna-alert-warning-soft-bg);
+  --luna-alert-current-border: var(--luna-alert-warning-soft-border);
+  --luna-alert-current-fg: var(--luna-alert-warning-soft-fg);
+}
+
+.luna-alert[data-tone="warning"][data-emphasis="solid"] {
+  --luna-alert-current-bg: var(--luna-alert-warning-solid-bg);
+  --luna-alert-current-border: var(--luna-alert-warning-solid-border);
+  --luna-alert-current-fg: var(--luna-alert-warning-solid-fg);
+}
+
+.luna-alert[data-tone="warning"][data-emphasis="outline"] {
+  --luna-alert-current-bg: var(--luna-alert-warning-outline-bg);
+  --luna-alert-current-border: var(--luna-alert-warning-outline-border);
+  --luna-alert-current-fg: var(--luna-alert-warning-outline-fg);
+}
+
+.luna-alert[data-tone="danger"][data-emphasis="soft"] {
+  --luna-alert-current-bg: var(--luna-alert-danger-soft-bg);
+  --luna-alert-current-border: var(--luna-alert-danger-soft-border);
+  --luna-alert-current-fg: var(--luna-alert-danger-soft-fg);
+}
+
+.luna-alert[data-tone="danger"][data-emphasis="solid"] {
+  --luna-alert-current-bg: var(--luna-alert-danger-solid-bg);
+  --luna-alert-current-border: var(--luna-alert-danger-solid-border);
+  --luna-alert-current-fg: var(--luna-alert-danger-solid-fg);
+}
+
+.luna-alert[data-tone="danger"][data-emphasis="outline"] {
+  --luna-alert-current-bg: var(--luna-alert-danger-outline-bg);
+  --luna-alert-current-border: var(--luna-alert-danger-outline-border);
+  --luna-alert-current-fg: var(--luna-alert-danger-outline-fg);
+}

--- a/src/components/luna-alert/LunaAlert.props.ts
+++ b/src/components/luna-alert/LunaAlert.props.ts
@@ -1,0 +1,15 @@
+import type React from "react";
+
+export type LunaAlertTone = "neutral" | "info" | "success" | "warning" | "danger";
+export type LunaAlertEmphasis = "soft" | "solid" | "outline";
+
+export type LunaAlertProps = Omit<React.HTMLAttributes<HTMLElement>, "title" | "color"> & {
+  as?: React.ElementType;
+  tone?: LunaAlertTone;
+  emphasis?: LunaAlertEmphasis;
+  title?: React.ReactNode;
+  icon?: React.ReactNode;
+  padding?: string;
+  gap?: string;
+  rounded?: boolean;
+};

--- a/src/components/luna-alert/LunaAlert.stories.tsx
+++ b/src/components/luna-alert/LunaAlert.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaAlert } from "./LunaAlert";
+
+const tones = ["neutral", "info", "success", "warning", "danger"] as const;
+const emphases = ["soft", "solid", "outline"] as const;
+
+const meta = {
+  title: "Components/LunaAlert",
+  component: LunaAlert,
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    title: "Mission update",
+    children: "The orbital sync finished successfully."
+  }
+} satisfies Meta<typeof LunaAlert>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const ToneAndEmphasisMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gap: "1rem",
+        gridTemplateColumns: "repeat(3, minmax(0, 1fr))"
+      }}
+    >
+      {emphases.map((emphasis) => (
+        <div key={emphasis} style={{ display: "grid", gap: "0.75rem" }}>
+          {tones.map((tone) => (
+            <LunaAlert
+              key={`${tone}-${emphasis}`}
+              tone={tone}
+              emphasis={emphasis}
+              title={`${tone[0].toUpperCase()}${tone.slice(1)} alert`}
+            >
+              Theme-driven inline messaging for {tone} surfaces.
+            </LunaAlert>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+};
+
+export const WithIconAndAnnouncementSemantics: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", maxWidth: "36rem" }}>
+      <LunaAlert
+        tone="info"
+        title="Scheduled update"
+        icon={<span>i</span>}
+        role="status"
+        aria-live="polite"
+      >
+        Background sync completed. Review the latest data when you are ready.
+      </LunaAlert>
+      <LunaAlert
+        tone="warning"
+        emphasis="outline"
+        title="Signal drift detected"
+        icon={<span>!</span>}
+        role="alert"
+        aria-live="assertive"
+      >
+        Manual review is needed before the next launch window opens.
+      </LunaAlert>
+    </div>
+  )
+};
+
+export const CustomSpacing: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", maxWidth: "30rem" }}>
+      <LunaAlert tone="success" title="Compact" padding="3" gap="2">
+        A tighter alert still resolves through theme spacing tokens first.
+      </LunaAlert>
+      <LunaAlert tone="danger" emphasis="solid" rounded padding="5" gap="4">
+        Stronger emphasis can be paired with larger spacing without leaving the component contract.
+      </LunaAlert>
+    </div>
+  )
+};

--- a/src/components/luna-alert/LunaAlert.test.tsx
+++ b/src/components/luna-alert/LunaAlert.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaAlert } from "./LunaAlert";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaAlert", () => {
+  it("renders the default inline alert contract", () => {
+    renderWithTheme(<LunaAlert title="Mission update">Orbit confirmed.</LunaAlert>);
+
+    const alert = document.querySelector(".luna-alert");
+
+    expect(alert).toHaveAttribute("data-tone", "neutral");
+    expect(alert).toHaveAttribute("data-emphasis", "soft");
+    expect(screen.getByText("Mission update")).toBeInTheDocument();
+    expect(screen.getByText("Orbit confirmed.")).toBeInTheDocument();
+  });
+
+  it("renders icon content and native semantics passthrough", () => {
+    renderWithTheme(
+      <LunaAlert title="Warning" icon={<span data-testid="alert-icon">!</span>} role="alert">
+        Check the launch path.
+      </LunaAlert>
+    );
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert.querySelector(".luna-alert__icon")).toBeInTheDocument();
+    expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
+  });
+
+  it("resolves padding and gap through theme spacing tokens", () => {
+    renderWithTheme(
+      <LunaAlert title="Spacing" padding="6" gap="2">
+        Calibrated spacing.
+      </LunaAlert>
+    );
+
+    const alert = document.querySelector(".luna-alert");
+
+    expect(alert).toHaveStyle({
+      "--luna-alert-padding": "1.5rem",
+      "--luna-alert-gap": "0.5rem"
+    });
+  });
+
+  it("supports a title-only alert", () => {
+    renderWithTheme(<LunaAlert title="Telemetry synced" />);
+
+    const alert = document.querySelector(".luna-alert");
+
+    expect(screen.getByText("Telemetry synced")).toBeInTheDocument();
+    expect(alert).toHaveClass("luna-alert--title-only");
+  });
+
+  it("uses theme overrides for alert defaults and tone tokens", () => {
+    const { container } = renderWithTheme(
+      <LunaAlert tone="info" emphasis="outline" title="Theme override">
+        Custom alert theme.
+      </LunaAlert>,
+      {
+        theme: {
+          components: {
+            alert: {
+              defaultPadding: "6",
+              tones: {
+                light: {
+                  info: {
+                    outline: {
+                      border: "accent.500"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-alert-padding-default": "1.5rem",
+      "--luna-alert-info-outline-border": "#8b5cf6"
+    });
+  });
+});

--- a/src/components/luna-alert/LunaAlert.tsx
+++ b/src/components/luna-alert/LunaAlert.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaAlertProps } from "./LunaAlert.props";
+import "./LunaAlert.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+export const LunaAlert = React.forwardRef<HTMLElement, LunaAlertProps>(function LunaAlert(
+  {
+    as,
+    children,
+    className,
+    emphasis = "soft",
+    gap,
+    icon,
+    padding,
+    rounded,
+    style,
+    title,
+    tone = "neutral",
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const Component = (as ?? "div") as React.ElementType;
+  const resolvedPadding = resolveSpacingValue(padding, theme);
+  const resolvedGap = resolveSpacingValue(gap, theme);
+  const hasBody = children !== undefined && children !== null;
+
+  const resolvedStyle = {
+    ...(resolvedPadding ? { ["--luna-alert-padding" as const]: resolvedPadding } : {}),
+    ...(resolvedGap ? { ["--luna-alert-gap" as const]: resolvedGap } : {}),
+    ...style
+  };
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      className={toClassName([
+        "luna-alert",
+        rounded && "luna-alert--rounded",
+        !hasBody && "luna-alert--title-only",
+        className
+      ])}
+      data-tone={tone}
+      data-emphasis={emphasis}
+      style={resolvedStyle}
+    >
+      {icon ? (
+        <div aria-hidden="true" className="luna-alert__icon">
+          {icon}
+        </div>
+      ) : null}
+      <div className="luna-alert__content">
+        {title ? <div className="luna-alert__title">{title}</div> : null}
+        {hasBody ? <div className="luna-alert__body">{children}</div> : null}
+      </div>
+    </Component>
+  );
+});

--- a/src/components/luna-alert/index.ts
+++ b/src/components/luna-alert/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaAlert";
+export * from "./LunaAlert.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -20,4 +20,25 @@ describe("theme size contract", () => {
     expect(avatarSizes?.large?.size).toBe(buttonSizes?.large?.minHeight);
     expect(avatarSizes?.["x-large"]?.size).toBe(buttonSizes?.["x-large"]?.minHeight);
   });
+
+  it("defines alert defaults and all built-in tones", () => {
+    const alert = lunarTheme.components.alert;
+
+    expect(alert?.defaultPadding).toBe("4");
+    expect(alert?.defaultGap).toBe("3");
+    expect(Object.keys(alert?.tones?.light ?? {})).toEqual([
+      "neutral",
+      "info",
+      "success",
+      "warning",
+      "danger"
+    ]);
+    expect(Object.keys(alert?.tones?.dark ?? {})).toEqual([
+      "neutral",
+      "info",
+      "success",
+      "warning",
+      "danger"
+    ]);
+  });
 });

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -340,6 +340,187 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    alert: {
+      defaultPadding: "4",
+      defaultGap: "3",
+      radius: "lg",
+      tones: {
+        light: {
+          neutral: {
+            soft: {
+              bg: "neutral.100",
+              border: "neutral.300",
+              fg: "neutral.900"
+            },
+            solid: {
+              bg: "neutral.800",
+              border: "neutral.800",
+              fg: "neutral.50"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "neutral.300",
+              fg: "neutral.900"
+            }
+          },
+          info: {
+            soft: {
+              bg: "primary.50",
+              border: "primary.200",
+              fg: "primary.800"
+            },
+            solid: {
+              bg: "primary.600",
+              border: "primary.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "primary.300",
+              fg: "primary.800"
+            }
+          },
+          success: {
+            soft: {
+              bg: "success.50",
+              border: "success.200",
+              fg: "success.800"
+            },
+            solid: {
+              bg: "success.600",
+              border: "success.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "success.300",
+              fg: "success.800"
+            }
+          },
+          warning: {
+            soft: {
+              bg: "warning.50",
+              border: "warning.200",
+              fg: "warning.900"
+            },
+            solid: {
+              bg: "warning.600",
+              border: "warning.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "warning.300",
+              fg: "warning.900"
+            }
+          },
+          danger: {
+            soft: {
+              bg: "danger.50",
+              border: "danger.200",
+              fg: "danger.800"
+            },
+            solid: {
+              bg: "danger.600",
+              border: "danger.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "danger.300",
+              fg: "danger.800"
+            }
+          }
+        },
+        dark: {
+          neutral: {
+            soft: {
+              bg: "neutral.800",
+              border: "neutral.600",
+              fg: "neutral.50"
+            },
+            solid: {
+              bg: "neutral.200",
+              border: "neutral.200",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "neutral.600",
+              fg: "neutral.50"
+            }
+          },
+          info: {
+            soft: {
+              bg: "primary.900",
+              border: "primary.700",
+              fg: "primary.100"
+            },
+            solid: {
+              bg: "primary.400",
+              border: "primary.400",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "primary.500",
+              fg: "primary.100"
+            }
+          },
+          success: {
+            soft: {
+              bg: "success.900",
+              border: "success.700",
+              fg: "success.100"
+            },
+            solid: {
+              bg: "success.400",
+              border: "success.400",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "success.500",
+              fg: "success.100"
+            }
+          },
+          warning: {
+            soft: {
+              bg: "warning.900",
+              border: "warning.700",
+              fg: "warning.100"
+            },
+            solid: {
+              bg: "warning.400",
+              border: "warning.400",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "warning.500",
+              fg: "warning.100"
+            }
+          },
+          danger: {
+            soft: {
+              bg: "danger.900",
+              border: "danger.700",
+              fg: "danger.100"
+            },
+            solid: {
+              bg: "danger.400",
+              border: "danger.400",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "danger.500",
+              fg: "danger.100"
+            }
+          }
+        }
+      }
+    },
     divider: {
       defaultSpacing: "4",
       defaultInset: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -98,6 +98,15 @@ export type ThemeCardModeTokens = {
   hoverShadow?: string;
 };
 
+export type ThemeAlertTone = "neutral" | "info" | "success" | "warning" | "danger";
+export type ThemeAlertEmphasis = "soft" | "solid" | "outline";
+
+export type ThemeAlertSurfaceTokens = {
+  bg?: string;
+  border?: string;
+  fg?: string;
+};
+
 export type ThemeDividerModeTokens = {
   default?: string;
   muted?: string;
@@ -188,6 +197,17 @@ export type ThemeComponents = {
     defaultGap?: string;
     radius?: string;
     modes?: Partial<Record<ThemeMode, ThemeCardModeTokens>>;
+  };
+  alert?: {
+    defaultPadding?: string;
+    defaultGap?: string;
+    radius?: string;
+    tones?: Partial<
+      Record<
+        ThemeMode,
+        Partial<Record<ThemeAlertTone, Partial<Record<ThemeAlertEmphasis, ThemeAlertSurfaceTokens>>>>
+      >
+    >;
   };
   divider?: {
     defaultSpacing?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -201,6 +201,52 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
       resolveTokenValue(theme, cardMode.hoverShadow);
   }
 
+  const alert = theme.components.alert;
+  if (alert?.defaultPadding) {
+    vars["--luna-alert-padding-default"] =
+      resolveScaleValue(theme.spacing, alert.defaultPadding) ?? alert.defaultPadding;
+  }
+  if (alert?.defaultGap) {
+    vars["--luna-alert-gap-default"] =
+      resolveScaleValue(theme.spacing, alert.defaultGap) ?? alert.defaultGap;
+  }
+  if (alert?.radius) {
+    vars["--luna-alert-radius"] = resolveScaleValue(theme.radii, alert.radius) ?? alert.radius;
+  }
+  const alertMode = alert?.tones?.[mode];
+  if (alertMode) {
+    for (const [toneName, emphasisMap] of Object.entries(alertMode)) {
+      if (!emphasisMap) {
+        continue;
+      }
+
+      for (const [emphasisName, surface] of Object.entries(emphasisMap)) {
+        if (!surface) {
+          continue;
+        }
+
+        if (surface.bg) {
+          vars[`--luna-alert-${toneName}-${emphasisName}-bg`] = resolveTokenValue(
+            theme,
+            surface.bg
+          );
+        }
+        if (surface.border) {
+          vars[`--luna-alert-${toneName}-${emphasisName}-border`] = resolveTokenValue(
+            theme,
+            surface.border
+          );
+        }
+        if (surface.fg) {
+          vars[`--luna-alert-${toneName}-${emphasisName}-fg`] = resolveTokenValue(
+            theme,
+            surface.fg
+          );
+        }
+      }
+    }
+  }
+
   const divider = theme.components.divider;
   if (divider?.defaultSpacing) {
     vars["--luna-divider-spacing-default"] =


### PR DESCRIPTION
Closes #76

## Summary
Implemented issue `#76` as a single vertical slice: new `LunaAlert` primitive with tone and emphasis variants, optional title and icon slots, theme-resolved spacing overrides, Storybook coverage, tests, docs, and a release changeset. The main work lives in [LunaAlert.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-alert/LunaAlert.tsx), [LunaAlert.css](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-alert/LunaAlert.css), [LunaAlert.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-alert/LunaAlert.stories.tsx), [LunaAlert.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-alert/LunaAlert.test.tsx), [LunaAlert.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaAlert.md), [LunaAlert.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaAlert.md), and [.changeset/luna-alert-issue-76.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-alert-issue-76.md). Theme support was added in [types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts), [base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts), and [vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts), with the export wired through [src/components/index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts).

Verification ran clean:
- `npm test -- src/components/luna-alert/LunaAlert.test.tsx src/theme/base.test.ts`
- `npm run build`

I also found existing repo-doc drift while checking guardrails: `WORKFLOW.md` uses `Backlog -> Ready -> In Progress -> Verify -> Done`, while `CHANGE_MANAGEMENT.md` still says `Todo -> In Progress -> Done`. I left that untouched because it is outside issue `#76`.

I could not create the requested commit because the sandbox denied Git index writes: `.git/index.lock: Operation not permitted`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`