### PR TITLE
Resolve #17: Build LunaTag primitive

### DIFF
--- a/.changeset/luna-tag-issue-17.md
+++ b/.changeset/luna-tag-issue-17.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaTag` primitive with theme-aware variants, Storybook coverage, tests, and docs.

--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -79,14 +79,30 @@ jobs:
           PREVIEW_DIR: pr-${{ github.event.pull_request.number }}
         with:
           script: |
+            const fs = require('fs');
+            const path = require('path');
             const marker = '<!-- storybook-visuals-artifact -->';
             const base = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/${process.env.PREVIEW_BRANCH}/${process.env.PREVIEW_DIR}`;
-            const images = [
-              { alt: 'LunaToast playground light', file: 'luna-toast-playground--light.png' },
-              { alt: 'LunaToast playground dark', file: 'luna-toast-playground--dark.png' },
-              { alt: 'LunaToast tone and emphasis matrix', file: 'luna-toast-tone-and-emphasis-matrix--light.png' },
-              { alt: 'LunaToast controlled visibility', file: 'luna-toast-controlled-visibility--light.png' },
-            ];
+            const artifactDir = path.join(process.env.GITHUB_WORKSPACE, 'artifacts', 'storybook-screenshots');
+            const images = fs.existsSync(artifactDir)
+              ? fs.readdirSync(artifactDir)
+                  .filter((file) => file.endsWith('.png'))
+                  .sort()
+                  .map((file) => ({
+                    alt: file
+                      .replace(/\.png$/, '')
+                      .split('--')
+                      .map((segment) =>
+                        segment
+                          .split('-')
+                          .filter(Boolean)
+                          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+                          .join(' ')
+                      )
+                      .join(' / '),
+                    file,
+                  }))
+              : [];
             const body = [
               marker,
               'Storybook screenshots are ready for review.',
@@ -94,11 +110,13 @@ jobs:
               `- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               `- Preview directory: [${process.env.PREVIEW_DIR}](${base}/)`,
               '',
-              ...images.flatMap((image) => [
-                `### ${image.alt}`,
-                `![${image.alt}](${base}/${image.file})`,
-                '',
-              ]),
+              ...(images.length > 0
+                ? images.flatMap((image) => [
+                    `### ${image.alt}`,
+                    `![${image.alt}](${base}/${image.file})`,
+                    '',
+                  ])
+                : ['No screenshots were generated for this run.', '']),
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/docs/v1/components/LunaTag.md
+++ b/docs/v1/components/LunaTag.md
@@ -1,0 +1,82 @@
+# LunaTag
+
+`LunaTag` is the compact inline classification primitive for `react-luna`.
+
+It is responsible for:
+- short categorical labels
+- theme-aware variant surfaces
+- semantic inline markup overrides
+- compact size scaling
+
+It is not responsible for:
+- counts or notification totals
+- removal or selection behavior
+- application-specific filtering logic
+
+## Contract
+
+`LunaTag` renders an inline element and defaults to `<span>`.
+
+Core rules:
+- `children` is the visible content
+- `className` and `style` pass through to the root
+- `as` changes semantics without changing the visual contract
+- `variant` and `size` resolve through theme defaults first
+- `color` overrides the visible surface background and border
+
+## Props
+
+- `as?: React.ElementType`
+- `variant?: string`
+- `size?: string`
+- `color?: string`
+- `rounded?: boolean`
+
+## Variants
+
+Built-in base theme variants:
+- `neutral`
+- `primary`
+- `success`
+- `warning`
+- `danger`
+
+Rules:
+- `variant` resolves against the active light or dark theme mode
+- unknown variants fall back to the current theme surface tokens
+- downstream themes can redefine built-in variants or add new named variants
+
+## Size
+
+Built-in base theme sizes:
+- `small`
+- `medium`
+- `large`
+
+Resolution:
+1. `size` resolves against `theme.components.tag.sizes`
+2. if no named size matches, the value is treated as a raw spacing size
+3. if `size` is omitted, the theme default size key is used
+
+## Color
+
+`color` accepts:
+- raw CSS colors such as hex, `rgb`, `hsl`, and `var(...)`
+- theme custom colors
+- theme tokens such as `accent.500`
+
+Rules:
+- `color` overrides the tag background and border together
+- foreground remains theme-driven unless the consumer overrides it through `style`
+
+## Theme Expectations
+
+`LunaTag` depends on the theme for:
+- default variant
+- default size
+- size profiles
+- radius
+- font weight
+- per-mode variant surface tokens
+
+This keeps the primitive easy to restyle without turning it into a badge or chip system.

