### PR TITLE
Resolve #19: Build LunaToast primitive

### DIFF
--- a/.changeset/luna-toast-primitive.md
+++ b/.changeset/luna-toast-primitive.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaToast` primitive with theme-aware placement, controlled or uncontrolled visibility, auto-dismiss handling, Storybook coverage, tests, and docs.

--- a/.github/ISSUE_TEMPLATE/codex-component.yml
+++ b/.github/ISSUE_TEMPLATE/codex-component.yml
@@ -46,6 +46,7 @@ body:
         - implementation
         - Storybook coverage
         - screenshot-ready story states
+        - note any motion-critical stories that should use clip capture later
         - tests
         - docs
     validations:

--- a/.github/ISSUE_TEMPLATE/codex-component.yml
+++ b/.github/ISSUE_TEMPLATE/codex-component.yml
@@ -45,6 +45,7 @@ body:
       value: |
         - implementation
         - Storybook coverage
+        - screenshot-ready story states
         - tests
         - docs
     validations:

--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -1,0 +1,44 @@
+name: Storybook Visuals
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  storybook-visuals:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Capture Storybook screenshots
+        run: npm run screenshots:storybook
+
+      - name: Upload Storybook screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-screenshots-pr-${{ github.event.pull_request.number }}
+          path: artifacts/storybook-screenshots
+          if-no-files-found: error

--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -12,7 +12,7 @@ jobs:
   storybook-visuals:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -36,28 +36,68 @@ jobs:
       - name: Capture Storybook screenshots
         run: npm run screenshots:storybook
 
-      - name: Upload Storybook screenshots
-        id: upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: storybook-screenshots-pr-${{ github.event.pull_request.number }}
-          path: artifacts/storybook-screenshots
-          if-no-files-found: error
+      - name: Publish screenshots to preview branch
+        env:
+          PREVIEW_BRANCH: storybook-visuals
+          PREVIEW_DIR: pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Comment on PR with screenshot artifact
+          temp_dir="$(mktemp -d)"
+          cp -R artifacts/storybook-screenshots "$temp_dir/screenshots"
+          rm -f "$temp_dir/screenshots/.last-run.json"
+
+          if git ls-remote --exit-code --heads origin "$PREVIEW_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$PREVIEW_BRANCH":"$PREVIEW_BRANCH"
+            git checkout "$PREVIEW_BRANCH"
+          else
+            git checkout --orphan "$PREVIEW_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p "$PREVIEW_DIR"
+          rm -rf "$PREVIEW_DIR"/*
+          cp -R "$temp_dir/screenshots"/. "$PREVIEW_DIR"/
+
+          git add "$PREVIEW_DIR"
+          if git diff --cached --quiet; then
+            echo "No preview changes to commit."
+          else
+            git commit -m "Update Storybook visuals for PR #${{ github.event.pull_request.number }}"
+            git push origin "$PREVIEW_BRANCH"
+          fi
+
+          git checkout -
+
+      - name: Comment on PR with inline screenshot links
         uses: actions/github-script@v7
         env:
-          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
-          ARTIFACT_NAME: storybook-screenshots-pr-${{ github.event.pull_request.number }}
+          PREVIEW_BRANCH: storybook-visuals
+          PREVIEW_DIR: pr-${{ github.event.pull_request.number }}
         with:
           script: |
             const marker = '<!-- storybook-visuals-artifact -->';
+            const base = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/${process.env.PREVIEW_BRANCH}/${process.env.PREVIEW_DIR}`;
+            const images = [
+              { alt: 'LunaToast playground light', file: 'luna-toast-playground--light.png' },
+              { alt: 'LunaToast playground dark', file: 'luna-toast-playground--dark.png' },
+              { alt: 'LunaToast tone and emphasis matrix', file: 'luna-toast-tone-and-emphasis-matrix--light.png' },
+              { alt: 'LunaToast controlled visibility', file: 'luna-toast-controlled-visibility--light.png' },
+            ];
             const body = [
               marker,
               'Storybook screenshots are ready for review.',
               '',
-              `- Artifact: [${process.env.ARTIFACT_NAME}](${process.env.ARTIFACT_URL})`,
               `- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `- Preview directory: [${process.env.PREVIEW_DIR}](${base}/)`,
+              '',
+              ...images.flatMap((image) => [
+                `### ${image.alt}`,
+                `![${image.alt}](${base}/${image.file})`,
+                '',
+              ]),
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -37,8 +37,51 @@ jobs:
         run: npm run screenshots:storybook
 
       - name: Upload Storybook screenshots
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: storybook-screenshots-pr-${{ github.event.pull_request.number }}
           path: artifacts/storybook-screenshots
           if-no-files-found: error
