### PR TITLE
Resolve #18: Build LunaTooltip primitive

### DIFF
--- a/.changeset/tiny-rivers-approve.md
+++ b/.changeset/tiny-rivers-approve.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaTooltip` primitive with theme support, Storybook coverage, tests, and docs.

--- a/docs/v1/components/LunaTooltip.md
+++ b/docs/v1/components/LunaTooltip.md
@@ -1,0 +1,55 @@
+# LunaTooltip
+
+`LunaTooltip` is the lightweight descriptive overlay primitive for `react-luna`.
+
+It owns:
+- short supplemental descriptions for a single trigger
+- hover and focus visibility behavior
+- keyboard dismissal with `Escape`
+- theme-aware bubble styling and placement
+
+It does not own:
+- interactive floating content
+- focus trapping
+- click-to-open disclosure behavior
+- menu or popover actions
+
+## Contract
+
+`LunaTooltip` wraps one React element child and describes that trigger when the tooltip is visible.
+
+Core rules:
+- the child must be a single React element
+- `content` is the tooltip body and may be text or richer non-interactive markup
+- the tooltip opens on pointer hover and keyboard focus
+- the tooltip closes on pointer leave, focus leave, and `Escape`
+- `aria-describedby` is applied to the trigger while the tooltip is visible
+- `disabled` suppresses all tooltip behavior
+
+## Props
+
+- `content: React.ReactNode`
+- `children: React.ReactElement`
+- `placement?: "top" | "right" | "bottom" | "left"`
+- `disabled?: boolean`
+- `offset?: string`
+- `maxWidth?: string`
+
+Native `HTMLAttributes<HTMLSpanElement>` continue to pass through to the wrapping root, including `className` and `style`.
+
+## Accessibility Notes
+
+- the bubble renders with `role="tooltip"`
+- the trigger keeps its own native semantics
+- the component preserves any existing `aria-describedby` values on the trigger and appends the tooltip id while open
+- tooltip content should remain descriptive, not interactive
+
+## Theme Integration
+
+`LunaTooltip` consumes the theme system for:
+- bubble background, foreground, and border
+- radius and shadow
+- default offset and max width
+- default horizontal and vertical padding
+
+`offset` and `maxWidth` resolve through theme spacing first, then raw CSS values.

--- a/docs/v1/design/LunaTooltip.md
+++ b/docs/v1/design/LunaTooltip.md
@@ -1,0 +1,24 @@
+# LunaTooltip
+
+## Purpose
+
+`LunaTooltip` provides short contextual guidance for an existing control without changing that control's semantics or flow position.
+
+It should stay small, descriptive, and easy to theme.
+
+## Design Rules
+
+- keep the primitive descriptive rather than interactive
+- make hover and focus behavior consistent so mouse and keyboard users reach the same content
+- support the common four-side placement model without growing into general floating-surface logic
+- let downstream themes restyle the bubble completely through tokens and CSS variables
+- keep the trigger contract strict: one child, one described element
+
+## Boundary
+
+`LunaTooltip` is not the answer for:
+- actionable overlay content
+- larger teaching callouts
+- click-driven disclosure
+
+Those cases belong to future floating-surface primitives such as `LunaPopover`.

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export * from "./luna-skeleton";
 export * from "./luna-spinner";
 export * from "./luna-switch";
 export * from "./luna-text";
+export * from "./luna-tooltip";
 export * from "./luna-row";
 export * from "./luna-column";
 export * from "./luna-grid";

--- a/src/components/luna-tooltip/LunaTooltip.css
+++ b/src/components/luna-tooltip/LunaTooltip.css
@@ -1,0 +1,91 @@
+.luna-tooltip {
+  display: inline-flex;
+  position: relative;
+  max-width: 100%;
+}
+
+.luna-tooltip__bubble {
+  position: absolute;
+  z-index: 20;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  width: max-content;
+  max-width: var(--luna-tooltip-max-width, 18rem);
+  padding: var(--luna-tooltip-padding-y, 0.5rem) var(--luna-tooltip-padding-x, 0.75rem);
+  border: 1px solid var(--luna-tooltip-border, var(--luna-border));
+  border-radius: var(--luna-tooltip-radius, var(--luna-radius-md));
+  background: var(--luna-tooltip-bg, var(--luna-surface));
+  color: var(--luna-tooltip-fg, var(--luna-foreground));
+  box-shadow: var(--luna-tooltip-shadow, var(--luna-shadow-md));
+  font-family: var(--luna-font-family);
+  font-size: var(--luna-text-variant-caption-font-size, 0.75rem);
+  font-weight: var(--luna-text-variant-caption-font-weight, 500);
+  line-height: var(--luna-text-variant-caption-line-height, 1.4);
+  letter-spacing: var(--luna-text-variant-caption-letter-spacing, 0.01em);
+  text-align: center;
+  pointer-events: none;
+}
+
+.luna-tooltip__content {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.luna-tooltip__arrow {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-right: 1px solid var(--luna-tooltip-border, var(--luna-border));
+  border-bottom: 1px solid var(--luna-tooltip-border, var(--luna-border));
+  background: var(--luna-tooltip-bg, var(--luna-surface));
+}
+
+.luna-tooltip[data-placement="top"] .luna-tooltip__bubble {
+  left: 50%;
+  bottom: calc(100% + var(--luna-tooltip-offset, var(--luna-tooltip-offset-default, 0.5rem)));
+  transform: translateX(-50%);
+}
+
+.luna-tooltip[data-placement="top"] .luna-tooltip__arrow {
+  margin-top: -0.4375rem;
+  transform: rotate(45deg);
+}
+
+.luna-tooltip[data-placement="bottom"] .luna-tooltip__bubble {
+  left: 50%;
+  top: calc(100% + var(--luna-tooltip-offset, var(--luna-tooltip-offset-default, 0.5rem)));
+  transform: translateX(-50%);
+  flex-direction: column-reverse;
+}
+
+.luna-tooltip[data-placement="bottom"] .luna-tooltip__arrow {
+  margin-bottom: -0.4375rem;
+  transform: rotate(225deg);
+}
+
+.luna-tooltip[data-placement="left"] .luna-tooltip__bubble {
+  top: 50%;
+  right: calc(100% + var(--luna-tooltip-offset, var(--luna-tooltip-offset-default, 0.5rem)));
+  transform: translateY(-50%);
+}
+
+.luna-tooltip[data-placement="left"] .luna-tooltip__arrow {
+  position: absolute;
+  top: 50%;
+  right: -0.375rem;
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.luna-tooltip[data-placement="right"] .luna-tooltip__bubble {
+  top: 50%;
+  left: calc(100% + var(--luna-tooltip-offset, var(--luna-tooltip-offset-default, 0.5rem)));
+  transform: translateY(-50%);
+}
+
+.luna-tooltip[data-placement="right"] .luna-tooltip__arrow {
+  position: absolute;
+  top: 50%;
+  left: -0.375rem;
+  transform: translateY(-50%) rotate(135deg);
+}

--- a/src/components/luna-tooltip/LunaTooltip.props.ts
+++ b/src/components/luna-tooltip/LunaTooltip.props.ts
@@ -1,0 +1,15 @@
+import type React from "react";
+
+export type LunaTooltipPlacement = "top" | "right" | "bottom" | "left";
+
+export type LunaTooltipProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children" | "content"
+> & {
+  children: React.ReactElement;
+  content: React.ReactNode;
+  placement?: LunaTooltipPlacement;
+  disabled?: boolean;
+  offset?: string;
+  maxWidth?: string;
+};

--- a/src/components/luna-tooltip/LunaTooltip.stories.tsx
+++ b/src/components/luna-tooltip/LunaTooltip.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaButton } from "../luna-button";
+import { LunaTooltip } from "./LunaTooltip";
+
+const placements = ["top", "right", "bottom", "left"] as const;
+
+const meta = {
+  title: "Components/LunaTooltip",
+  component: LunaTooltip,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    content: "Low-light calibration is active.",
+    children: <LunaButton>Telemetry</LunaButton>
+  }
+} satisfies Meta<typeof LunaTooltip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const PlacementMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(0, auto))",
+        gap: "4rem",
+        placeItems: "center"
+      }}
+    >
+      {placements.map((placement) => (
+        <LunaTooltip
+          key={placement}
+          placement={placement}
+          content={`Tooltip on the ${placement} side.`}
+        >
+          <LunaButton>
+            {placement[0].toUpperCase()}
+            {placement.slice(1)}
+          </LunaButton>
+        </LunaTooltip>
+      ))}
+    </div>
+  )
+};
+
+export const RichContentAndSizing: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1.5rem", placeItems: "center" }}>
+      <LunaTooltip
+        content={
+          <span>
+            Lunar drift is within tolerance.
+            <br />
+            Final sync completes in twelve seconds.
+          </span>
+        }
+        maxWidth="24"
+      >
+        <LunaButton outline>Mission status</LunaButton>
+      </LunaTooltip>
+      <LunaTooltip content="Tighter offsets can keep the bubble closer to dense controls." offset="1">
+        <LunaButton flat>Compact spacing</LunaButton>
+      </LunaTooltip>
+    </div>
+  )
+};
+
+export const DisabledTooltip: Story = {
+  render: () => (
+    <LunaTooltip content="This tooltip is intentionally disabled." disabled>
+      <LunaButton>Tooltip disabled</LunaButton>
+    </LunaTooltip>
+  )
+};

--- a/src/components/luna-tooltip/LunaTooltip.test.tsx
+++ b/src/components/luna-tooltip/LunaTooltip.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaTooltip } from "./LunaTooltip";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaTooltip", () => {
+  it("opens on hover and wires aria-describedby to the trigger", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaTooltip content="Low fuel warning">
+        <button type="button">Telemetry</button>
+      </LunaTooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Telemetry" });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.hover(trigger);
+
+    const tooltip = screen.getByRole("tooltip");
+
+    expect(tooltip).toHaveTextContent("Low fuel warning");
+    expect(trigger).toHaveAttribute("aria-describedby", tooltip.id);
+
+    await user.unhover(trigger);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("opens on focus and closes on Escape", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaTooltip content="Keyboard shortcut available">
+        <button type="button">Launch</button>
+      </LunaTooltip>
+    );
+
+    await user.tab();
+
+    const trigger = screen.getByRole("button", { name: "Launch" });
+
+    expect(trigger).toHaveFocus();
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Keyboard shortcut available");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("preserves an existing aria-describedby value when the tooltip opens", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <>
+        <span id="launch-help">Launch help</span>
+        <LunaTooltip content="Additional telemetry detail">
+          <button type="button" aria-describedby="launch-help">
+            Launch
+          </button>
+        </LunaTooltip>
+      </>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Launch" });
+
+    await user.hover(trigger);
+
+    const tooltip = screen.getByRole("tooltip");
+
+    expect(trigger).toHaveAttribute("aria-describedby", `launch-help ${tooltip.id}`);
+  });
+
+  it("does not open when disabled", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaTooltip content="Hidden detail" disabled>
+        <button type="button">Telemetry</button>
+      </LunaTooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Telemetry" });
+
+    await user.hover(trigger);
+    await user.tab();
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("resolves tooltip theme overrides onto the provider variables", () => {
+    const { container } = renderWithTheme(
+      <LunaTooltip content="Theme override" placement="right">
+        <button type="button">Telemetry</button>
+      </LunaTooltip>,
+      {
+        theme: {
+          components: {
+            tooltip: {
+              maxWidth: "16",
+              offset: "3",
+              modes: {
+                light: {
+                  bg: "accent.500",
+                  border: "accent.600"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-tooltip-max-width": "4rem",
+      "--luna-tooltip-offset-default": "0.75rem",
+      "--luna-tooltip-bg": "#8b5cf6",
+      "--luna-tooltip-border": "#7c3aed"
+    });
+  });
+});

--- a/src/components/luna-tooltip/LunaTooltip.tsx
+++ b/src/components/luna-tooltip/LunaTooltip.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaTooltipProps } from "./LunaTooltip.props";
+import "./LunaTooltip.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function composeEventHandlers<EventType extends React.SyntheticEvent>(
+  originalHandler: ((event: EventType) => void) | undefined,
+  nextHandler: (event: EventType) => void
+) {
+  return (event: EventType) => {
+    originalHandler?.(event);
+
+    if (!event.defaultPrevented) {
+      nextHandler(event);
+    }
+  };
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+export const LunaTooltip = React.forwardRef<HTMLSpanElement, LunaTooltipProps>(function LunaTooltip(
+  {
+    children,
+    className,
+    content,
+    disabled = false,
+    maxWidth,
+    offset,
+    onBlur,
+    onFocus,
+    onKeyDownCapture,
+    onMouseEnter,
+    onMouseLeave,
+    placement = "top",
+    style,
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const rootRef = React.useRef<HTMLSpanElement | null>(null);
+  const reactId = React.useId();
+  const tooltipId = `luna-tooltip-${reactId.replace(/:/g, "")}`;
+  const [open, setOpen] = React.useState(false);
+
+  React.useImperativeHandle(ref, () => rootRef.current as HTMLSpanElement, []);
+
+  React.useEffect(() => {
+    if (disabled && open) {
+      setOpen(false);
+    }
+  }, [disabled, open]);
+
+  const hasContent = content !== undefined && content !== null && content !== false;
+  const shouldShow = !disabled && hasContent && open;
+  const resolvedOffset = resolveSpacingValue(offset, theme);
+  const resolvedMaxWidth = resolveSpacingValue(maxWidth, theme) ?? maxWidth;
+  const resolvedStyle = {
+    ...(resolvedOffset ? { ["--luna-tooltip-offset" as const]: resolvedOffset } : {}),
+    ...(resolvedMaxWidth ? { ["--luna-tooltip-max-width" as const]: resolvedMaxWidth } : {}),
+    ...style
+  };
+
+  const child = React.Children.only(children);
+
+  if (!React.isValidElement(child)) {
+    throw new Error("LunaTooltip expects a single React element child.");
+  }
+
+  const childElement = child as React.ReactElement<{ "aria-describedby"?: string }>;
+  const describedBy = [childElement.props["aria-describedby"], shouldShow ? tooltipId : undefined]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span
+      {...props}
+      ref={rootRef}
+      className={toClassName(["luna-tooltip", className])}
+      data-open={shouldShow ? "true" : "false"}
+      data-placement={placement}
+      onMouseEnter={composeEventHandlers(onMouseEnter, () => {
+        if (!disabled && hasContent) {
+          setOpen(true);
+        }
+      })}
+      onMouseLeave={composeEventHandlers(onMouseLeave, () => {
+        setOpen(false);
+      })}
+      onFocus={composeEventHandlers(onFocus, () => {
+        if (!disabled && hasContent) {
+          setOpen(true);
+        }
+      })}
+      onBlur={composeEventHandlers(onBlur, (event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          return;
+        }
+
+        setOpen(false);
+      })}
+      onKeyDownCapture={composeEventHandlers(onKeyDownCapture, (event) => {
+        if (event.key === "Escape") {
+          setOpen(false);
+        }
+      })}
+      style={resolvedStyle}
+    >
+      {React.cloneElement(childElement, {
+        "aria-describedby": describedBy || undefined
+      })}
+      {shouldShow ? (
+        <span id={tooltipId} role="tooltip" className="luna-tooltip__bubble">
+          <span className="luna-tooltip__content">{content}</span>
+          <span aria-hidden="true" className="luna-tooltip__arrow" />
+        </span>
+      ) : null}
+    </span>
+  );
+});

--- a/src/components/luna-tooltip/index.ts
+++ b/src/components/luna-tooltip/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaTooltip";
+export * from "./LunaTooltip.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -964,6 +964,27 @@ export const lunarTheme: Theme = {
           disabledLabelFg: "neutral.500"
         }
       }
+    },
+    tooltip: {
+      radius: "md",
+      maxWidth: "18rem",
+      offset: "2",
+      paddingX: "3",
+      paddingY: "2",
+      modes: {
+        light: {
+          bg: "neutral.900",
+          fg: "neutral.50",
+          border: "neutral.700",
+          shadow: "md"
+        },
+        dark: {
+          bg: "neutral.100",
+          fg: "neutral.900",
+          border: "neutral.300",
+          shadow: "md"
+        }
+      }
     }
   }
 };

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -210,6 +210,13 @@ export type ThemeCheckboxModeTokens = {
   disabledLabelFg?: string;
 };
 
+export type ThemeTooltipModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  shadow?: string;
+};
+
 export type ThemeComponents = {
   button?: {
     defaultSize?: string;
@@ -306,6 +313,14 @@ export type ThemeComponents = {
     gap?: string;
     offsetY?: string;
     modes?: Partial<Record<ThemeMode, ThemeCheckboxModeTokens>>;
+  };
+  tooltip?: {
+    radius?: string;
+    maxWidth?: string;
+    offset?: string;
+    paddingX?: string;
+    paddingY?: string;
+    modes?: Partial<Record<ThemeMode, ThemeTooltipModeTokens>>;
   };
 };
 

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -395,6 +395,43 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     }
   }
 
+  const tooltip = theme.components.tooltip;
+  if (tooltip?.radius) {
+    vars["--luna-tooltip-radius"] =
+      resolveScaleValue(theme.radii, tooltip.radius) ?? tooltip.radius;
+  }
+  if (tooltip?.maxWidth) {
+    vars["--luna-tooltip-max-width"] =
+      resolveScaleValue(theme.spacing, tooltip.maxWidth) ?? tooltip.maxWidth;
+  }
+  if (tooltip?.offset) {
+    vars["--luna-tooltip-offset-default"] =
+      resolveScaleValue(theme.spacing, tooltip.offset) ?? tooltip.offset;
+  }
+  if (tooltip?.paddingX) {
+    vars["--luna-tooltip-padding-x"] =
+      resolveScaleValue(theme.spacing, tooltip.paddingX) ?? tooltip.paddingX;
+  }
+  if (tooltip?.paddingY) {
+    vars["--luna-tooltip-padding-y"] =
+      resolveScaleValue(theme.spacing, tooltip.paddingY) ?? tooltip.paddingY;
+  }
+  const tooltipMode = tooltip?.modes?.[mode];
+  if (tooltipMode?.bg) {
+    vars["--luna-tooltip-bg"] = resolveTokenValue(theme, tooltipMode.bg);
+  }
+  if (tooltipMode?.fg) {
+    vars["--luna-tooltip-fg"] = resolveTokenValue(theme, tooltipMode.fg);
+  }
+  if (tooltipMode?.border) {
+    vars["--luna-tooltip-border"] = resolveTokenValue(theme, tooltipMode.border);
+  }
+  if (tooltipMode?.shadow) {
+    vars["--luna-tooltip-shadow"] =
+      resolveScaleValue(theme.shadows, tooltipMode.shadow) ??
+      resolveTokenValue(theme, tooltipMode.shadow);
+  }
+
   const input = theme.components.input;
   if (input?.defaultSize) {
     vars["--luna-input-size-default"] = input.defaultSize;


### PR DESCRIPTION
Closes #18

## Summary
Implemented `LunaTooltip` as a scoped primitive for issue `#18`, including theme support, exports, Storybook, tests, docs, and a changeset. The core contract lives in [src/components/luna-tooltip/LunaTooltip.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tooltip/LunaTooltip.tsx), with typed props in [src/components/luna-tooltip/LunaTooltip.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tooltip/LunaTooltip.props.ts) and styling in [src/components/luna-tooltip/LunaTooltip.css](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tooltip/LunaTooltip.css). It opens on hover and focus, closes on blur, pointer leave, and `Escape`, applies `role="tooltip"`, and merges `aria-describedby` onto the trigger while visible.

I also added Storybook coverage in [src/components/luna-tooltip/LunaTooltip.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tooltip/LunaTooltip.stories.tsx), tests in [src/components/luna-tooltip/LunaTooltip.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-tooltip/LunaTooltip.test.tsx), public docs in [docs/v1/components/LunaTooltip.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaTooltip.md) and [docs/v1/design/LunaTooltip.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaTooltip.md), and theme wiring in [src/theme/types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts), [src/theme/base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts), and [src/theme/vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts). The export surface was updated in [src/components/index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts), and release metadata was added in [.changeset/tiny-rivers-approve.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/tiny-rivers-approve.md).

Verification ran clean:
- `npm test -- src/components/luna-tooltip/LunaTooltip.test.tsx`
- `npm test -- src/theme/base.test.ts src/components/luna-tooltip/LunaTooltip.test.tsx`
- `npm run build`

I attempted to commit the step as `Add LunaTooltip primitive for issue #18`, but the sandbox blocked writing `.git/index.lock`, so the code is changed locally but not committed.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`