--- a/docs/v1/design/LunaTag.md
+++ b/docs/v1/design/LunaTag.md
@@ -1,0 +1,43 @@
+# LunaTag
+
+## Purpose
+
+`LunaTag` provides one durable inline surface for labeling status, grouping, or metadata without turning that label into a counter, filter control, or removable chip.
+
+## Distinction From Nearby Primitives
+
+The intended split is:
+
+- `LunaTag` handles compact inline labels
+- `LunaBadge` can carry its own nearby notification or count-oriented role
+- richer removable or selectable chip behavior should be its own future primitive
+
+That keeps the tag contract compact and prevents interaction behaviors from leaking into a simple labeling surface.
+
+## Design Rules
+
+- keep the contract semantic and inline by default
+- make variants mode-aware so light and dark themes remain balanced
+- let downstream themes replace variant surfaces without rewriting the component
+- keep size control compact and token-driven
+- do not add removal, selection, or icon-system behavior in this primitive
+
+## Contract Shape
+
+The primitive uses two visible controls:
+
+- `variant` chooses the theme surface family
+- `size` chooses the compact scale
+
+That is enough for a reusable label primitive without pulling in badge or chip responsibilities.
+
+## Theme Expectations
+
+The tag theme slice should remain responsible for:
+
+- default variant
+- default size
+- radius
+- font weight
+- size profiles
+- light and dark surface tokens for each named variant

