### PR TITLE
Resolve #21: Build LunaDrawer composite

### DIFF
--- a/.changeset/luna-drawer.md
+++ b/.changeset/luna-drawer.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaDrawer` composite with theme support, Storybook stories, tests, and docs.

--- a/docs/v1/components/LunaDrawer.md
+++ b/docs/v1/components/LunaDrawer.md
@@ -1,0 +1,75 @@
+# LunaDrawer
+
+`LunaDrawer` is the edge-anchored overlay surface for contextual workflows that should stay near the current page state.
+
+It owns:
+- one drawer panel and its optional backdrop
+- controlled and uncontrolled visibility
+- edge placement and theme-aware sizing
+- optional title, description, footer, and dismiss affordance
+- local dismissal through overlay click or Escape
+
+It does not own:
+- focus trapping
+- portals
+- routing
+- nested drawer orchestration
+- multi-step workflow state
+
+## Props
+
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `footer?: React.ReactNode`
+- `open?: boolean`
+- `defaultOpen?: boolean`
+- `onOpenChange?: (open: boolean, reason: "dismiss" | "overlay" | "escape") => void`
+- `placement?: "left" | "right" | "top" | "bottom"`
+- `size?: string`
+- `inset?: string`
+- `padding?: string`
+- `gap?: string`
+- `rounded?: boolean`
+- `dismissible?: boolean`
+- `dismissLabel?: string`
+- `closeOnOverlayClick?: boolean`
+- `closeOnEscape?: boolean`
+- `showOverlay?: boolean`
+
+Native `HTMLAttributes<HTMLDivElement>` continue to pass through to the outer shell. Use `aria-label`, `aria-labelledby`, `aria-describedby`, and `role` when a different dialog announcement rule is needed.
+
+## Contract
+
+- default root shell is `div`
+- default panel semantics are `role="dialog"` and `aria-modal={true}` when the backdrop is visible
+- `open` makes the component controlled
+- `defaultOpen` seeds uncontrolled visibility and defaults to `false`
+- `onOpenChange` reports local close events with `"dismiss"`, `"overlay"`, or `"escape"`
+- `title` and `description` wire the default dialog labeling when explicit aria attributes are not provided
+- `footer` renders a dedicated action region below the body content
+- `size` applies width for left and right drawers, and height for top and bottom drawers
+- `showOverlay={false}` keeps the drawer inline to its story or container while preserving placement behavior
+- `className` and `style` pass through to the outer shell
+
+## Theme Integration
+
+`LunaDrawer` consumes the existing theme system for:
+- default padding
+- default gap
+- default inset
+- default size
+- default placement
+- radius
+- shadow
+- light and dark panel and backdrop tokens
+
+Spacing overrides resolve through theme spacing first, then raw CSS values.
+
+## Accessibility Notes
+
+`LunaDrawer` exposes dialog semantics, but it does not trap focus or move focus on open.
+
+Consumers remain responsible for:
+- moving focus into the drawer when their workflow needs it
+- restoring focus after close
+- deciding whether the drawer should behave as a modal or a non-modal side panel

--- a/docs/v1/design/LunaDrawer.md
+++ b/docs/v1/design/LunaDrawer.md
@@ -1,0 +1,40 @@
+# LunaDrawer
+
+## Purpose
+
+`LunaDrawer` provides an edge-anchored overlay panel for contextual tasks that should stay connected to the current screen instead of replacing it.
+
+It is the right surface for inspect panels, side settings, and compact workflows that need more room than a tooltip or toast but less context switching than a full page.
+
+## Design Rules
+
+- keep the contract narrower than a full modal framework
+- support controlled and uncontrolled visibility
+- keep sizing, spacing, and placement theme-driven
+- treat backdrop and dismissal behaviors as explicit controls
+- allow applications to add focus management above the component instead of forcing one strategy
+
+## Distinction From Other Overlays
+
+The intended split is:
+
+- `LunaTooltip` handles lightweight anchored explanation
+- `LunaToast` handles transient feedback
+- `LunaDrawer` handles contextual workflow surfaces that slide in from an edge
+- `LunaModal` can take the fully interruptive centered-dialog role later
+
+That keeps `LunaDrawer` focused on one edge surface instead of turning it into a universal overlay abstraction.
+
+## Theme Expectations
+
+The drawer theme slice should remain responsible for:
+- default padding
+- default gap
+- default inset
+- default size
+- default placement
+- radius
+- shadow
+- light and dark panel and backdrop tokens
+
+If future work adds focus trapping, portals, or multi-drawer coordination, that should build on top of this composite instead of inflating the base contract.

--- a/playwright/storybook/manifests/luna-drawer.json
+++ b/playwright/storybook/manifests/luna-drawer.json
@@ -1,0 +1,17 @@
+[
+  {
+    "storyId": "components-lunadrawer--playground",
+    "fileName": "luna-drawer-playground",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunadrawer--controlled-visibility",
+    "fileName": "luna-drawer-controlled-visibility",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunadrawer--placement-matrix",
+    "fileName": "luna-drawer-placement-matrix",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./luna-date-input";
 export * from "./luna-date-picker";
 export * from "./luna-radio";
 export * from "./luna-divider";
+export * from "./luna-drawer";
 export * from "./luna-empty-state";
 export * from "./luna-header";
 export * from "./luna-hover-text";

--- a/src/components/luna-drawer/LunaDrawer.css
+++ b/src/components/luna-drawer/LunaDrawer.css
@@ -1,0 +1,149 @@
+.luna-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  padding: var(--luna-drawer-inset, var(--luna-drawer-inset-default, var(--luna-space-4)));
+  pointer-events: none;
+}
+
+.luna-drawer[data-overlay="false"] {
+  position: absolute;
+}
+
+.luna-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--luna-drawer-backdrop, rgba(15, 23, 42, 0.52));
+  pointer-events: auto;
+}
+
+.luna-drawer__panel {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: var(--luna-drawer-gap, var(--luna-drawer-gap-default, var(--luna-space-4)));
+  width: min(var(--luna-drawer-size, var(--luna-drawer-size-default, 28rem)), 100%);
+  max-width: calc(
+    100vw - (var(--luna-drawer-inset, var(--luna-drawer-inset-default, var(--luna-space-4))) * 2)
+  );
+  max-height: calc(
+    100vh - (var(--luna-drawer-inset, var(--luna-drawer-inset-default, var(--luna-space-4))) * 2)
+  );
+  padding: var(--luna-drawer-padding, var(--luna-drawer-padding-default, var(--luna-space-5)));
+  border: 1px solid var(--luna-drawer-border, var(--luna-border));
+  border-radius: var(--luna-drawer-radius, var(--luna-radius-lg));
+  background: var(--luna-drawer-bg, var(--luna-surface));
+  color: var(--luna-drawer-fg, var(--luna-foreground));
+  box-shadow: var(--luna-drawer-shadow, var(--luna-shadow-lg));
+  overflow: auto;
+  pointer-events: auto;
+}
+
+.luna-drawer--rounded .luna-drawer__panel {
+  border-radius: calc(var(--luna-drawer-radius, var(--luna-radius-lg)) * 1.25);
+}
+
+.luna-drawer__header,
+.luna-drawer__footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: calc(var(--luna-drawer-gap, var(--luna-drawer-gap-default, var(--luna-space-4))) * 0.75);
+}
+
+.luna-drawer__heading,
+.luna-drawer__content {
+  display: grid;
+  gap: calc(var(--luna-drawer-gap, var(--luna-drawer-gap-default, var(--luna-space-4))) * 0.5);
+  min-width: 0;
+}
+
+.luna-drawer__content {
+  align-content: start;
+}
+
+.luna-drawer__title {
+  font-size: var(--luna-text-variant-title-font-size, 1.25rem);
+  font-weight: var(--luna-text-variant-title-font-weight, 600);
+  line-height: var(--luna-text-variant-title-line-height, 1.1);
+}
+
+.luna-drawer__description,
+.luna-drawer__footer {
+  color: var(--luna-muted);
+}
+
+.luna-drawer__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--luna-drawer-border, var(--luna-border));
+  border-radius: var(--luna-radius-pill);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.luna-drawer__dismiss:hover {
+  background: color-mix(
+    in srgb,
+    var(--luna-drawer-bg, var(--luna-surface)) 88%,
+    var(--luna-foreground) 12%
+  );
+}
+
+.luna-drawer__dismiss:focus-visible {
+  outline: 2px solid var(--luna-color-primary-500);
+  outline-offset: 2px;
+}
+
+.luna-drawer[data-placement="left"] {
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+.luna-drawer[data-placement="right"] {
+  justify-content: flex-end;
+  align-items: stretch;
+}
+
+.luna-drawer[data-placement="top"] {
+  justify-content: stretch;
+  align-items: flex-start;
+}
+
+.luna-drawer[data-placement="bottom"] {
+  justify-content: stretch;
+  align-items: flex-end;
+}
+
+.luna-drawer[data-placement="left"] .luna-drawer__panel,
+.luna-drawer[data-placement="right"] .luna-drawer__panel {
+  height: 100%;
+}
+
+.luna-drawer[data-placement="top"] .luna-drawer__panel,
+.luna-drawer[data-placement="bottom"] .luna-drawer__panel {
+  width: 100%;
+  height: min(var(--luna-drawer-size, var(--luna-drawer-size-default, 28rem)), 100%);
+}
+
+@media (max-width: 768px) {
+  .luna-drawer {
+    padding: var(--luna-drawer-inset, var(--luna-drawer-inset-default, var(--luna-space-2)));
+  }
+
+  .luna-drawer[data-placement="left"] .luna-drawer__panel,
+  .luna-drawer[data-placement="right"] .luna-drawer__panel {
+    width: min(
+      var(--luna-drawer-size, var(--luna-drawer-size-default, 28rem)),
+      calc(
+        100vw - (var(--luna-drawer-inset, var(--luna-drawer-inset-default, var(--luna-space-2))) * 2)
+      )
+    );
+  }
+}

--- a/src/components/luna-drawer/LunaDrawer.props.ts
+++ b/src/components/luna-drawer/LunaDrawer.props.ts
@@ -1,0 +1,24 @@
+import type React from "react";
+
+export type LunaDrawerPlacement = "left" | "right" | "top" | "bottom";
+export type LunaDrawerDismissReason = "dismiss" | "overlay" | "escape";
+
+export type LunaDrawerProps = Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "color"> & {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  footer?: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean, reason: LunaDrawerDismissReason) => void;
+  placement?: LunaDrawerPlacement;
+  size?: string;
+  inset?: string;
+  padding?: string;
+  gap?: string;
+  rounded?: boolean;
+  dismissible?: boolean;
+  dismissLabel?: string;
+  closeOnOverlayClick?: boolean;
+  closeOnEscape?: boolean;
+  showOverlay?: boolean;
+};

--- a/src/components/luna-drawer/LunaDrawer.stories.tsx
+++ b/src/components/luna-drawer/LunaDrawer.stories.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaButton } from "../luna-button";
+import { LunaDrawer } from "./LunaDrawer";
+
+const placements = ["left", "right", "top", "bottom"] as const;
+
+const meta = {
+  title: "Components/LunaDrawer",
+  component: LunaDrawer,
+  parameters: {
+    layout: "fullscreen"
+  },
+  args: {
+    open: true,
+    title: "Mission drawer",
+    description:
+      "Secondary content can move out of the page flow without leaving the current context.",
+    children: (
+      <div style={{ display: "grid", gap: "0.75rem" }}>
+        <p>Use the drawer for contextual workflows, inspect panels, and compact settings.</p>
+        <p>
+          Keep the contract narrow and let applications decide focus management or routing above
+          it.
+        </p>
+      </div>
+    ),
+    footer: (
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end", width: "100%" }}>
+        <LunaButton flat>Cancel</LunaButton>
+        <LunaButton>Apply changes</LunaButton>
+      </div>
+    )
+  }
+} satisfies Meta<typeof LunaDrawer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const PlacementMatrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+        gap: "1.5rem",
+        padding: "2rem"
+      }}
+    >
+      {placements.map((placement) => (
+        <div
+          key={placement}
+          style={{
+            position: "relative",
+            minHeight: "18rem",
+            border: "1px dashed var(--luna-border)",
+            borderRadius: "1rem",
+            overflow: "hidden",
+            background: "color-mix(in srgb, var(--luna-surface) 92%, transparent)"
+          }}
+        >
+          <LunaDrawer
+            open
+            showOverlay={false}
+            placement={placement}
+            title={`${placement[0].toUpperCase()}${placement.slice(1)} drawer`}
+            description="Inline story preview without the viewport backdrop."
+            size={placement === "left" || placement === "right" ? "18rem" : "12rem"}
+          >
+            Drawer content stays aligned to the chosen edge.
+          </LunaDrawer>
+        </div>
+      ))}
+    </div>
+  )
+};
+
+export const ControlledVisibility: Story = {
+  render: () => {
+    function ControlledDrawerStory() {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <div style={{ minHeight: "24rem", padding: "2rem" }}>
+          <LunaButton onClick={() => setOpen(true)}>Open drawer</LunaButton>
+          <LunaDrawer
+            open={open}
+            title="Controlled visibility"
+            description="This story keeps the open state in the story itself."
+            onOpenChange={(nextOpen) => setOpen(nextOpen)}
+            footer={
+              <div style={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
+                <LunaButton onClick={() => setOpen(false)}>Done</LunaButton>
+              </div>
+            }
+          >
+            Application code can coordinate the drawer with local page state.
+          </LunaDrawer>
+        </div>
+      );
+    }
+
+    return <ControlledDrawerStory />;
+  }
+};

--- a/src/components/luna-drawer/LunaDrawer.test.tsx
+++ b/src/components/luna-drawer/LunaDrawer.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaDrawer } from "./LunaDrawer";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaDrawer", () => {
+  it("renders the default drawer contract with dialog semantics", () => {
+    renderWithTheme(
+      <LunaDrawer open title="Mission details" description="Inspect the latest telemetry.">
+        Orbit data.
+      </LunaDrawer>
+    );
+
+    const drawer = screen.getByRole("dialog", { name: "Mission details" });
+
+    expect(drawer).toHaveAttribute("aria-modal", "true");
+    expect(drawer).toHaveAttribute("aria-describedby");
+    expect(screen.getByText("Orbit data.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss drawer" })).toBeInTheDocument();
+  });
+
+  it("supports overlay dismissal and reports the reason", () => {
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <LunaDrawer open title="Dismiss me" onOpenChange={onOpenChange}>
+        Overlay close.
+      </LunaDrawer>
+    );
+
+    fireEvent.click(document.querySelector(".luna-drawer__backdrop") as Element);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "overlay");
+  });
+
+  it("closes on Escape when enabled", () => {
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <LunaDrawer open title="Escape close" onOpenChange={onOpenChange}>
+        Keyboard close.
+      </LunaDrawer>
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "escape");
+  });
+
+  it("supports controlled visibility without mutating its own open state", () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = renderWithTheme(
+      <LunaDrawer open title="Controlled" onOpenChange={onOpenChange}>
+        Controlled drawer.
+      </LunaDrawer>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss drawer" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, "dismiss");
+    expect(screen.getByRole("dialog", { name: "Controlled" })).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider>
+        <LunaDrawer open={false} title="Controlled" onOpenChange={onOpenChange}>
+          Controlled drawer.
+        </LunaDrawer>
+      </ThemeProvider>
+    );
+
+    expect(screen.queryByRole("dialog", { name: "Controlled" })).not.toBeInTheDocument();
+  });
+
+  it("resolves spacing and drawer theme tokens through the theme system", () => {
+    const { container } = renderWithTheme(
+      <LunaDrawer
+        open
+        title="Theme override"
+        placement="left"
+        padding="6"
+        gap="2"
+        inset="8"
+        size="16"
+      >
+        Custom theme.
+      </LunaDrawer>,
+      {
+        theme: {
+          components: {
+            drawer: {
+              defaultPlacement: "left",
+              shadow: "md",
+              modes: {
+                light: {
+                  bg: "neutral.50",
+                  border: "accent.500",
+                  backdrop: "rgba(15, 23, 42, 0.4)"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+    const shell = document.querySelector(".luna-drawer");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-drawer-shadow": "0 8px 24px rgba(15, 23, 42, 0.18)",
+      "--luna-drawer-border": "#8b5cf6",
+      "--luna-drawer-backdrop": "rgba(15, 23, 42, 0.4)"
+    });
+    expect(shell).toHaveAttribute("data-placement", "left");
+    expect(shell).toHaveStyle({
+      "--luna-drawer-padding": "1.5rem",
+      "--luna-drawer-gap": "0.5rem",
+      "--luna-drawer-inset": "2rem",
+      "--luna-drawer-size": "4rem"
+    });
+  });
+});

--- a/src/components/luna-drawer/LunaDrawer.tsx
+++ b/src/components/luna-drawer/LunaDrawer.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaDrawerDismissReason, LunaDrawerProps } from "./LunaDrawer.props";
+import "./LunaDrawer.css";
+
+type DrawerCssVariable =
+  | "--luna-drawer-padding"
+  | "--luna-drawer-gap"
+  | "--luna-drawer-inset"
+  | "--luna-drawer-size";
+
+type LunaDrawerStyle = React.CSSProperties &
+  Partial<Record<DrawerCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+export const LunaDrawer = React.forwardRef<HTMLDivElement, LunaDrawerProps>(function LunaDrawer(
+  {
+    children,
+    className,
+    closeOnEscape = true,
+    closeOnOverlayClick = true,
+    defaultOpen = false,
+    description,
+    dismissLabel = "Dismiss drawer",
+    dismissible = true,
+    footer,
+    gap,
+    inset,
+    onOpenChange,
+    open,
+    padding,
+    placement,
+    role,
+    rounded,
+    showOverlay = true,
+    size,
+    style,
+    title,
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const reactId = React.useId();
+  const safeId = reactId.replace(/:/g, "");
+  const titleId = title ? `luna-drawer-title-${safeId}` : undefined;
+  const descriptionId = description ? `luna-drawer-description-${safeId}` : undefined;
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const resolvedPlacement = placement ?? theme.components.drawer?.defaultPlacement ?? "right";
+  const resolvedPadding = resolveSpacingValue(padding, theme);
+  const resolvedGap = resolveSpacingValue(gap, theme);
+  const resolvedInset = resolveSpacingValue(inset, theme);
+  const resolvedSize =
+    resolveSpacingValue(size, theme) ??
+    resolveSpacingValue(theme.components.drawer?.defaultSize, theme) ??
+    theme.components.drawer?.defaultSize;
+
+  const closeDrawer = React.useCallback(
+    (reason: LunaDrawerDismissReason) => {
+      if (!isControlled) {
+        setInternalOpen(false);
+      }
+
+      onOpenChange?.(false, reason);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  React.useEffect(() => {
+    if (!isOpen || !closeOnEscape) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeDrawer("escape");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeDrawer, closeOnEscape, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const resolvedStyle: LunaDrawerStyle = {
+    ...(resolvedPadding ? { ["--luna-drawer-padding" as const]: resolvedPadding } : {}),
+    ...(resolvedGap ? { ["--luna-drawer-gap" as const]: resolvedGap } : {}),
+    ...(resolvedInset ? { ["--luna-drawer-inset" as const]: resolvedInset } : {}),
+    ...(resolvedSize ? { ["--luna-drawer-size" as const]: resolvedSize } : {}),
+    ...style
+  };
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      className={toClassName(["luna-drawer", rounded && "luna-drawer--rounded", className])}
+      data-overlay={showOverlay ? "true" : "false"}
+      data-placement={resolvedPlacement}
+      style={resolvedStyle}
+    >
+      {showOverlay ? (
+        <div
+          aria-hidden="true"
+          className="luna-drawer__backdrop"
+          onClick={() => {
+            if (closeOnOverlayClick) {
+              closeDrawer("overlay");
+            }
+          }}
+        />
+      ) : null}
+      <div
+        className="luna-drawer__panel"
+        role={role ?? "dialog"}
+        aria-modal={showOverlay ? true : undefined}
+        aria-labelledby={props["aria-labelledby"] ?? titleId}
+        aria-describedby={props["aria-describedby"] ?? descriptionId}
+      >
+        {title || description || dismissible ? (
+          <div className="luna-drawer__header">
+            <div className="luna-drawer__heading">
+              {title ? (
+                <div id={titleId} className="luna-drawer__title">
+                  {title}
+                </div>
+              ) : null}
+              {description ? (
+                <div id={descriptionId} className="luna-drawer__description">
+                  {description}
+                </div>
+              ) : null}
+            </div>
+            {dismissible ? (
+              <button
+                type="button"
+                className="luna-drawer__dismiss"
+                aria-label={dismissLabel}
+                onClick={() => {
+                  closeDrawer("dismiss");
+                }}
+              >
+                <span aria-hidden="true">x</span>
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="luna-drawer__content">{children}</div>
+        {footer ? <div className="luna-drawer__footer">{footer}</div> : null}
+      </div>
+    </div>
+  );
+});

--- a/src/components/luna-drawer/index.ts
+++ b/src/components/luna-drawer/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaDrawer";
+export * from "./LunaDrawer.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -62,4 +62,14 @@ describe("theme size contract", () => {
       "danger"
     ]);
   });
+
+  it("defines drawer defaults for the composite overlay surface", () => {
+    const drawer = lunarTheme.components.drawer;
+
+    expect(drawer?.defaultPlacement).toBe("right");
+    expect(drawer?.defaultPadding).toBe("5");
+    expect(drawer?.defaultGap).toBe("4");
+    expect(drawer?.defaultInset).toBe("4");
+    expect(drawer?.defaultSize).toBe("28rem");
+  });
 });

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1287,6 +1287,29 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    drawer: {
+      defaultPadding: "5",
+      defaultGap: "4",
+      defaultInset: "4",
+      defaultSize: "28rem",
+      defaultPlacement: "right",
+      radius: "lg",
+      shadow: "lg",
+      modes: {
+        light: {
+          bg: "neutral.50",
+          fg: "neutral.900",
+          border: "neutral.200",
+          backdrop: "rgba(15, 23, 42, 0.52)"
+        },
+        dark: {
+          bg: "neutral.800",
+          fg: "neutral.50",
+          border: "neutral.700",
+          backdrop: "rgba(2, 6, 23, 0.72)"
+        }
+      }
+    },
     divider: {
       defaultSpacing: "4",
       defaultInset: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -294,6 +294,15 @@ export type ThemeAccordionModeTokens = {
   panelFg?: string;
 };
 
+export type ThemeDrawerPlacement = "left" | "right" | "top" | "bottom";
+
+export type ThemeDrawerModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  backdrop?: string;
+};
+
 export type ThemeComponents = {
   button?: {
     defaultSize?: string;
@@ -395,6 +404,16 @@ export type ThemeComponents = {
         >
       >
     >;
+  };
+  drawer?: {
+    defaultPadding?: string;
+    defaultGap?: string;
+    defaultInset?: string;
+    defaultSize?: string;
+    defaultPlacement?: ThemeDrawerPlacement;
+    radius?: string;
+    shadow?: string;
+    modes?: Partial<Record<ThemeMode, ThemeDrawerModeTokens>>;
   };
   divider?: {
     defaultSpacing?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -500,6 +500,47 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     }
   }
 
+  const drawer = theme.components.drawer;
+  if (drawer?.defaultPadding) {
+    vars["--luna-drawer-padding-default"] =
+      resolveScaleValue(theme.spacing, drawer.defaultPadding) ?? drawer.defaultPadding;
+  }
+  if (drawer?.defaultGap) {
+    vars["--luna-drawer-gap-default"] =
+      resolveScaleValue(theme.spacing, drawer.defaultGap) ?? drawer.defaultGap;
+  }
+  if (drawer?.defaultInset) {
+    vars["--luna-drawer-inset-default"] =
+      resolveScaleValue(theme.spacing, drawer.defaultInset) ?? drawer.defaultInset;
+  }
+  if (drawer?.defaultSize) {
+    vars["--luna-drawer-size-default"] =
+      resolveScaleValue(theme.spacing, drawer.defaultSize) ?? drawer.defaultSize;
+  }
+  if (drawer?.defaultPlacement) {
+    vars["--luna-drawer-placement-default"] = drawer.defaultPlacement;
+  }
+  if (drawer?.radius) {
+    vars["--luna-drawer-radius"] = resolveScaleValue(theme.radii, drawer.radius) ?? drawer.radius;
+  }
+  if (drawer?.shadow) {
+    vars["--luna-drawer-shadow"] =
+      resolveScaleValue(theme.shadows, drawer.shadow) ?? resolveTokenValue(theme, drawer.shadow);
+  }
+  const drawerMode = drawer?.modes?.[mode];
+  if (drawerMode?.bg) {
+    vars["--luna-drawer-bg"] = resolveTokenValue(theme, drawerMode.bg);
+  }
+  if (drawerMode?.fg) {
+    vars["--luna-drawer-fg"] = resolveTokenValue(theme, drawerMode.fg);
+  }
+  if (drawerMode?.border) {
+    vars["--luna-drawer-border"] = resolveTokenValue(theme, drawerMode.border);
+  }
+  if (drawerMode?.backdrop) {
+    vars["--luna-drawer-backdrop"] = resolveTokenValue(theme, drawerMode.backdrop);
+  }
+
   const divider = theme.components.divider;
   if (divider?.defaultSpacing) {
     vars["--luna-divider-spacing-default"] =


### PR DESCRIPTION
storybook-component: luna-drawer

Closes #21

## Summary
Implemented `LunaDrawer` as a scoped issue `#21` slice. The new composite adds a controlled or uncontrolled edge-anchored drawer with overlay dismissal, Escape handling, theme-aware sizing and spacing, and optional title, description, footer, and dismiss affordances in [LunaDrawer.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-drawer/LunaDrawer.tsx#L31) and [LunaDrawer.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-drawer/LunaDrawer.props.ts#L3). It is exported from [index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts#L10), with theme contract support added in [types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts#L249), [base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts#L996), and [vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts#L355).

Storybook, docs, tests, and release metadata were updated alongside the component in [LunaDrawer.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-drawer/LunaDrawer.stories.tsx), [LunaDrawer.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-drawer/LunaDrawer.test.tsx#L19), [LunaDrawer.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaDrawer.md#L1), [LunaDrawer.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaDrawer.md#L1), and [.changeset/luna-drawer.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-drawer.md#L1).

Verification run:
- `npm test -- src/components/luna-drawer/LunaDrawer.test.tsx src/theme/base.test.ts`
- `npm run build`

Both passed.

I could not complete the commit step because the sandbox blocked writing `.git/index.lock`, so the changes are present in the worktree but uncommitted.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`