+
+      - name: Comment on PR with screenshot artifact
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          ARTIFACT_NAME: storybook-screenshots-pr-${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const marker = '<!-- storybook-visuals-artifact -->';
+            const body = [
+              marker,
+              'Storybook screenshots are ready for review.',
+              '',
+              `- Artifact: [${process.env.ARTIFACT_NAME}](${process.env.ARTIFACT_URL})`,
+              `- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -37,6 +37,7 @@ jobs:
         run: npm run screenshots:storybook
 
       - name: Publish screenshots to preview branch
+        continue-on-error: true
         env:
           PREVIEW_BRANCH: storybook-visuals
           PREVIEW_DIR: pr-${{ github.event.pull_request.number }}
@@ -69,9 +70,9 @@ jobs:
             git push origin "$PREVIEW_BRANCH"
           fi
 
-          git checkout -
-
       - name: Comment on PR with inline screenshot links
+        if: always()
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           PREVIEW_BRANCH: storybook-visuals

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea
 dist
 storybook-static
+artifacts
+playwright-report

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,7 +19,7 @@ const preview: Preview = {
   decorators: [
     (Story, context) => {
       const canvasBackground = context.globals.backgrounds?.value;
-      const mode = canvasBackground === DARK_CANVAS ? "dark" : "light";
+      const mode = canvasBackground === DARK_CANVAS || canvasBackground === "dark" ? "dark" : "light";
 
       return (
         <ThemeProvider mode={mode}>

--- a/docs/ISSUE_AUTOMATION.md
+++ b/docs/ISSUE_AUTOMATION.md
@@ -97,6 +97,11 @@ The issue should already answer:
 - what outputs are required
 - what done looks like
 
+For component issues that are expected to use the Storybook visual workflow, the issue should also make clear whether the component needs:
+
+- screenshot-ready story states only
+- or motion-critical story states that should later be captured as clips
+
 If an issue does not answer those cleanly, it is usually not ready for `codex-ready`.
 
 ## Root Issue Pattern
@@ -230,6 +235,11 @@ To make automation reliable, issues should say:
 - important contract or non-goal notes
 
 For `react-luna`, this means the issue body should usually be good enough that Codex does not need a second manual translation pass before starting.
+
+When visual review matters, the issue should also say whether:
+
+- still screenshots are sufficient
+- or the component includes motion that deserves clip capture
 
 ## Initial Scope Recommendation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,6 +55,7 @@ The current shipped base already includes:
 - `LunaSwitch`
 - `LunaText`
 - `LunaTextarea`
+- `LunaToast`
 
 ### Tracked Base Gaps
 
@@ -63,7 +64,6 @@ The roadmap already includes these valid component ideas and they should stay in
 - `LunaBadge`
 - `LunaTag`
 - `LunaTooltip`
-- `LunaToast`
 - `LunaNotification`
 - `LunaHoverText`
 - `LunaForm`

--- a/docs/v1/components/LunaToast.md
+++ b/docs/v1/components/LunaToast.md
@@ -1,0 +1,89 @@
+# LunaToast
+
+`LunaToast` is the transient overlay feedback primitive for `react-luna`.
+
+It owns:
+- transient overlay messaging
+- controlled and uncontrolled visibility
+- optional auto-dismiss timing
+- theme-aware placement and spacing
+- optional dismiss affordance
+
+It does not own:
+- multi-toast orchestration
+- stacking and queue management
+- application-level notification history
+- application-specific message formatting
+
+## Position In The Feedback Stack
+
+The intended split is:
+
+- `LunaAlert`: inline, persistent feedback inside normal content flow
+- `LunaToast`: transient overlay feedback for time-bound updates
+- `LunaNotification`: broader application-level notification surface
+
+`LunaToast` should stay small enough to be embedded directly where a consumer already knows when one overlay message should appear.
+
+## Props
+
+- `tone?: "neutral" | "info" | "success" | "warning" | "danger"`
+- `emphasis?: "soft" | "solid" | "outline"`
+- `title?: React.ReactNode`
+- `icon?: React.ReactNode`
+- `action?: React.ReactNode`
+- `open?: boolean`
+- `defaultOpen?: boolean`
+- `onOpenChange?: (open: boolean, reason: "dismiss" | "timeout") => void`
+- `duration?: number`
+- `pauseOnHover?: boolean`
+- `dismissible?: boolean`
+- `dismissLabel?: string`
+- `placement?: "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right"`
+- `inset?: string`
+- `padding?: string`
+- `gap?: string`
+- `rounded?: boolean`
+
+Native `HTMLAttributes<HTMLDivElement>` continue to pass through to the root, including `role`, `aria-live`, and `aria-atomic`.
+
+## Contract
+
+- default root element is `div`
+- default announcement semantics are `role="status"`, `aria-live="polite"`, and `aria-atomic={true}`
+- `children` render the body content
+- `title` renders the stronger heading line
+- `action` renders an optional content region below the body
+- `dismissible` adds a close button without requiring a separate manager
+- `open` makes the component controlled
+- `defaultOpen` seeds uncontrolled visibility and defaults to `true`
+- `duration` controls auto-dismiss in milliseconds
+- `duration={0}` or any non-positive value disables auto-dismiss
+- `pauseOnHover` pauses the auto-dismiss timer while the pointer is over the toast
+- `onOpenChange` reports local close events with either `"dismiss"` or `"timeout"`
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaToast` consumes the existing theme system for:
+- default padding
+- default gap
+- default inset
+- default placement
+- default duration
+- max width
+- radius
+- shadow
+- per-tone surface colors for each emphasis level
+
+Spacing overrides resolve through theme spacing first, then raw CSS values.
+
+## Accessibility Notes
+
+`LunaToast` defaults to polite status semantics because it represents transient feedback.
+
+Override the native attributes when a different announcement rule is needed:
+- use `role="alert"` and `aria-live="assertive"` for urgent interruptions
+- pass `aria-live="off"` when the toast is purely visual
+
+Consumers remain responsible for deciding when a toast should appear and whether multiple messages need a higher-level container.

--- a/docs/v1/design/LunaToast.md
+++ b/docs/v1/design/LunaToast.md
@@ -1,0 +1,52 @@
+# LunaToast
+
+## Purpose
+
+`LunaToast` provides one transient overlay surface for short-lived status, success, warning, and error feedback without turning the primitive into a notification system.
+
+It should be usable anywhere an interface needs a single overlay message that appears near the viewport edge and then leaves.
+
+## Distinction From Other Feedback Surfaces
+
+The intended split is:
+
+- `LunaAlert` handles inline page-flow messaging
+- `LunaToast` handles transient overlay feedback
+- `LunaNotification` can grow into broader application-level notification work later
+
+That keeps the toast primitive focused on one overlay message instead of stack layout, queueing, or cross-page message history.
+
+## Design Rules
+
+- keep the contract smaller than a full notification manager
+- keep tone and emphasis theme-driven
+- allow both controlled and uncontrolled open state
+- support optional auto-dismiss without forcing it
+- let downstream consumers choose the announcement semantics when a polite status is not enough
+- keep placement explicit without assuming a stacking container
+
+## Contract Shape
+
+The primitive uses the same tone and emphasis language as `LunaAlert` so feedback surfaces stay consistent.
+
+Toast-specific controls are:
+- visibility through `open` or `defaultOpen`
+- time-bound dismissal through `duration`
+- viewport anchoring through `placement` and `inset`
+
+This keeps the feedback language aligned while leaving transient behavior explicit.
+
+## Theme Expectations
+
+The toast theme slice should remain responsible for:
+- default padding
+- default gap
+- default inset
+- default placement
+- default duration
+- max width
+- radius
+- shadow
+- light and dark color tokens for every built-in tone and emphasis combination
+
+If future work adds stacking or queue management, that should build on top of this primitive instead of inflating this component into a notification framework.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@liketysplit/react-luna",
-  "version": "0.1.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@liketysplit/react-luna",
-      "version": "0.1.6",
+      "version": "0.3.0",
       "devDependencies": {
         "@changesets/cli": "^2.29.6",
+        "@playwright/test": "^1.53.0",
         "@storybook/addon-essentials": "^8.5.0",
         "@storybook/react": "^8.5.0",
         "@storybook/react-vite": "^8.5.0",
@@ -1581,6 +1582,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4932,6 +4949,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/polished": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "version-packages": "changeset version",
     "release": "changeset publish",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "screenshots:storybook": "playwright test -c playwright.storybook.config.ts",
+    "screenshots:storybook:list": "playwright test -c playwright.storybook.config.ts --list"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
@@ -50,6 +52,7 @@
     "@storybook/addon-essentials": "^8.5.0",
     "@storybook/react": "^8.5.0",
     "@storybook/react-vite": "^8.5.0",
+    "@playwright/test": "^1.53.0",
     "@changesets/cli": "^2.29.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.storybook.config.ts
+++ b/playwright.storybook.config.ts
@@ -25,9 +25,9 @@ export default defineConfig({
     }
   ],
   webServer: {
-    command: "node scripts/serve-static.mjs storybook-static 6006",
-    url: "http://127.0.0.1:6006",
-    reuseExistingServer: !process.env.CI,
+    command: "node scripts/serve-static.mjs storybook-static 6106",
+    url: "http://127.0.0.1:6106",
+    reuseExistingServer: false,
     stdout: "ignore",
     stderr: "pipe"
   }

--- a/playwright.storybook.config.ts
+++ b/playwright.storybook.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const outputDir = "artifacts/storybook-screenshots";
+
+export default defineConfig({
+  testDir: "./playwright/storybook",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:6006",
+    trace: "off",
+    video: "off",
+    screenshot: "off"
+  },
+  outputDir,
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 1080 }
+      }
+    }
+  ],
+  webServer: {
+    command: "node scripts/serve-static.mjs storybook-static 6006",
+    url: "http://127.0.0.1:6006",
+    reuseExistingServer: !process.env.CI,
+    stdout: "ignore",
+    stderr: "pipe"
+  }
+});