--- a/playwright/storybook/manifest.ts
+++ b/playwright/storybook/manifest.ts
@@ -6,18 +6,23 @@ export type StoryCapture = {
 
 export const storybookCaptures: StoryCapture[] = [
   {
-    storyId: "components-lunatoast--playground",
-    fileName: "luna-toast-playground",
+    storyId: "components-lunatag--playground",
+    fileName: "luna-tag-playground",
     backgrounds: ["light", "dark"]
   },
   {
-    storyId: "components-lunatoast--tone-and-emphasis-matrix",
-    fileName: "luna-toast-tone-and-emphasis-matrix",
+    storyId: "components-lunatag--variant-matrix",
+    fileName: "luna-tag-variant-matrix",
     backgrounds: ["light"]
   },
   {
-    storyId: "components-lunatoast--controlled-visibility",
-    fileName: "luna-toast-controlled-visibility",
+    storyId: "components-lunatag--size-scale",
+    fileName: "luna-tag-size-scale",
+    backgrounds: ["light"]
+  },
+  {
+    storyId: "components-lunatag--semantic-overrides-and-color",
+    fileName: "luna-tag-semantic-overrides-and-color",
     backgrounds: ["light"]
   }
 ];

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -12,9 +12,10 @@ for (const capture of storybookCaptures) {
     test(`${capture.storyId} [${background}]`, async ({ page }) => {
       const screenshotPath = join(screenshotDir, `${capture.fileName}--${background}.png`);
       mkdirSync(dirname(screenshotPath), { recursive: true });
+      const globalsQuery = background === "light" ? "" : `&globals=backgrounds.value:${background}`;
 
       await page.goto(
-        `/iframe.html?id=${capture.storyId}&viewMode=story&globals=backgrounds.value:${background}`,
+        `/iframe.html?id=${capture.storyId}&viewMode=story${globalsQuery}`,
         { waitUntil: "networkidle" }
       );
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export * from "./luna-autocomplete";
 export * from "./luna-skeleton";
 export * from "./luna-spinner";
 export * from "./luna-switch";
+export * from "./luna-tag";
 export * from "./luna-text";
 export * from "./luna-tooltip";
 export * from "./luna-row";

--- a/src/components/luna-tag/LunaTag.css
+++ b/src/components/luna-tag/LunaTag.css
@@ -1,0 +1,24 @@
+.luna-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--luna-tag-gap, var(--luna-space-1));
+  min-height: var(--luna-tag-min-height, 1.5rem);
+  padding: var(--luna-tag-padding-y, var(--luna-space-1))
+    var(--luna-tag-padding-x, var(--luna-space-3));
+  border: 1px solid var(--luna-tag-border, var(--luna-border));
+  border-radius: var(--luna-tag-radius, var(--luna-radius-pill));
+  background: var(--luna-tag-bg, var(--luna-surface));
+  color: var(--luna-tag-fg, var(--luna-foreground));
+  font-family: var(--luna-font-family);
+  font-size: var(--luna-tag-font-size, var(--luna-font-size-xs, 0.75rem));
+  font-weight: var(--luna-tag-font-weight, 500);
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.luna-tag--rounded {
+  border-radius: var(--luna-radius-pill);
+}

--- a/src/components/luna-tag/LunaTag.props.ts
+++ b/src/components/luna-tag/LunaTag.props.ts
@@ -1,0 +1,9 @@
+import type React from "react";
+
+export type LunaTagProps = Omit<React.HTMLAttributes<HTMLElement>, "color"> & {
+  as?: React.ElementType;
+  variant?: string;
+  size?: string;
+  color?: string;
+  rounded?: boolean;
+};

--- a/src/components/luna-tag/LunaTag.stories.tsx
+++ b/src/components/luna-tag/LunaTag.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type React from "react";
+import { LunaTag } from "./LunaTag";
+
+const variants = ["neutral", "primary", "success", "warning", "danger"] as const;
+const sizes = ["small", "medium", "large"] as const;
+
+const meta = {
+  title: "Components/LunaTag",
+  component: LunaTag,
+  args: {
+    children: "Stable orbit"
+  },
+  parameters: {
+    layout: "centered"
+  }
+} satisfies Meta<typeof LunaTag>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const VariantMatrix: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "0.75rem" }}>
+      {variants.map((variant) => (
+        <div key={variant} style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+          <LunaTag variant={variant}>{variant}</LunaTag>
+          <LunaTag variant={variant} rounded>
+            {variant} rounded
+          </LunaTag>
+        </div>
+      ))}
+    </div>
+  )
+};
+
+export const SizeScale: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap" }}>
+      {sizes.map((size) => (
+        <LunaTag key={size} size={size} variant="primary">
+          {size}
+        </LunaTag>
+      ))}
+      <LunaTag size="2.25rem">custom</LunaTag>
+    </div>
+  )
+};
+
+export const SemanticOverridesAndColor: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap" }}>
+      <LunaTag as="strong" variant="success">
+        semantic strong
+      </LunaTag>
+      <LunaTag as="span" color="accent.500">
+        token color
+      </LunaTag>
+      <LunaTag
+        color="#0f766e"
+        style={
+          {
+            "--luna-tag-fg": "#ecfeff"
+          } as React.CSSProperties
+        }
+      >
+        custom surface
+      </LunaTag>
+    </div>
+  )
+};

