### PR TITLE
Resolve #20: Build LunaModal composite

### DIFF
--- a/.changeset/issue-20-luna-modal.md
+++ b/.changeset/issue-20-luna-modal.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaModal` composite with theme support, Storybook coverage, tests, and public documentation.

--- a/docs/v1/components/LunaModal.md
+++ b/docs/v1/components/LunaModal.md
@@ -1,0 +1,73 @@
+# LunaModal
+
+`LunaModal` is the focused overlay composite for interrupting the current workflow with one bounded dialog surface.
+
+It owns:
+- one modal shell with backdrop
+- controlled and uncontrolled visibility
+- optional dismiss affordances
+- title, description, body, and actions regions
+- theme-aware size and spacing
+
+It does not own:
+- stacking or queue management
+- portal orchestration
+- route-aware workflows
+- application-specific form or confirmation logic
+
+## Props
+
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `actions?: React.ReactNode`
+- `open?: boolean`
+- `defaultOpen?: boolean`
+- `onOpenChange?: (open: boolean, reason: "dismiss" | "backdrop" | "escape") => void`
+- `dismissible?: boolean`
+- `dismissLabel?: string`
+- `closeOnEscape?: boolean`
+- `closeOnBackdrop?: boolean`
+- `inset?: string`
+- `padding?: string`
+- `gap?: string`
+- `size?: "small" | "medium" | "large" | "full" | string`
+- `rounded?: boolean`
+
+Native `HTMLAttributes<HTMLDivElement>` continue to pass through to the dialog panel, including `role`, `aria-labelledby`, `aria-describedby`, `className`, and `style`.
+
+## Contract
+
+- the modal renders nothing when closed
+- the inner panel defaults to `role="dialog"` and `aria-modal={true}`
+- `title` labels the dialog when `aria-labelledby` is not provided manually
+- `description` and `children` provide the described content region
+- `actions` renders a footer row aligned to the end
+- `open` makes the modal controlled
+- `defaultOpen` seeds uncontrolled visibility and defaults to `false`
+- dismiss button, backdrop click, and `Escape` each report a distinct close reason
+- `closeOnBackdrop={false}` and `closeOnEscape={false}` disable those local dismiss paths
+- the modal traps page scroll while open and restores the previous body overflow when it closes
+
+## Theme Integration
+
+`LunaModal` consumes the existing theme system for:
+- default size
+- default padding
+- default gap
+- default inset
+- radius
+- per-size max widths
+- surface background
+- foreground
+- border
+- backdrop color
+- shadow
+
+Spacing overrides resolve through theme spacing first, then raw CSS values.
+
+## Accessibility Notes
+
+- use a clear `title` for the dialog name unless a custom `aria-labelledby` is provided
+- keep `description` concise when the body already contains rich content
+- leave `dismissible` enabled for most confirmation and review flows unless the dialog must stay pinned until another action resolves it
+- focus moves into the modal when it opens and returns to the prior focused element when it closes

--- a/docs/v1/design/LunaModal.md
+++ b/docs/v1/design/LunaModal.md
@@ -1,0 +1,76 @@
+# LunaModal
+
+## Purpose
+
+`LunaModal` provides one bounded overlay surface for focused review, confirmation, and interruption states where inline content is not strong enough.
+
+It should give `react-luna` one durable modal shell without turning this first composite into a full overlay framework.
+
+## Design Rules
+
+- keep the contract small and explicit
+- keep title, description, body, and actions as the only built-in regions
+- support controlled and uncontrolled visibility
+- keep dismiss behavior reason-aware so downstream state can react cleanly
+- preserve themeability for shell size, spacing, surface, backdrop, and shadow
+- avoid portal and stacking abstractions in V1
+
+## Scope Boundaries
+
+`LunaModal` should own:
+- one modal backdrop
+- one dialog panel
+- local close affordances
+- scroll-safe body content inside the shell
+- focus entry and focus return
+
+`LunaModal` should not own:
+- nested modal orchestration
+- app-wide overlay management
+- route interception
+- form submission policies
+
+## Contract Shape
+
+The public inputs should stay slot-like:
+- `title`
+- `description`
+- `children`
+- `actions`
+
+Behavior should remain explicit through:
+- `open`
+- `defaultOpen`
+- `onOpenChange`
+- `dismissible`
+- `closeOnBackdrop`
+- `closeOnEscape`
+
+That keeps the modal composable without introducing a deep subcomponent family immediately.
+
+## Theme Expectations
+
+The modal theme slice should remain responsible for:
+- default size
+- default padding
+- default gap
+- default inset
+- radius
+- size max widths
+- light and dark surface colors
+- light and dark foreground colors
+- light and dark border colors
+- light and dark backdrop colors
+- shadow
+
+This keeps downstream customization at the shell level instead of forcing consumers to override one-off selectors.
+
+## Testing Focus
+
+When implemented, tests should cover:
+- default dialog semantics
+- controlled and uncontrolled visibility
+- dismiss reasons
+- disabled dismiss paths
+- focus handoff on open and close
+- theme token resolution for spacing and size

--- a/playwright/storybook/manifests/luna-modal.json
+++ b/playwright/storybook/manifests/luna-modal.json
@@ -1,0 +1,32 @@
+[
+  {
+    "storyId": "components-lunamodal--playground",
+    "fileName": "luna-modal-playground",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunamodal--controlled-visibility",
+    "fileName": "luna-modal-controlled-visibility",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamodal--small",
+    "fileName": "luna-modal-small",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamodal--large",
+    "fileName": "luna-modal-large",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamodal--full",
+    "fileName": "luna-modal-full",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamodal--long-body-content",
+    "fileName": "luna-modal-long-body-content",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ export * from "./luna-slider";
 export * from "./luna-textarea";
 export * from "./luna-select";
 export * from "./luna-multiselect";
+export * from "./luna-modal";
 export * from "./luna-notification";
 export * from "./luna-autocomplete";
 export * from "./luna-skeleton";

--- a/src/components/luna-modal/LunaModal.css
+++ b/src/components/luna-modal/LunaModal.css
@@ -1,0 +1,152 @@
+.luna-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+}
+
+.luna-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--luna-modal-backdrop, rgb(15 23 42 / 0.58));
+}
+
+.luna-modal__viewport {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 100dvh;
+  padding: var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4)));
+}
+
+.luna-modal__panel {
+  width: min(
+    calc(100vw - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2)),
+    var(--luna-modal-size-medium-max-width, 36rem)
+  );
+  max-height: calc(100dvh - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: var(--luna-modal-gap, var(--luna-modal-gap-default, var(--luna-space-4)));
+  padding: var(--luna-modal-padding, var(--luna-modal-padding-default, var(--luna-space-5)));
+  border: 1px solid var(--luna-modal-border, var(--luna-border));
+  border-radius: var(--luna-modal-radius, var(--luna-radius-lg));
+  background: var(--luna-modal-bg, var(--luna-surface));
+  color: var(--luna-modal-fg, var(--luna-foreground));
+  box-shadow: var(--luna-modal-shadow, var(--luna-shadow-lg));
+  overflow: hidden;
+}
+
+.luna-modal__panel--rounded {
+  border-radius: calc(var(--luna-modal-radius, var(--luna-radius-lg)) * 1.35);
+}
+
+.luna-modal__panel[data-size="small"] {
+  width: min(
+    calc(100vw - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2)),
+    var(--luna-modal-size-small-max-width, 28rem)
+  );
+}
+
+.luna-modal__panel[data-size="large"] {
+  width: min(
+    calc(100vw - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2)),
+    var(--luna-modal-size-large-max-width, 48rem)
+  );
+}
+
+.luna-modal__panel[data-size="full"] {
+  width: calc(100vw - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2));
+  height: calc(100dvh - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2));
+  max-width: none;
+}
+
+.luna-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--luna-modal-gap, var(--luna-modal-gap-default, var(--luna-space-4)));
+}
+
+.luna-modal__header-copy {
+  display: grid;
+  gap: calc(var(--luna-modal-gap, var(--luna-modal-gap-default, var(--luna-space-4))) * 0.35);
+  min-width: 0;
+}
+
+.luna-modal__title {
+  margin: 0;
+  font-size: var(--luna-text-variant-title-font-size, 1.25rem);
+  font-weight: var(--luna-text-variant-title-font-weight, 600);
+  line-height: var(--luna-text-variant-title-line-height, 1.1);
+}
+
+.luna-modal__description,
+.luna-modal__body,
+.luna-modal__actions {
+  margin: 0;
+  font-size: var(--luna-text-variant-body-font-size, 1rem);
+  line-height: var(--luna-text-variant-body-line-height, 1.6);
+}
+
+.luna-modal__description {
+  color: color-mix(in srgb, var(--luna-modal-fg, var(--luna-foreground)) 74%, transparent);
+}
+
+.luna-modal__body {
+  min-height: 0;
+  overflow: auto;
+}
+
+.luna-modal__body > :first-child,
+.luna-modal__actions > :first-child {
+  margin-top: 0;
+}
+
+.luna-modal__body > :last-child,
+.luna-modal__actions > :last-child {
+  margin-bottom: 0;
+}
+
+.luna-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: calc(var(--luna-modal-gap, var(--luna-modal-gap-default, var(--luna-space-4))) * 0.5);
+}
+
+.luna-modal__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--luna-radius-pill);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.luna-modal__dismiss:hover {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.luna-modal__dismiss:focus-visible,
+.luna-modal__panel:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .luna-modal__viewport {
+    place-items: end center;
+  }
+
+  .luna-modal__panel,
+  .luna-modal__panel[data-size="small"],
+  .luna-modal__panel[data-size="large"] {
+    width: calc(100vw - (var(--luna-modal-inset, var(--luna-modal-inset-default, var(--luna-space-4))) * 2));
+  }
+}

--- a/src/components/luna-modal/LunaModal.props.ts
+++ b/src/components/luna-modal/LunaModal.props.ts
@@ -1,0 +1,22 @@
+import type React from "react";
+
+export type LunaModalDismissReason = "dismiss" | "backdrop" | "escape";
+export type LunaModalSize = "small" | "medium" | "large" | "full";
+
+export type LunaModalProps = Omit<React.HTMLAttributes<HTMLDivElement>, "title"> & {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean, reason: LunaModalDismissReason) => void;
+  dismissible?: boolean;
+  dismissLabel?: string;
+  closeOnEscape?: boolean;
+  closeOnBackdrop?: boolean;
+  inset?: string;
+  padding?: string;
+  gap?: string;
+  size?: LunaModalSize | string;
+  rounded?: boolean;
+};

--- a/src/components/luna-modal/LunaModal.stories.tsx
+++ b/src/components/luna-modal/LunaModal.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaButton } from "../luna-button";
+import { LunaModal } from "./LunaModal";
+
+const meta = {
+  title: "Components/LunaModal",
+  component: LunaModal,
+  parameters: {
+    layout: "fullscreen"
+  },
+  args: {
+    open: true,
+    title: "Confirm launch window",
+    description: "Review the final checklist before promoting this mission to the live manifest.",
+    children:
+      "This modal stays focused on one composite surface. It does not own stacking, portal orchestration, or route-level workflows.",
+    actions: (
+      <>
+        <LunaButton flat>Cancel</LunaButton>
+        <LunaButton>Confirm</LunaButton>
+      </>
+    )
+  }
+} satisfies Meta<typeof LunaModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Small: Story = {
+  args: {
+    size: "small",
+    title: "Small dialog",
+    description: "Use the small shell for terse confirmations and compact reviews."
+  }
+};
+
+export const Large: Story = {
+  args: {
+    size: "large",
+    title: "Large dialog",
+    description: "Use the large shell when the body needs more reading room."
+  }
+};
+
+export const Full: Story = {
+  args: {
+    size: "full",
+    title: "Full dialog",
+    description: "The full shell keeps the same contract while expanding to the viewport inset."
+  }
+};
+
+export const LongBodyContent: Story = {
+  render: () => (
+    <LunaModal
+      open
+      size="large"
+      title="Manifest review"
+      description="Long content should scroll inside the modal body instead of pushing the shell off-screen."
+      actions={
+        <>
+          <LunaButton flat>Dismiss</LunaButton>
+          <LunaButton>Save changes</LunaButton>
+        </>
+      }
+    >
+      <div style={{ display: "grid", gap: "1rem" }}>
+        {Array.from({ length: 8 }, (_, index) => (
+          <p key={index}>
+            Segment {index + 1}. Orbital telemetry remains stable and the downstream application can still replace the modal theme without rewriting the structure.
+          </p>
+        ))}
+      </div>
+    </LunaModal>
+  )
+};
+
+export const ControlledVisibility: Story = {
+  render: () => {
+    function ControlledModalStory() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <div style={{ minHeight: "100dvh", padding: "2rem" }}>
+          <LunaButton onClick={() => setOpen(true)}>Open modal</LunaButton>
+          <LunaModal
+            open={open}
+            title="Controlled state"
+            description="This story shows controlled visibility with reason-aware dismiss callbacks."
+            onOpenChange={(nextOpen) => setOpen(nextOpen)}
+            actions={
+              <>
+                <LunaButton flat onClick={() => setOpen(false)}>
+                  Close
+                </LunaButton>
+                <LunaButton onClick={() => setOpen(false)}>Apply</LunaButton>
+              </>
+            }
+          >
+            The parent decides whether to keep the modal open.
+          </LunaModal>
+        </div>
+      );
+    }
+
+    return <ControlledModalStory />;
+  }
+};

--- a/src/components/luna-modal/LunaModal.test.tsx
+++ b/src/components/luna-modal/LunaModal.test.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaModal } from "./LunaModal";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaModal", () => {
+  it("renders the default modal contract with dialog semantics", () => {
+    renderWithTheme(
+      <LunaModal open title="Mission review" description="Review before launch.">
+        Confirm the latest checklist.
+      </LunaModal>
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Mission review" });
+
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("data-size", "medium");
+    expect(screen.getByText("Review before launch.")).toBeInTheDocument();
+    expect(screen.getByText("Confirm the latest checklist.")).toBeInTheDocument();
+  });
+
+  it("supports dismiss button, backdrop, and escape close reasons", () => {
+    const onOpenChange = vi.fn();
+    const { rerender, container } = renderWithTheme(
+      <LunaModal open title="Close me" onOpenChange={onOpenChange}>
+        Body
+      </LunaModal>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false, "dismiss");
+
+    rerender(
+      <ThemeProvider>
+        <LunaModal open title="Close me" onOpenChange={onOpenChange}>
+          Body
+        </LunaModal>
+      </ThemeProvider>
+    );
+
+    fireEvent.click(container.querySelector(".luna-modal__backdrop") as Element);
+    expect(onOpenChange).toHaveBeenCalledWith(false, "backdrop");
+
+    rerender(
+      <ThemeProvider>
+        <LunaModal open title="Close me" onOpenChange={onOpenChange}>
+          Body
+        </LunaModal>
+      </ThemeProvider>
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false, "escape");
+  });
+
+  it("keeps the modal open when backdrop and escape dismissal are disabled", () => {
+    const onOpenChange = vi.fn();
+    const { container } = renderWithTheme(
+      <LunaModal
+        open
+        title="Pinned"
+        onOpenChange={onOpenChange}
+        closeOnBackdrop={false}
+        closeOnEscape={false}
+      >
+        Body
+      </LunaModal>
+    );
+
+    fireEvent.click(container.querySelector(".luna-modal__backdrop") as Element);
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("supports uncontrolled visibility", () => {
+    renderWithTheme(
+      <LunaModal defaultOpen title="Uncontrolled">
+        Body
+      </LunaModal>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("focuses the dialog and restores the previous trigger focus when it closes", async () => {
+    function Example() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open modal
+          </button>
+          <LunaModal open={open} title="Focus test" onOpenChange={(nextOpen) => setOpen(nextOpen)}>
+            Body
+          </LunaModal>
+        </>
+      );
+    }
+
+    renderWithTheme(<Example />);
+
+    const trigger = screen.getByRole("button", { name: "Open modal" });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Focus test" });
+    const dismissButton = screen.getByRole("button", { name: "Close dialog" });
+    await vi.waitFor(() => {
+      expect(dismissButton).toHaveFocus();
+    });
+
+    fireEvent.click(dismissButton);
+
+    await vi.waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("resolves modal theme tokens and spacing overrides through the theme system", () => {
+    const { container } = renderWithTheme(
+      <LunaModal open title="Theme override" size="large" padding="6" gap="2" inset="8">
+        Custom theme.
+      </LunaModal>,
+      {
+        theme: {
+          components: {
+            modal: {
+              defaultSize: "large",
+              radius: "pill",
+              sizes: {
+                large: {
+                  maxWidth: "52rem"
+                }
+              },
+              modes: {
+                light: {
+                  border: "accent.500"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+    const dialog = screen.getByRole("dialog");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-modal-size-default": "large",
+      "--luna-modal-radius": "999px",
+      "--luna-modal-size-large-max-width": "52rem",
+      "--luna-modal-border": "#8b5cf6"
+    });
+    expect(dialog).toHaveAttribute("data-size", "large");
+    expect(dialog).toHaveStyle({
+      "--luna-modal-padding": "1.5rem",
+      "--luna-modal-gap": "0.5rem",
+      "--luna-modal-inset": "2rem"
+    });
+  });
+});

--- a/src/components/luna-modal/LunaModal.tsx
+++ b/src/components/luna-modal/LunaModal.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaModalDismissReason, LunaModalProps } from "./LunaModal.props";
+import "./LunaModal.css";
+
+type ModalCssVariable =
+  | "--luna-modal-padding"
+  | "--luna-modal-gap"
+  | "--luna-modal-inset";
+
+type LunaModalStyle = React.CSSProperties &
+  Partial<Record<ModalCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true");
+}
+
+export const LunaModal = React.forwardRef<HTMLDivElement, LunaModalProps>(function LunaModal(
+  {
+    actions,
+    children,
+    className,
+    closeOnBackdrop = true,
+    closeOnEscape = true,
+    defaultOpen = false,
+    description,
+    dismissible = true,
+    dismissLabel = "Close dialog",
+    gap,
+    inset,
+    onOpenChange,
+    open,
+    padding,
+    rounded,
+    size,
+    style,
+    title,
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const reactId = React.useId();
+  const baseId = reactId.replace(/:/g, "");
+  const titleId = title ? `luna-modal-title-${baseId}` : undefined;
+  const descriptionTextId = description ? `luna-modal-description-text-${baseId}` : undefined;
+  const bodyId = children !== undefined && children !== null ? `luna-modal-body-${baseId}` : undefined;
+  const describedBy =
+    props["aria-describedby"] ??
+    ([descriptionTextId, bodyId].filter(Boolean).join(" ") || undefined);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = React.useRef<HTMLElement | null>(null);
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const resolvedSize = size ?? theme.components.modal?.defaultSize ?? "medium";
+  const resolvedPadding = resolveSpacingValue(padding, theme);
+  const resolvedGap = resolveSpacingValue(gap, theme);
+  const resolvedInset = resolveSpacingValue(inset, theme);
+  const resolvedStyle: LunaModalStyle = {
+    ...(resolvedPadding ? { ["--luna-modal-padding" as const]: resolvedPadding } : {}),
+    ...(resolvedGap ? { ["--luna-modal-gap" as const]: resolvedGap } : {}),
+    ...(resolvedInset ? { ["--luna-modal-inset" as const]: resolvedInset } : {}),
+    ...style
+  };
+
+  React.useImperativeHandle(ref, () => panelRef.current as HTMLDivElement, []);
+
+  const closeModal = React.useCallback(
+    (reason: LunaModalDismissReason) => {
+      if (!isControlled) {
+        setInternalOpen(false);
+      }
+
+      onOpenChange?.(false, reason);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+
+    const frameId = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) {
+        return;
+      }
+
+      const [firstFocusable] = getFocusableElements(panel);
+      (firstFocusable ?? panel).focus();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      body.style.overflow = previousOverflow;
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="luna-modal" data-open="true">
+      <div
+        aria-hidden="true"
+        className="luna-modal__backdrop"
+        onClick={() => {
+          if (closeOnBackdrop) {
+            closeModal("backdrop");
+          }
+        }}
+      />
+      <div className="luna-modal__viewport">
+        <div
+          {...props}
+          ref={panelRef}
+          className={toClassName([
+            "luna-modal__panel",
+            rounded && "luna-modal__panel--rounded",
+            className
+          ])}
+          data-size={resolvedSize}
+          role={props.role ?? "dialog"}
+          aria-modal={props["aria-modal"] ?? true}
+          aria-labelledby={props["aria-labelledby"] ?? titleId}
+          aria-describedby={describedBy}
+          tabIndex={props.tabIndex ?? -1}
+          style={resolvedStyle}
+          onKeyDown={(event) => {
+            props.onKeyDown?.(event);
+
+            if (!event.defaultPrevented && event.key === "Escape" && closeOnEscape) {
+              event.stopPropagation();
+              closeModal("escape");
+            }
+          }}
+        >
+          {(title || description || dismissible) ? (
+            <div className="luna-modal__header">
+              <div className="luna-modal__header-copy">
+                {title ? (
+                  <div className="luna-modal__title" id={titleId}>
+                    {title}
+                  </div>
+                ) : null}
+                {description ? (
+                  <div className="luna-modal__description" id={descriptionTextId}>
+                    {description}
+                  </div>
+                ) : null}
+              </div>
+              {dismissible ? (
+                <button
+                  type="button"
+                  className="luna-modal__dismiss"
+                  aria-label={dismissLabel}
+                  onClick={() => {
+                    closeModal("dismiss");
+                  }}
+                >
+                  <span aria-hidden="true">x</span>
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {children !== undefined && children !== null ? (
+            <div className="luna-modal__body" id={bodyId}>
+              {children}
+            </div>
+          ) : null}
+          {actions ? <div className="luna-modal__actions">{actions}</div> : null}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/luna-modal/index.ts
+++ b/src/components/luna-modal/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaModal";
+export * from "./LunaModal.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -72,4 +72,12 @@ describe("theme size contract", () => {
     expect(drawer?.defaultInset).toBe("4");
     expect(drawer?.defaultSize).toBe("28rem");
   });
+
+  it("defines modal defaults and supported size tiers", () => {
+    const modal = lunarTheme.components.modal;
+
+    expect(modal?.defaultSize).toBe("medium");
+    expect(modal?.defaultPadding).toBe("5");
+    expect(Object.keys(modal?.sizes ?? {})).toEqual(["small", "medium", "large", "full"]);
+  });
 });

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1310,6 +1310,43 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    modal: {
+      defaultSize: "medium",
+      defaultPadding: "5",
+      defaultGap: "4",
+      defaultInset: "4",
+      radius: "lg",
+      sizes: {
+        small: {
+          maxWidth: "28rem"
+        },
+        medium: {
+          maxWidth: "36rem"
+        },
+        large: {
+          maxWidth: "48rem"
+        },
+        full: {
+          maxWidth: "100%"
+        }
+      },
+      modes: {
+        light: {
+          bg: "neutral.50",
+          fg: "neutral.900",
+          border: "neutral.200",
+          backdrop: "rgb(15 23 42 / 0.58)",
+          shadow: "lg"
+        },
+        dark: {
+          bg: "neutral.800",
+          fg: "neutral.50",
+          border: "neutral.600",
+          backdrop: "rgb(2 6 23 / 0.74)",
+          shadow: "lg"
+        }
+      }
+    },
     divider: {
       defaultSpacing: "4",
       defaultInset: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -303,6 +303,18 @@ export type ThemeDrawerModeTokens = {
   backdrop?: string;
 };
 
+export type ThemeModalSizeProfile = {
+  maxWidth?: string;
+};
+
+export type ThemeModalModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  backdrop?: string;
+  shadow?: string;
+};
+
 export type ThemeComponents = {
   button?: {
     defaultSize?: string;
@@ -414,6 +426,16 @@ export type ThemeComponents = {
     radius?: string;
     shadow?: string;
     modes?: Partial<Record<ThemeMode, ThemeDrawerModeTokens>>;
+  };
+
+  modal?: {
+    defaultSize?: string;
+    defaultPadding?: string;
+    defaultGap?: string;
+    defaultInset?: string;
+    radius?: string;
+    sizes?: Record<string, ThemeModalSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemeModalModeTokens>>;
   };
   divider?: {
     defaultSpacing?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -541,6 +541,56 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     vars["--luna-drawer-backdrop"] = resolveTokenValue(theme, drawerMode.backdrop);
   }
 
+  const modal = theme.components.modal;
+  if (modal?.defaultSize) {
+    vars["--luna-modal-size-default"] = modal.defaultSize;
+  }
+  if (modal?.defaultPadding) {
+    vars["--luna-modal-padding-default"] =
+      resolveScaleValue(theme.spacing, modal.defaultPadding) ?? modal.defaultPadding;
+  }
+  if (modal?.defaultGap) {
+    vars["--luna-modal-gap-default"] =
+      resolveScaleValue(theme.spacing, modal.defaultGap) ?? modal.defaultGap;
+  }
+  if (modal?.defaultInset) {
+    vars["--luna-modal-inset-default"] =
+      resolveScaleValue(theme.spacing, modal.defaultInset) ?? modal.defaultInset;
+  }
+  if (modal?.radius) {
+    vars["--luna-modal-radius"] = resolveScaleValue(theme.radii, modal.radius) ?? modal.radius;
+  }
+  if (modal?.sizes) {
+    for (const [sizeName, profile] of Object.entries(modal.sizes)) {
+      if (!profile) {
+        continue;
+      }
+
+      if (profile.maxWidth) {
+        vars[`--luna-modal-size-${sizeName}-max-width`] =
+          resolveScaleValue(theme.spacing, profile.maxWidth) ?? profile.maxWidth;
+      }
+    }
+  }
+  const modalMode = modal?.modes?.[mode];
+  if (modalMode?.bg) {
+    vars["--luna-modal-bg"] = resolveTokenValue(theme, modalMode.bg);
+  }
+  if (modalMode?.fg) {
+    vars["--luna-modal-fg"] = resolveTokenValue(theme, modalMode.fg);
+  }
+  if (modalMode?.border) {
+    vars["--luna-modal-border"] = resolveTokenValue(theme, modalMode.border);
+  }
+  if (modalMode?.backdrop) {
+    vars["--luna-modal-backdrop"] = resolveTokenValue(theme, modalMode.backdrop);
+  }
+  if (modalMode?.shadow) {
+    vars["--luna-modal-shadow"] =
+      resolveScaleValue(theme.shadows, modalMode.shadow) ??
+      resolveTokenValue(theme, modalMode.shadow);
+  }
+
   const divider = theme.components.divider;
   if (divider?.defaultSpacing) {
     vars["--luna-divider-spacing-default"] =


### PR DESCRIPTION
storybook-component: luna-modal

Closes #20

## Summary
Implemented `LunaModal` as a scoped composite for issue #20, with theme support, public exports, docs, Storybook, tests, and a changeset. The core contract lives in [src/components/luna-modal/LunaModal.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-modal/LunaModal.tsx), the public component doc is [docs/v1/components/LunaModal.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaModal.md), and Storybook coverage is in [src/components/luna-modal/LunaModal.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-modal/LunaModal.stories.tsx).

Scope stayed tight to this issue. The modal supports controlled and uncontrolled open state, dismiss reasons for button/backdrop/escape, focus entry and return, body scroll containment, theme-driven size and shell tokens, and no overlay manager or portal abstraction.

Verification ran and passed:
- `npm test -- src/components/luna-modal/LunaModal.test.tsx src/theme/base.test.ts`
- `npm run build`
- `npm run storybook:build`

Note: I could not create the requested git commit in this environment because writing `.git/index.lock` is blocked by the sandbox, so the code changes are present locally but not committed.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`