--- a/playwright.storybook.config.ts
+++ b/playwright.storybook.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: 1,
   reporter: [["list"]],
   use: {
-    baseURL: "http://127.0.0.1:6006",
+    baseURL: "http://127.0.0.1:6106",
     trace: "off",
     video: "off",
     screenshot: "off"

--- a/playwright/storybook/manifest.ts
+++ b/playwright/storybook/manifest.ts
@@ -1,0 +1,23 @@
+export type StoryCapture = {
+  storyId: string;
+  fileName: string;
+  backgrounds?: string[];
+};
+
+export const storybookCaptures: StoryCapture[] = [
+  {
+    storyId: "components-lunatoast--playground",
+    fileName: "luna-toast-playground",
+    backgrounds: ["light", "dark"]
+  },
+  {
+    storyId: "components-lunatoast--tone-and-emphasis-matrix",
+    fileName: "luna-toast-tone-and-emphasis-matrix",
+    backgrounds: ["light"]
+  },
+  {
+    storyId: "components-lunatoast--controlled-visibility",
+    fileName: "luna-toast-controlled-visibility",
+    backgrounds: ["light"]
+  }
+];

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { storybookCaptures } from "./manifest";
+
+const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
+
+for (const capture of storybookCaptures) {
+  const backgrounds = capture.backgrounds ?? ["light"];
+
+  for (const background of backgrounds) {
+    test(`${capture.storyId} [${background}]`, async ({ page }) => {
+      const screenshotPath = join(screenshotDir, `${capture.fileName}--${background}.png`);
+      mkdirSync(dirname(screenshotPath), { recursive: true });
+
+      await page.goto(
+        `/iframe.html?id=${capture.storyId}&viewMode=story&globals=backgrounds.value:${background}`,
+        { waitUntil: "networkidle" }
+      );
+
+      await page.setViewportSize({ width: 1440, height: 1080 });
+      await expect(page.locator("#storybook-root")).toBeVisible();
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    });
+  }
+}

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -1,0 +1,51 @@
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { extname, join, normalize, resolve } from "node:path";
+import { createServer } from "node:http";
+
+const root = resolve(process.argv[2] ?? "storybook-static");
+const port = Number(process.argv[3] ?? "6006");
+
+const contentTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2"
+};
+
+function safePath(urlPath) {
+  const raw = decodeURIComponent(urlPath.split("?")[0]);
+  const normalized = normalize(raw).replace(/^(\.\.[/\\])+/, "");
+  return normalized === "/" ? "/index.html" : normalized;
+}
+
+createServer((request, response) => {
+  const relativePath = safePath(request.url ?? "/");
+  const filePath = join(root, relativePath);
+
+  if (!existsSync(filePath)) {
+    response.statusCode = 404;
+    response.end("Not found");
+    return;
+  }
+
+  const stats = statSync(filePath);
+  const resolvedPath = stats.isDirectory() ? join(filePath, "index.html") : filePath;
+
+  if (!existsSync(resolvedPath)) {
+    response.statusCode = 404;
+    response.end("Not found");
+    return;
+  }
+
+  response.setHeader("Content-Type", contentTypes[extname(resolvedPath)] ?? "application/octet-stream");
+  createReadStream(resolvedPath).pipe(response);
+}).listen(port, "127.0.0.1", () => {
+  console.log(`Serving ${root} at http://127.0.0.1:${port}`);
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,3 +22,4 @@ export * from "./luna-text";
 export * from "./luna-row";
 export * from "./luna-column";
 export * from "./luna-grid";
+export * from "./luna-toast";

--- a/src/components/luna-toast/LunaToast.css
+++ b/src/components/luna-toast/LunaToast.css
@@ -1,0 +1,221 @@
+.luna-toast {
+  --luna-toast-current-bg: var(--luna-toast-neutral-soft-bg, var(--luna-surface));
+  --luna-toast-current-border: var(--luna-toast-neutral-soft-border, var(--luna-border));
+  --luna-toast-current-fg: var(--luna-toast-neutral-soft-fg, var(--luna-foreground));
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--luna-toast-gap, var(--luna-toast-gap-default, var(--luna-space-3)));
+  width: min(calc(100vw - (var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4))) * 2)), var(--luna-toast-max-width, 24rem));
+  padding: var(--luna-toast-padding, var(--luna-toast-padding-default, var(--luna-space-4)));
+  border: 1px solid var(--luna-toast-current-border);
+  border-radius: var(--luna-toast-radius, var(--luna-radius-lg));
+  background: var(--luna-toast-current-bg);
+  color: var(--luna-toast-current-fg);
+  box-shadow: var(--luna-toast-shadow, var(--luna-shadow-md));
+}
+
+.luna-toast--rounded {
+  border-radius: calc(var(--luna-toast-radius, var(--luna-radius-lg)) * 1.5);
+}
+
+.luna-toast__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
+  color: inherit;
+}
+
+.luna-toast__content {
+  display: grid;
+  gap: calc(var(--luna-toast-gap, var(--luna-toast-gap-default, var(--luna-space-3))) * 0.5);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.luna-toast--title-only .luna-toast__content {
+  gap: 0;
+}
+
+.luna-toast__title {
+  margin: 0;
+  font-size: var(--luna-text-variant-label-font-size, 0.875rem);
+  font-weight: var(--luna-text-variant-label-font-weight, 600);
+  line-height: var(--luna-text-variant-label-line-height, 1.4);
+  letter-spacing: var(--luna-text-variant-label-letter-spacing, 0.01em);
+}
+
+.luna-toast__body,
+.luna-toast__action {
+  margin: 0;
+  font-size: var(--luna-text-variant-body-small-font-size, 0.875rem);
+  line-height: var(--luna-text-variant-body-small-line-height, 1.6);
+}
+
+.luna-toast__body > :first-child,
+.luna-toast__title > :first-child,
+.luna-toast__action > :first-child {
+  margin-top: 0;
+}
+
+.luna-toast__body > :last-child,
+.luna-toast__title > :last-child,
+.luna-toast__action > :last-child {
+  margin-bottom: 0;
+}
+
+.luna-toast__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.875rem;
+  height: 1.875rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--luna-radius-pill);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.luna-toast__dismiss:hover {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.luna-toast__dismiss:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.luna-toast[data-placement="top-left"] {
+  top: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  left: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+}
+
+.luna-toast[data-placement="top-center"] {
+  top: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.luna-toast[data-placement="top-right"] {
+  top: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  right: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+}
+
+.luna-toast[data-placement="bottom-left"] {
+  bottom: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  left: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+}
+
+.luna-toast[data-placement="bottom-center"] {
+  bottom: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.luna-toast[data-placement="bottom-right"] {
+  right: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+  bottom: var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4)));
+}
+
+.luna-toast[data-tone="neutral"][data-emphasis="soft"] {
+  --luna-toast-current-bg: var(--luna-toast-neutral-soft-bg);
+  --luna-toast-current-border: var(--luna-toast-neutral-soft-border);
+  --luna-toast-current-fg: var(--luna-toast-neutral-soft-fg);
+}
+
+.luna-toast[data-tone="neutral"][data-emphasis="solid"] {
+  --luna-toast-current-bg: var(--luna-toast-neutral-solid-bg);
+  --luna-toast-current-border: var(--luna-toast-neutral-solid-border);
+  --luna-toast-current-fg: var(--luna-toast-neutral-solid-fg);
+}
+
+.luna-toast[data-tone="neutral"][data-emphasis="outline"] {
+  --luna-toast-current-bg: var(--luna-toast-neutral-outline-bg);
+  --luna-toast-current-border: var(--luna-toast-neutral-outline-border);
+  --luna-toast-current-fg: var(--luna-toast-neutral-outline-fg);
+}
+
+.luna-toast[data-tone="info"][data-emphasis="soft"] {
+  --luna-toast-current-bg: var(--luna-toast-info-soft-bg);
+  --luna-toast-current-border: var(--luna-toast-info-soft-border);
+  --luna-toast-current-fg: var(--luna-toast-info-soft-fg);
+}
+
+.luna-toast[data-tone="info"][data-emphasis="solid"] {
+  --luna-toast-current-bg: var(--luna-toast-info-solid-bg);
+  --luna-toast-current-border: var(--luna-toast-info-solid-border);
+  --luna-toast-current-fg: var(--luna-toast-info-solid-fg);
+}
+
+.luna-toast[data-tone="info"][data-emphasis="outline"] {
+  --luna-toast-current-bg: var(--luna-toast-info-outline-bg);
+  --luna-toast-current-border: var(--luna-toast-info-outline-border);
+  --luna-toast-current-fg: var(--luna-toast-info-outline-fg);
+}
+
+.luna-toast[data-tone="success"][data-emphasis="soft"] {
+  --luna-toast-current-bg: var(--luna-toast-success-soft-bg);
+  --luna-toast-current-border: var(--luna-toast-success-soft-border);
+  --luna-toast-current-fg: var(--luna-toast-success-soft-fg);
+}
+
+.luna-toast[data-tone="success"][data-emphasis="solid"] {
+  --luna-toast-current-bg: var(--luna-toast-success-solid-bg);
+  --luna-toast-current-border: var(--luna-toast-success-solid-border);
+  --luna-toast-current-fg: var(--luna-toast-success-solid-fg);
+}
+
+.luna-toast[data-tone="success"][data-emphasis="outline"] {
+  --luna-toast-current-bg: var(--luna-toast-success-outline-bg);
+  --luna-toast-current-border: var(--luna-toast-success-outline-border);
+  --luna-toast-current-fg: var(--luna-toast-success-outline-fg);
+}
+
+.luna-toast[data-tone="warning"][data-emphasis="soft"] {
+  --luna-toast-current-bg: var(--luna-toast-warning-soft-bg);
+  --luna-toast-current-border: var(--luna-toast-warning-soft-border);
+  --luna-toast-current-fg: var(--luna-toast-warning-soft-fg);
+}
+
+.luna-toast[data-tone="warning"][data-emphasis="solid"] {
+  --luna-toast-current-bg: var(--luna-toast-warning-solid-bg);
+  --luna-toast-current-border: var(--luna-toast-warning-solid-border);
+  --luna-toast-current-fg: var(--luna-toast-warning-solid-fg);
+}
+
+.luna-toast[data-tone="warning"][data-emphasis="outline"] {
+  --luna-toast-current-bg: var(--luna-toast-warning-outline-bg);
+  --luna-toast-current-border: var(--luna-toast-warning-outline-border);
+  --luna-toast-current-fg: var(--luna-toast-warning-outline-fg);
+}
+
+.luna-toast[data-tone="danger"][data-emphasis="soft"] {
+  --luna-toast-current-bg: var(--luna-toast-danger-soft-bg);
+  --luna-toast-current-border: var(--luna-toast-danger-soft-border);
+  --luna-toast-current-fg: var(--luna-toast-danger-soft-fg);
+}
+
+.luna-toast[data-tone="danger"][data-emphasis="solid"] {
+  --luna-toast-current-bg: var(--luna-toast-danger-solid-bg);
+  --luna-toast-current-border: var(--luna-toast-danger-solid-border);
+  --luna-toast-current-fg: var(--luna-toast-danger-solid-fg);
+}
+
+.luna-toast[data-tone="danger"][data-emphasis="outline"] {
+  --luna-toast-current-bg: var(--luna-toast-danger-outline-bg);
+  --luna-toast-current-border: var(--luna-toast-danger-outline-border);
+  --luna-toast-current-fg: var(--luna-toast-danger-outline-fg);
+}
+
+@media (max-width: 640px) {
+  .luna-toast {
+    width: calc(100vw - (var(--luna-toast-inset, var(--luna-toast-inset-default, var(--luna-space-4))) * 2));
+  }
+}