--- a/src/components/luna-tag/LunaTag.test.tsx
+++ b/src/components/luna-tag/LunaTag.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaTag } from "./LunaTag";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaTag", () => {
+  it("renders a span by default with the neutral medium contract", () => {
+    renderWithTheme(<LunaTag>Stable orbit</LunaTag>);
+
+    const tag = screen.getByText("Stable orbit");
+
+    expect(tag.tagName).toBe("SPAN");
+    expect(tag).toHaveAttribute("data-variant", "neutral");
+    expect(tag).toHaveAttribute("data-size", "medium");
+    expect(tag).toHaveStyle({
+      "--luna-tag-bg": "#f1f5f9",
+      "--luna-tag-fg": "#334155",
+      "--luna-tag-border": "#cbd5e1"
+    });
+  });
+
+  it("supports semantic overrides through as", () => {
+    renderWithTheme(<LunaTag as="strong">Queued</LunaTag>);
+
+    expect(screen.getByText("Queued").tagName).toBe("STRONG");
+  });
+
+  it("resolves theme variant and size defaults when provided", () => {
+    renderWithTheme(<LunaTag>Synced</LunaTag>, {
+      theme: {
+        components: {
+          tag: {
+            defaultVariant: "success",
+            defaultSize: "large",
+            sizes: {
+              large: {
+                paddingX: "5",
+                paddingY: "2",
+                fontSize: "md",
+                minHeight: "2rem"
+              }
+            },
+            variants: {
+              light: {
+                success: {
+                  bg: "success.200",
+                  fg: "success.900",
+                  border: "success.300"
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(screen.getByText("Synced")).toHaveAttribute("data-variant", "success");
+    expect(screen.getByText("Synced")).toHaveAttribute("data-size", "large");
+    expect(screen.getByText("Synced")).toHaveStyle({
+      "--luna-tag-bg": "#a7f3d0",
+      "--luna-tag-fg": "#064e3b",
+      "--luna-tag-border": "#6ee7b7",
+      "--luna-tag-padding-x": "1.25rem",
+      "--luna-tag-min-height": "2rem"
+    });
+  });
+
+  it("accepts raw CSS sizes outside named theme tiers", () => {
+    renderWithTheme(<LunaTag size="2rem">Tight</LunaTag>);
+
+    expect(screen.getByText("Tight")).toHaveStyle({
+      "--luna-tag-padding-x": "2rem",
+      "--luna-tag-min-height": "2rem"
+    });
+  });
+
+  it("resolves color overrides against the tag surface", () => {
+    renderWithTheme(<LunaTag color="accent.500">Accent</LunaTag>);
+
+    expect(screen.getByText("Accent")).toHaveStyle({
+      "--luna-tag-bg": "#8b5cf6",
+      "--luna-tag-border": "#8b5cf6"
+    });
+  });
+});

--- a/src/components/luna-tag/LunaTag.tsx
+++ b/src/components/luna-tag/LunaTag.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveModeTokens, resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import type { ThemeTagSurfaceTokens } from "../../theme/types";
+import type { LunaTagProps } from "./LunaTag.props";
+import "./LunaTag.css";
+
+type TagCssVariable =
+  | "--luna-tag-padding-x"
+  | "--luna-tag-padding-y"
+  | "--luna-tag-font-size"
+  | "--luna-tag-min-height"
+  | "--luna-tag-gap"
+  | "--luna-tag-bg"
+  | "--luna-tag-fg"
+  | "--luna-tag-border"
+  | "--luna-tag-radius"
+  | "--luna-tag-font-weight";
+
+type LunaTagStyle = React.CSSProperties &
+  Partial<Record<TagCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveTagSize(size: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!size) {
+    return undefined;
+  }
+
+  const profile = theme.components.tag?.sizes?.[size];
+  if (profile) {
+    return {
+      paddingX: resolveScaleValue(theme.spacing, profile.paddingX) ?? profile.paddingX,
+      paddingY: resolveScaleValue(theme.spacing, profile.paddingY) ?? profile.paddingY,
+      fontSize:
+        resolveScaleValue(theme.typography.sizes, profile.fontSize) ?? profile.fontSize,
+      minHeight: resolveScaleValue(theme.spacing, profile.minHeight) ?? profile.minHeight,
+      gap: resolveScaleValue(theme.spacing, profile.gap) ?? profile.gap
+    };
+  }
+
+  const resolvedSpacing = resolveScaleValue(theme.spacing, size) ?? size;
+  return {
+    paddingX: resolvedSpacing,
+    paddingY: undefined,
+    fontSize: undefined,
+    minHeight: resolvedSpacing,
+    gap: undefined
+  };
+}
+
+function resolveRadius(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function resolveFontWeight(
+  value: string | number | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "number") {
+    return value;
+  }
+
+  return theme.typography.weights[value] ?? value;
+}
+
+function resolveSurfaceToken(
+  token: string | undefined,
+  fallback: string,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!token) {
+    return fallback;
+  }
+
+  return resolveTokenValue(theme, token);
+}
+
+export const LunaTag = React.forwardRef<HTMLElement, LunaTagProps>(function LunaTag(
+  { as, children, className, color, rounded, size, style, variant, ...tagProps },
+  ref
+) {
+  const { mode, theme } = useTheme();
+  const Component = (as ?? "span") as React.ElementType;
+  const modeTokens = resolveModeTokens(theme, mode);
+  const resolvedVariant = variant ?? theme.components.tag?.defaultVariant ?? "neutral";
+  const resolvedSize = size ?? theme.components.tag?.defaultSize ?? "medium";
+  const sizeProfile = resolveTagSize(resolvedSize, theme);
+  const variantTokens: ThemeTagSurfaceTokens | undefined =
+    theme.components.tag?.variants?.[mode]?.[resolvedVariant];
+  const resolvedRadius = resolveRadius(theme.components.tag?.radius, theme);
+  const resolvedFontWeight = resolveFontWeight(theme.components.tag?.fontWeight, theme);
+  const resolvedColor = color ? resolveTokenValue(theme, color) : undefined;
+
+  const tagStyle: LunaTagStyle = {
+    ["--luna-tag-padding-x" as const]: sizeProfile?.paddingX,
+    ["--luna-tag-padding-y" as const]: sizeProfile?.paddingY,
+    ["--luna-tag-font-size" as const]:
+      sizeProfile?.fontSize ?? theme.typography.sizes.xs,
+    ["--luna-tag-min-height" as const]: sizeProfile?.minHeight,
+    ["--luna-tag-gap" as const]: sizeProfile?.gap,
+    ["--luna-tag-bg" as const]: resolvedColor ?? resolveSurfaceToken(variantTokens?.bg, modeTokens.surface, theme),
+    ["--luna-tag-fg" as const]:
+      variantTokens?.fg ? resolveTokenValue(theme, variantTokens.fg) : modeTokens.foreground,
+    ["--luna-tag-border" as const]:
+      resolvedColor ?? resolveSurfaceToken(variantTokens?.border, modeTokens.border, theme),
+    ["--luna-tag-radius" as const]: resolvedRadius,
+    ["--luna-tag-font-weight" as const]:
+      resolvedFontWeight !== undefined ? String(resolvedFontWeight) : undefined,
+    ...style
+  };
+
+  return (
+    <Component
+      {...tagProps}
+      ref={ref}
+      className={toClassName(["luna-tag", rounded && "luna-tag--rounded", className])}
+      data-size={resolvedSize}
+      data-variant={resolvedVariant}
+      style={tagStyle}
+    >
+      {children}
+    </Component>
+  );
+});

--- a/src/components/luna-tag/index.ts
+++ b/src/components/luna-tag/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaTag";
+export * from "./LunaTag.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -315,6 +315,91 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    tag: {
+      defaultVariant: "neutral",
+      defaultSize: "medium",
+      radius: "md",
+      fontWeight: "medium",
+      sizes: {
+        small: {
+          paddingX: "2",
+          paddingY: "1",
+          fontSize: "xs",
+          minHeight: "1.25rem",
+          gap: "1"
+        },
+        medium: {
+          paddingX: "3",
+          paddingY: "1",
+          fontSize: "sm",
+          minHeight: "1.5rem",
+          gap: "1"
+        },
+        large: {
+          paddingX: "4",
+          paddingY: "2",
+          fontSize: "sm",
+          minHeight: "1.875rem",
+          gap: "2"
+        }
+      },
+      variants: {
+        light: {
+          neutral: {
+            bg: "neutral.100",
+            fg: "neutral.700",
+            border: "neutral.300"
+          },
+          primary: {
+            bg: "primary.100",
+            fg: "primary.700",
+            border: "primary.200"
+          },
+          success: {
+            bg: "success.100",
+            fg: "success.800",
+            border: "success.200"
+          },
+          warning: {
+            bg: "warning.100",
+            fg: "warning.800",
+            border: "warning.200"
+          },
+          danger: {
+            bg: "danger.100",
+            fg: "danger.800",
+            border: "danger.200"
+          }
+        },
+        dark: {
+          neutral: {
+            bg: "neutral.800",
+            fg: "neutral.100",
+            border: "neutral.700"
+          },
+          primary: {
+            bg: "primary.900",
+            fg: "primary.100",
+            border: "primary.700"
+          },
+          success: {
+            bg: "success.900",
+            fg: "success.100",
+            border: "success.700"
+          },
+          warning: {
+            bg: "warning.900",
+            fg: "warning.100",
+            border: "warning.700"
+          },
+          danger: {
+            bg: "danger.900",
+            fg: "danger.100",
+            border: "danger.700"
+          }
+        }
+      }
+    },
     card: {
       defaultPadding: "4",
       defaultGap: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -88,6 +88,20 @@ export type ThemeTextModeTokens = {
   surfaceBorder?: string;
 };
 
+export type ThemeTagSizeProfile = {
+  paddingX?: string;
+  paddingY?: string;
+  fontSize?: string;
+  minHeight?: string;
+  gap?: string;
+};
+
+export type ThemeTagSurfaceTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+};
+
 export type ThemeCardModeTokens = {
   bg?: string;
   fg?: string;
@@ -238,6 +252,14 @@ export type ThemeComponents = {
     defaultVariant?: string;
     variants?: Record<string, ThemeTextVariantProfile>;
     modes?: Partial<Record<ThemeMode, ThemeTextModeTokens>>;
+  };
+  tag?: {
+    defaultVariant?: string;
+    defaultSize?: string;
+    radius?: string;
+    fontWeight?: string | number;
+    sizes?: Record<string, ThemeTagSizeProfile>;
+    variants?: Partial<Record<ThemeMode, Record<string, ThemeTagSurfaceTokens>>>;
   };
   card?: {
     defaultPadding?: string;


### PR DESCRIPTION
Closes #17

## Summary
Implemented issue `#17` as a scoped `LunaTag` vertical slice. The new primitive lives in [src/components/luna-tag/LunaTag.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tag/LunaTag.tsx) with its contract in [src/components/luna-tag/LunaTag.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tag/LunaTag.props.ts) and styles in [src/components/luna-tag/LunaTag.css](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tag/LunaTag.css). It defaults to a semantic inline `span`, supports theme-aware `variant` and `size` resolution, allows direct surface `color` overrides, and is exported from [src/components/index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts). Theme support was added in [src/theme/types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts) and [src/theme/base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts).

Storybook, tests, docs, and release metadata were added in [src/components/luna-tag/LunaTag.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tag/LunaTag.stories.tsx), [src/components/luna-tag/LunaTag.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tag/LunaTag.test.tsx), [docs/v1/components/LunaTag.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaTag.md), [docs/v1/design/LunaTag.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaTag.md), and [.changeset/luna-tag-issue-17.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-tag-issue-17.md).

Verification ran cleanly:
- `npm run test -- LunaTag`
- `npm run build`

I attempted to create the required scoped commit with message `Add LunaTag primitive for issue #17`, but the sandbox blocked writes to `.git/index.lock`, so the code is still uncommitted in the worktree.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`