--- a/src/components/luna-toast/LunaToast.props.ts
+++ b/src/components/luna-toast/LunaToast.props.ts
@@ -1,0 +1,32 @@
+import type React from "react";
+import type { LunaAlertEmphasis, LunaAlertTone } from "../luna-alert";
+
+export type LunaToastPlacement =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
+export type LunaToastDismissReason = "dismiss" | "timeout";
+
+export type LunaToastProps = Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "color"> & {
+  tone?: LunaAlertTone;
+  emphasis?: LunaAlertEmphasis;
+  title?: React.ReactNode;
+  icon?: React.ReactNode;
+  action?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean, reason: LunaToastDismissReason) => void;
+  duration?: number;
+  pauseOnHover?: boolean;
+  dismissible?: boolean;
+  dismissLabel?: string;
+  placement?: LunaToastPlacement;
+  inset?: string;
+  padding?: string;
+  gap?: string;
+  rounded?: boolean;
+};

--- a/src/components/luna-toast/LunaToast.stories.tsx
+++ b/src/components/luna-toast/LunaToast.stories.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaToast } from "./LunaToast";
+
+const tones = ["neutral", "info", "success", "warning", "danger"] as const;
+const emphases = ["soft", "solid", "outline"] as const;
+
+const meta = {
+  title: "Components/LunaToast",
+  component: LunaToast,
+  parameters: {
+    layout: "fullscreen"
+  },
+  args: {
+    title: "Mission update",
+    children: "The orbital sync finished successfully.",
+    dismissible: true
+  }
+} satisfies Meta<typeof LunaToast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const ToneAndEmphasisMatrix: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1rem", padding: "2rem" }}>
+      {emphases.map((emphasis) => (
+        <div
+          key={emphasis}
+          style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(3, minmax(0, 1fr))" }}
+        >
+          {tones.map((tone, index) => (
+            <div key={`${tone}-${emphasis}`} style={{ position: "relative", minHeight: "9rem" }}>
+              <LunaToast
+                tone={tone}
+                emphasis={emphasis}
+                placement={
+                  index === 0 ? "top-left" : index === 1 ? "top-center" : "top-right"
+                }
+                title={`${tone[0].toUpperCase()}${tone.slice(1)} toast`}
+                dismissible
+                duration={0}
+                style={{ position: "absolute" }}
+              >
+                Transient overlay feedback for {tone} surfaces.
+              </LunaToast>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+};
+
+export const AutoDismissAndAction: Story = {
+  render: () => (
+    <LunaToast
+      tone="success"
+      title="Upload complete"
+      duration={4000}
+      action={<a href="#review">Review payload</a>}
+      icon={<span>+</span>}
+      dismissible
+    >
+      The latest transmission is ready for verification.
+    </LunaToast>
+  )
+};
+
+export const ControlledVisibility: Story = {
+  render: () => {
+    function ControlledToastStory() {
+      const [open, setOpen] = React.useState(true);
+
+      return (
+        <div style={{ minHeight: "14rem", padding: "2rem" }}>
+          <button type="button" onClick={() => setOpen((value) => !value)}>
+            {open ? "Hide toast" : "Show toast"}
+          </button>
+          <LunaToast
+            open={open}
+            title="Controlled visibility"
+            tone="info"
+            dismissible
+            onOpenChange={(nextOpen) => setOpen(nextOpen)}
+            duration={0}
+          >
+            This story shows controlled open state without a notification manager.
+          </LunaToast>
+        </div>
+      );
+    }
+
+    return <ControlledToastStory />;
+  }
+};

--- a/src/components/luna-toast/LunaToast.test.tsx
+++ b/src/components/luna-toast/LunaToast.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaToast } from "./LunaToast";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("LunaToast", () => {
+  it("renders the default toast contract with announcement semantics", () => {
+    renderWithTheme(<LunaToast title="Mission update">Orbit confirmed.</LunaToast>);
+
+    const toast = screen.getByRole("status");
+
+    expect(toast).toHaveAttribute("data-tone", "neutral");
+    expect(toast).toHaveAttribute("data-emphasis", "soft");
+    expect(toast).toHaveAttribute("data-placement", "bottom-right");
+    expect(toast).toHaveAttribute("aria-live", "polite");
+    expect(toast).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText("Mission update")).toBeInTheDocument();
+    expect(screen.getByText("Orbit confirmed.")).toBeInTheDocument();
+  });
+
+  it("supports dismiss buttons and reports dismiss events", () => {
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <LunaToast title="Dismiss me" dismissible onOpenChange={onOpenChange}>
+        Manual close.
+      </LunaToast>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "dismiss");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("auto dismisses after the resolved duration", () => {
+    vi.useFakeTimers();
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <LunaToast title="Telemetry synced" duration={1200} onOpenChange={onOpenChange}>
+        Auto close.
+      </LunaToast>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "timeout");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("pauses auto dismiss while hovered", () => {
+    vi.useFakeTimers();
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <LunaToast title="Hover hold" duration={1000} onOpenChange={onOpenChange}>
+        Stay visible while hovered.
+      </LunaToast>
+    );
+
+    const toast = screen.getByRole("status");
+
+    fireEvent.mouseEnter(toast);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.mouseLeave(toast);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "timeout");
+  });
+
+  it("supports controlled visibility without mutating its own open state", () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = renderWithTheme(
+      <LunaToast open title="Controlled" dismissible onOpenChange={onOpenChange}>
+        Controlled toast.
+      </LunaToast>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "dismiss");
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider>
+        <LunaToast open={false} title="Controlled" dismissible onOpenChange={onOpenChange}>
+          Controlled toast.
+        </LunaToast>
+      </ThemeProvider>
+    );
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("resolves spacing and toast theme tokens through the theme system", () => {
+    const { container } = renderWithTheme(
+      <LunaToast title="Theme override" tone="info" emphasis="outline" padding="6" gap="2" inset="8">
+        Custom theme.
+      </LunaToast>,
+      {
+        theme: {
+          components: {
+            toast: {
+              defaultPlacement: "top-left",
+              maxWidth: "28rem",
+              shadow: "lg",
+              tones: {
+                light: {
+                  info: {
+                    outline: {
+                      border: "accent.500"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+    const toast = screen.getByRole("status");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-toast-max-width": "28rem",
+      "--luna-toast-shadow": "0 16px 40px rgba(15, 23, 42, 0.22)",
+      "--luna-toast-info-outline-border": "#8b5cf6"
+    });
+    expect(toast).toHaveAttribute("data-placement", "top-left");
+    expect(toast).toHaveStyle({
+      "--luna-toast-padding": "1.5rem",
+      "--luna-toast-gap": "0.5rem",
+      "--luna-toast-inset": "2rem"
+    });
+  });
+});

--- a/src/components/luna-toast/LunaToast.tsx
+++ b/src/components/luna-toast/LunaToast.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaToastDismissReason, LunaToastProps } from "./LunaToast.props";
+import "./LunaToast.css";
+
+type ToastCssVariable =
+  | "--luna-toast-padding"
+  | "--luna-toast-gap"
+  | "--luna-toast-inset";
+
+type LunaToastStyle = React.CSSProperties &
+  Partial<Record<ToastCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+export const LunaToast = React.forwardRef<HTMLDivElement, LunaToastProps>(function LunaToast(
+  {
+    action,
+    children,
+    className,
+    defaultOpen = true,
+    dismissible,
+    dismissLabel = "Dismiss notification",
+    duration,
+    emphasis = "soft",
+    gap,
+    icon,
+    inset,
+    onOpenChange,
+    open,
+    padding,
+    pauseOnHover = true,
+    placement,
+    rounded,
+    role,
+    style,
+    title,
+    tone = "neutral",
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const [isHovered, setIsHovered] = React.useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const resolvedPlacement =
+    placement ?? theme.components.toast?.defaultPlacement ?? "bottom-right";
+  const resolvedDuration = duration ?? theme.components.toast?.defaultDuration;
+  const resolvedPadding = resolveSpacingValue(padding, theme);
+  const resolvedGap = resolveSpacingValue(gap, theme);
+  const resolvedInset = resolveSpacingValue(inset, theme);
+  const hasBody = children !== undefined && children !== null;
+  const resolvedStyle: LunaToastStyle = {
+    ...(resolvedPadding ? { ["--luna-toast-padding" as const]: resolvedPadding } : {}),
+    ...(resolvedGap ? { ["--luna-toast-gap" as const]: resolvedGap } : {}),
+    ...(resolvedInset ? { ["--luna-toast-inset" as const]: resolvedInset } : {}),
+    ...style
+  };
+
+  const closeToast = React.useCallback(
+    (reason: LunaToastDismissReason) => {
+      if (!isControlled) {
+        setInternalOpen(false);
+      }
+
+      onOpenChange?.(false, reason);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    if (!resolvedDuration || resolvedDuration <= 0) {
+      return undefined;
+    }
+
+    if (pauseOnHover && isHovered) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      closeToast("timeout");
+    }, resolvedDuration);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [closeToast, isHovered, isOpen, pauseOnHover, resolvedDuration]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      className={toClassName([
+        "luna-toast",
+        rounded && "luna-toast--rounded",
+        !hasBody && "luna-toast--title-only",
+        className
+      ])}
+      data-tone={tone}
+      data-emphasis={emphasis}
+      data-placement={resolvedPlacement}
+      role={role ?? "status"}
+      aria-live={props["aria-live"] ?? "polite"}
+      aria-atomic={props["aria-atomic"] ?? true}
+      style={resolvedStyle}
+      onMouseEnter={(event) => {
+        setIsHovered(true);
+        props.onMouseEnter?.(event);
+      }}
+      onMouseLeave={(event) => {
+        setIsHovered(false);
+        props.onMouseLeave?.(event);
+      }}
+    >
+      {icon ? (
+        <div aria-hidden="true" className="luna-toast__icon">
+          {icon}
+        </div>
+      ) : null}
+      <div className="luna-toast__content">
+        {title ? <div className="luna-toast__title">{title}</div> : null}
+        {hasBody ? <div className="luna-toast__body">{children}</div> : null}
+        {action ? <div className="luna-toast__action">{action}</div> : null}
+      </div>
+      {dismissible ? (
+        <button
+          type="button"
+          className="luna-toast__dismiss"
+          aria-label={dismissLabel}
+          onClick={() => {
+            closeToast("dismiss");
+          }}
+        >
+          <span aria-hidden="true">x</span>
+        </button>
+      ) : null}
+    </div>
+  );
+});

--- a/src/components/luna-toast/index.ts
+++ b/src/components/luna-toast/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaToast";
+export * from "./LunaToast.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -521,6 +521,192 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    toast: {
+      defaultPadding: "4",
+      defaultGap: "3",
+      defaultInset: "4",
+      defaultDuration: 5000,
+      defaultPlacement: "bottom-right",
+      radius: "lg",
+      maxWidth: "24rem",
+      shadow: "md",
+      tones: {
+        light: {
+          neutral: {
+            soft: {
+              bg: "neutral.50",
+              border: "neutral.200",
+              fg: "neutral.900"
+            },
+            solid: {
+              bg: "neutral.800",
+              border: "neutral.800",
+              fg: "neutral.50"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "neutral.300",
+              fg: "neutral.900"
+            }
+          },
+          info: {
+            soft: {
+              bg: "primary.50",
+              border: "primary.200",
+              fg: "primary.800"
+            },
+            solid: {
+              bg: "primary.600",
+              border: "primary.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "primary.300",
+              fg: "primary.800"
+            }
+          },
+          success: {
+            soft: {
+              bg: "success.50",
+              border: "success.200",
+              fg: "success.800"
+            },
+            solid: {
+              bg: "success.600",
+              border: "success.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "success.300",
+              fg: "success.800"
+            }
+          },
+          warning: {
+            soft: {
+              bg: "warning.50",
+              border: "warning.200",
+              fg: "warning.900"
+            },
+            solid: {
+              bg: "warning.600",
+              border: "warning.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "warning.300",
+              fg: "warning.900"
+            }
+          },
+          danger: {
+            soft: {
+              bg: "danger.50",
+              border: "danger.200",
+              fg: "danger.800"
+            },
+            solid: {
+              bg: "danger.600",
+              border: "danger.600",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.50",
+              border: "danger.300",
+              fg: "danger.800"
+            }
+          }
+        },
+        dark: {
+          neutral: {
+            soft: {
+              bg: "neutral.800",
+              border: "neutral.600",
+              fg: "neutral.50"
+            },
+            solid: {
+              bg: "neutral.200",
+              border: "neutral.200",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "neutral.600",
+              fg: "neutral.50"
+            }
+          },
+          info: {
+            soft: {
+              bg: "primary.900",
+              border: "primary.700",
+              fg: "primary.100"
+            },
+            solid: {
+              bg: "primary.400",
+              border: "primary.400",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "primary.500",
+              fg: "primary.100"
+            }
+          },
+          success: {
+            soft: {
+              bg: "success.900",
+              border: "success.700",
+              fg: "success.100"
+            },
+            solid: {
+              bg: "success.400",
+              border: "success.400",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "success.500",
+              fg: "success.100"
+            }
+          },
+          warning: {
+            soft: {
+              bg: "warning.900",
+              border: "warning.700",
+              fg: "warning.100"
+            },
+            solid: {
+              bg: "warning.400",
+              border: "warning.400",
+              fg: "#0b1220"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "warning.500",
+              fg: "warning.100"
+            }
+          },
+          danger: {
+            soft: {
+              bg: "danger.900",
+              border: "danger.700",
+              fg: "danger.100"
+            },
+            solid: {
+              bg: "danger.400",
+              border: "danger.400",
+              fg: "#ffffff"
+            },
+            outline: {
+              bg: "neutral.900",
+              border: "danger.500",
+              fg: "danger.100"
+            }
+          }
+        }
+      }
+    },
     divider: {
       defaultSpacing: "4",
       defaultInset: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -107,6 +107,20 @@ export type ThemeAlertSurfaceTokens = {
   fg?: string;
 };
 
+export type ThemeToastPlacement =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
+export type ThemeToastSurfaceTokens = {
+  bg?: string;
+  border?: string;
+  fg?: string;
+};
+
 export type ThemeDividerModeTokens = {
   default?: string;
   muted?: string;
@@ -232,6 +246,22 @@ export type ThemeComponents = {
       Record<
         ThemeMode,
         Partial<Record<ThemeAlertTone, Partial<Record<ThemeAlertEmphasis, ThemeAlertSurfaceTokens>>>>
+      >
+    >;
+  };
+  toast?: {
+    defaultPadding?: string;
+    defaultGap?: string;
+    defaultInset?: string;
+    defaultDuration?: number;
+    defaultPlacement?: ThemeToastPlacement;
+    radius?: string;
+    maxWidth?: string;
+    shadow?: string;
+    tones?: Partial<
+      Record<
+        ThemeMode,
+        Partial<Record<ThemeAlertTone, Partial<Record<ThemeAlertEmphasis, ThemeToastSurfaceTokens>>>>
       >
     >;
   };

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -247,6 +247,66 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     }
   }
 
+  const toast = theme.components.toast;
+  if (toast?.defaultPadding) {
+    vars["--luna-toast-padding-default"] =
+      resolveScaleValue(theme.spacing, toast.defaultPadding) ?? toast.defaultPadding;
+  }
+  if (toast?.defaultGap) {
+    vars["--luna-toast-gap-default"] =
+      resolveScaleValue(theme.spacing, toast.defaultGap) ?? toast.defaultGap;
+  }
+  if (toast?.defaultInset) {
+    vars["--luna-toast-inset-default"] =
+      resolveScaleValue(theme.spacing, toast.defaultInset) ?? toast.defaultInset;
+  }
+  if (toast?.defaultPlacement) {
+    vars["--luna-toast-placement-default"] = toast.defaultPlacement;
+  }
+  if (toast?.radius) {
+    vars["--luna-toast-radius"] = resolveScaleValue(theme.radii, toast.radius) ?? toast.radius;
+  }
+  if (toast?.maxWidth) {
+    vars["--luna-toast-max-width"] = resolveScaleValue(theme.spacing, toast.maxWidth) ?? toast.maxWidth;
+  }
+  if (toast?.shadow) {
+    vars["--luna-toast-shadow"] =
+      resolveScaleValue(theme.shadows, toast.shadow) ?? resolveTokenValue(theme, toast.shadow);
+  }
+  const toastMode = toast?.tones?.[mode];
+  if (toastMode) {
+    for (const [toneName, emphasisMap] of Object.entries(toastMode)) {
+      if (!emphasisMap) {
+        continue;
+      }
+
+      for (const [emphasisName, surface] of Object.entries(emphasisMap)) {
+        if (!surface) {
+          continue;
+        }
+
+        if (surface.bg) {
+          vars[`--luna-toast-${toneName}-${emphasisName}-bg`] = resolveTokenValue(
+            theme,
+            surface.bg
+          );
+        }
+        if (surface.border) {
+          vars[`--luna-toast-${toneName}-${emphasisName}-border`] = resolveTokenValue(
+            theme,
+            surface.border
+          );
+        }
+        if (surface.fg) {
+          vars[`--luna-toast-${toneName}-${emphasisName}-fg`] = resolveTokenValue(
+            theme,
+            surface.fg
+          );
+        }
+      }
+    }
+  }
+
   const divider = theme.components.divider;
   if (divider?.defaultSpacing) {
     vars["--luna-divider-spacing-default"] =

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,10 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
+    exclude: ["playwright/**"],
     passWithNoTests: true
   }
 });


### PR DESCRIPTION
Closes #19

## Summary
Implemented `LunaToast` as a new primitive with a small, issue-scoped contract: alert-aligned `tone` and `emphasis`, controlled or uncontrolled visibility, optional auto-dismiss, hover pause, dismiss button support, placement, and theme-aware spacing. The core component lives in [LunaToast.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-toast/LunaToast.tsx), with styles in [LunaToast.css](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-toast/LunaToast.css), public props in [LunaToast.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-toast/LunaToast.props.ts), exports in [index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts), and theme support added in [types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts), [base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts), and [vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts).

Storybook, docs, and release metadata were added in [LunaToast.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-toast/LunaToast.stories.tsx), [LunaToast.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaToast.md), [LunaToast.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaToast.md), and [.changeset/luna-toast-primitive.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-toast-primitive.md). I also updated [ROADMAP.md](/Users/jordanb/Documents/workspace/react-luna/docs/ROADMAP.md) so `LunaToast` now reflects implemented status.

Verification ran cleanly:
- `npm test` -> 24 test files passed, 172 tests passed
- `npm run build` -> succeeded

One workflow note: repository docs still have an existing tracking-model drift between [WORKFLOW.md](/Users/jordanb/Documents/workspace/react-luna/WORKFLOW.md) and [CHANGE_MANAGEMENT.md](/Users/jordanb/Documents/workspace/react-luna/CHANGE_MANAGEMENT.md). I did not expand scope into that. I also could not create the requested commit because the sandbox denied Git from creating `.git/index.lock`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`