### PR TITLE
Resolve #23: Build LunaAccordion composite

### DIFF
--- a/.changeset/luna-accordion-issue-23.md
+++ b/.changeset/luna-accordion-issue-23.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaAccordion` composite with theme support, Storybook coverage, tests, and public docs.

--- a/docs/v1/components/LunaAccordion.md
+++ b/docs/v1/components/LunaAccordion.md
@@ -1,0 +1,85 @@
+# LunaAccordion
+
+`LunaAccordion` is the grouped disclosure composite for `react-luna`.
+
+It owns:
+- repeated trigger and panel rendering
+- accessible disclosure semantics
+- single or multiple expansion behavior
+- controlled and uncontrolled open state
+- theme-aware surface styling
+
+It does not own:
+- nested navigation trees
+- rich layout composition beyond each item panel
+- asynchronous loading or data fetching
+
+## Props
+
+- `items: Array<{ value: string; title: React.ReactNode; content: React.ReactNode; description?: React.ReactNode; disabled?: boolean }>`
+- `value?: string | string[] | null`
+- `defaultValue?: string | string[] | null`
+- `onValueChange?: (value: string | string[] | null) => void`
+- `multiple?: boolean`
+- `collapsible?: boolean`
+- `headingLevel?: 2 | 3 | 4 | 5 | 6`
+- `gap?: string`
+- `itemGap?: string`
+- `panelPadding?: string`
+- `rounded?: boolean`
+
+## Contract
+
+- `items` is the only required content input in V1
+- each item needs a stable `value`
+- `title` renders inside the trigger button
+- `description` is optional supporting text inside the trigger
+- `content` renders inside the associated panel region
+- `className`, `style`, `id`, `role`, `aria-*`, and `data-*` pass through to the root
+
+## State Model
+
+- single-expand mode is the default
+- `multiple` allows more than one item to stay open
+- `collapsible` defaults to `true`
+- in single-expand mode, `value` and `defaultValue` use `string | null`
+- in multiple mode, `value` and `defaultValue` use `string[]`
+- `onValueChange` returns the same shape the current mode expects
+
+## Accessibility
+
+- each item trigger is a native `button`
+- each trigger owns `aria-expanded` and `aria-controls`
+- each panel uses `role="region"` and `aria-labelledby`
+- `headingLevel` controls the semantic wrapper around each trigger
+- disabled items remain visible but cannot be toggled
+
+## Theme Integration
+
+`LunaAccordion` consumes the existing `ThemeProvider` for:
+- item background
+- item border
+- hover and open-state surfaces
+- foreground and muted foreground
+- indicator color
+- gap, item gap, and panel padding
+- radius
+
+Spacing props resolve through theme spacing first, then raw CSS values.
+
+## Behavior Rules
+
+- clicking a closed item opens it
+- clicking an open item closes it only when `collapsible` is `true`
+- clicking an item in single-expand mode closes any other open item
+- disabled items never change the open-state model
+
+## Testing Focus
+
+The accordion contract should stay covered in unit tests for:
+- default and controlled expansion
+- single and multiple behavior
+- disabled item handling
+- semantic heading level rendering
+- spacing token resolution
+- accessible trigger and panel wiring

--- a/docs/v1/design/LunaAccordion.md
+++ b/docs/v1/design/LunaAccordion.md
@@ -1,0 +1,98 @@
+# Accordion Design
+
+This document defines the design direction for `LunaAccordion` before implementation.
+
+`LunaAccordion` should be the grouped disclosure composite for `react-luna`. It should stay easy to theme, preserve native button semantics, and keep the content model explicit.
+
+## Design Stance
+
+- Favor one clear prop-driven accordion over a compound subcomponent family in V1.
+- Keep item structure explicit and serializable through an `items` array.
+- Treat open-state control as part of the public contract.
+- Keep the default behavior useful for settings panels, checklists, and grouped details.
+
+## Role In The System
+
+`LunaAccordion` should own:
+- trigger and panel pairing
+- expansion state behavior
+- semantic heading wrappers
+- item-level surface styling
+- theme-aware spacing and radius
+
+`LunaAccordion` should not own:
+- page layout
+- tree navigation
+- async data orchestration
+- virtualized collections
+
+## Content Model
+
+V1 should support a simple repeated item shape:
+- `value`
+- `title`
+- `description`
+- `content`
+- `disabled`
+
+Rules:
+- `value` identifies the item in the open-state model
+- `title` is required and should stay concise
+- `description` is optional supporting context in the trigger row
+- `content` is the revealed panel body
+
+## Open State
+
+Recommended props:
+- `value?: string | string[] | null`
+- `defaultValue?: string | string[] | null`
+- `onValueChange?: (value: string | string[] | null) => void`
+- `multiple?: boolean`
+- `collapsible?: boolean`
+
+Rules:
+- single-expand mode should be the default
+- multiple mode should support any number of open items
+- `collapsible` should default to `true`
+- controlled and uncontrolled usage should both work
+
+## Accessibility
+
+- each trigger should be a native `button`
+- each panel should be labelled by its trigger
+- each trigger should sit inside a semantic heading wrapper
+- heading level should be configurable without exposing custom heading markup
+
+## Theme Provider Integration
+
+`LunaAccordion` must use the existing `ThemeProvider` and `useTheme()` path.
+
+Recommended theme direction:
+- `components.accordion`
+
+Likely theme tokens:
+- `defaultGap`
+- `defaultItemGap`
+- `defaultPanelPadding`
+- `radius`
+- light and dark mode item surface tokens
+
+## Recommended Testing Focus
+
+When implemented, tests should cover:
+- default open state
+- controlled open state
+- single and multiple expansion behavior
+- non-collapsible behavior
+- disabled item behavior
+- heading-level output
+- spacing token resolution
+
+## Implementation Order
+
+1. Define the `LunaAccordion` item and state contract
+2. Add accordion theme typing and base theme defaults
+3. Build the component shell
+4. Add Storybook coverage
+5. Add unit tests
+6. Add the component contract doc under `docs/v1/components`

--- a/playwright/storybook/manifests/luna-accordion.json
+++ b/playwright/storybook/manifests/luna-accordion.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunaaccordion--single-expand",
+    "fileName": "luna-accordion-single-expand",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunaaccordion--multiple-expand",
+    "fileName": "luna-accordion-multiple-expand",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunaaccordion--non-collapsible",
+    "fileName": "luna-accordion-non-collapsible",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunaaccordion--theme-override",
+    "fileName": "luna-accordion-theme-override",
+    "backgrounds": ["light"]
+  }
+]

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { storybookCaptures } from "./manifest";
 
@@ -7,6 +7,22 @@ const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
 const requestedComponent = process.env.STORYBOOK_COMPONENT?.trim();
 
 type StoryCapture = (typeof storybookCaptures)[number];
+
+function loadBranchManifest(componentSlug: string): StoryCapture[] | null {
+  const manifestPath = join(
+    process.cwd(),
+    "playwright",
+    "storybook",
+    "manifests",
+    `${componentSlug}.json`
+  );
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as StoryCapture[];
+}
 
 function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] {
   const normalizedComponent = componentSlug.replace(/-/g, "");
@@ -31,7 +47,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 
 const captures =
   requestedComponent && requestedComponent.length > 0
-    ? buildCapturesFromStorybookIndex(requestedComponent)
+    ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
     : storybookCaptures;
 
 for (const capture of captures) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./luna-avatar";
 export * from "./luna-alert";
+export * from "./luna-accordion";
 export * from "./luna-badge";
 export * from "./luna-button";
 export * from "./luna-card";

--- a/src/components/luna-accordion/LunaAccordion.css
+++ b/src/components/luna-accordion/LunaAccordion.css
@@ -1,0 +1,112 @@
+.luna-accordion {
+  display: grid;
+  gap: var(--luna-accordion-gap, var(--luna-accordion-gap-default, 0.75rem));
+}
+
+.luna-accordion__item {
+  border: 1px solid var(--luna-accordion-item-border, var(--luna-border));
+  border-radius: var(--luna-accordion-radius, var(--luna-radius-lg));
+  background: var(--luna-accordion-item-bg, var(--luna-surface));
+  color: var(--luna-accordion-item-fg, var(--luna-foreground));
+  overflow: clip;
+  transition:
+    border-color var(--luna-motion-base),
+    background-color var(--luna-motion-base),
+    box-shadow var(--luna-motion-base);
+}
+
+.luna-accordion__item[data-state="open"] {
+  background: var(--luna-accordion-item-active-bg, var(--luna-accordion-item-bg, var(--luna-surface)));
+}
+
+.luna-accordion__item[data-disabled="true"] {
+  opacity: 0.7;
+}
+
+.luna-accordion--rounded .luna-accordion__item {
+  border-radius: var(--luna-radius-xl, 1.25rem);
+}
+
+.luna-accordion__heading {
+  margin: 0;
+}
+
+.luna-accordion__trigger {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: var(--luna-accordion-panel-padding, var(--luna-accordion-panel-padding-default, 1rem));
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color var(--luna-motion-fast),
+    color var(--luna-motion-fast);
+}
+
+.luna-accordion__trigger:hover {
+  background: var(--luna-accordion-item-hover-bg, transparent);
+}
+
+.luna-accordion__trigger:focus-visible {
+  outline: 2px solid var(--luna-color-primary-400, #818cf8);
+  outline-offset: -2px;
+}
+
+.luna-accordion__trigger:disabled {
+  cursor: not-allowed;
+}
+
+.luna-accordion__trigger-content {
+  display: grid;
+  gap: var(--luna-accordion-item-gap, var(--luna-accordion-item-gap-default, 0.375rem));
+  min-width: 0;
+}
+
+.luna-accordion__title,
+.luna-accordion__description,
+.luna-accordion__panel {
+  min-width: 0;
+}
+
+.luna-accordion__title {
+  color: var(--luna-accordion-item-fg, var(--luna-foreground));
+}
+
+.luna-accordion__description {
+  color: var(--luna-accordion-item-muted-fg, var(--luna-muted));
+}
+
+.luna-accordion__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--luna-accordion-item-indicator-fg, currentColor);
+  transform: rotate(0deg);
+  transition:
+    transform var(--luna-motion-fast),
+    color var(--luna-motion-fast);
+}
+
+.luna-accordion__item[data-state="open"] .luna-accordion__indicator {
+  transform: rotate(180deg);
+}
+
+.luna-accordion__panel {
+  padding:
+    0
+    var(--luna-accordion-panel-padding, var(--luna-accordion-panel-padding-default, 1rem))
+    var(--luna-accordion-panel-padding, var(--luna-accordion-panel-padding-default, 1rem));
+  color: var(--luna-accordion-panel-fg, var(--luna-foreground));
+}
+
+.luna-accordion__panel[hidden] {
+  display: none;
+}

--- a/src/components/luna-accordion/LunaAccordion.props.ts
+++ b/src/components/luna-accordion/LunaAccordion.props.ts
@@ -1,0 +1,28 @@
+import type React from "react";
+
+export type LunaAccordionValue = string | string[] | null;
+
+export type LunaAccordionItem = {
+  value: string;
+  title: React.ReactNode;
+  content: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+};
+
+export type LunaAccordionProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children" | "defaultValue" | "onChange" | "value"
+> & {
+  items: LunaAccordionItem[];
+  value?: LunaAccordionValue;
+  defaultValue?: LunaAccordionValue;
+  onValueChange?: (value: LunaAccordionValue) => void;
+  multiple?: boolean;
+  collapsible?: boolean;
+  headingLevel?: 2 | 3 | 4 | 5 | 6;
+  gap?: string;
+  itemGap?: string;
+  panelPadding?: string;
+  rounded?: boolean;
+};

--- a/src/components/luna-accordion/LunaAccordion.stories.tsx
+++ b/src/components/luna-accordion/LunaAccordion.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ThemeProvider } from "../../theme";
+import { LunaButton } from "../luna-button";
+import { LunaText } from "../luna-text";
+import { LunaAccordion } from "./LunaAccordion";
+
+const items = [
+  {
+    value: "systems",
+    title: "Systems check",
+    description: "Telemetry, pressure, and thermal routing.",
+    content: (
+      <LunaText variant="body-small">
+        Core telemetry is stable and thermal routing remains within the expected launch window.
+      </LunaText>
+    )
+  },
+  {
+    value: "payload",
+    title: "Payload manifest",
+    description: "Scientific instruments and relay cargo.",
+    content: (
+      <LunaText variant="body-small">
+        The relay package is locked, sealed, and cleared for lunar transfer.
+      </LunaText>
+    )
+  },
+  {
+    value: "handoff",
+    title: "Ground handoff",
+    description: "Final communication path before departure.",
+    content: (
+      <div style={{ display: "grid", gap: "0.75rem" }}>
+        <LunaText variant="body-small">
+          Ground control remains synchronized across all channels.
+        </LunaText>
+        <div>
+          <LunaButton size="small">Review checklist</LunaButton>
+        </div>
+      </div>
+    )
+  }
+];
+
+const meta = {
+  title: "Components/LunaAccordion",
+  component: LunaAccordion,
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    items
+  }
+} satisfies Meta<typeof LunaAccordion>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SingleExpand: Story = {
+  args: {
+    defaultValue: "systems"
+  }
+};
+
+export const MultipleExpand: Story = {
+  args: {
+    multiple: true,
+    defaultValue: ["systems", "payload"]
+  }
+};
+
+export const NonCollapsible: Story = {
+  args: {
+    collapsible: false,
+    defaultValue: "systems"
+  }
+};
+
+export const ThemeOverride: Story = {
+  render: () => (
+    <ThemeProvider
+      theme={{
+        components: {
+          accordion: {
+            radius: "xl",
+            defaultGap: "4",
+            modes: {
+              light: {
+                itemBg: "neutral.100",
+                itemBorder: "primary.200",
+                itemHoverBg: "primary.50",
+                itemActiveBg: "primary.100",
+                itemIndicatorFg: "primary.700",
+                itemMutedFg: "neutral.700",
+                panelFg: "neutral.800"
+              }
+            }
+          }
+        }
+      }}
+    >
+      <LunaAccordion
+        items={items}
+        defaultValue="payload"
+        panelPadding="5"
+        itemGap="2"
+      />
+    </ThemeProvider>
+  )
+};

--- a/src/components/luna-accordion/LunaAccordion.test.tsx
+++ b/src/components/luna-accordion/LunaAccordion.test.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaAccordion } from "./LunaAccordion";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+const items = [
+  {
+    value: "systems",
+    title: "Systems check",
+    description: "Telemetry and thermal routing.",
+    content: <div>Systems content</div>
+  },
+  {
+    value: "payload",
+    title: "Payload manifest",
+    content: <div>Payload content</div>
+  },
+  {
+    value: "disabled",
+    title: "Disabled section",
+    disabled: true,
+    content: <div>Disabled content</div>
+  }
+];
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("LunaAccordion", () => {
+  it("renders buttons for each item and opens the default value", () => {
+    renderWithTheme(<LunaAccordion items={items} defaultValue="systems" />);
+
+    expect(screen.getByRole("button", { name: /Systems check/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByRole("region", { name: /Systems check/i })).toBeVisible();
+    expect(screen.getByText("Telemetry and thermal routing.")).toBeInTheDocument();
+  });
+
+  it("supports single-expand behavior by default", () => {
+    renderWithTheme(<LunaAccordion items={items} defaultValue="systems" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Payload manifest/i }));
+
+    expect(screen.getByRole("button", { name: /Systems check/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(screen.getByRole("button", { name: /Payload manifest/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("supports multiple open items when multiple is true", () => {
+    renderWithTheme(<LunaAccordion items={items} multiple />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Systems check/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Payload manifest/i }));
+
+    expect(screen.getByRole("button", { name: /Systems check/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /Payload manifest/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("keeps the open item expanded when collapsible is false", () => {
+    renderWithTheme(
+      <LunaAccordion items={items} defaultValue="systems" collapsible={false} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Systems check/i }));
+
+    expect(screen.getByRole("button", { name: /Systems check/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("supports controlled usage and emits value changes", () => {
+    const handleValueChange = vi.fn();
+
+    const { rerender } = renderWithTheme(
+      <LunaAccordion items={items} value="systems" onValueChange={handleValueChange} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Payload manifest/i }));
+
+    expect(handleValueChange).toHaveBeenCalledWith("payload");
+
+    rerender(
+      <ThemeProvider>
+        <LunaAccordion items={items} value="payload" onValueChange={handleValueChange} />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole("button", { name: /Payload manifest/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("does not toggle disabled items", () => {
+    renderWithTheme(<LunaAccordion items={items} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Disabled section/i }));
+
+    expect(screen.getByRole("button", { name: /Disabled section/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    const trigger = screen.getByRole("button", { name: /Disabled section/i });
+    const panelId = trigger.getAttribute("aria-controls");
+
+    expect(document.getElementById(panelId ?? "")).toHaveAttribute("hidden");
+  });
+
+  it("applies spacing overrides onto the root style", () => {
+    renderWithTheme(
+      <LunaAccordion items={items} gap="5" itemGap="2" panelPadding="6" />
+    );
+
+    const accordion = screen.getByRole("button", { name: /Systems check/i }).closest(
+      ".luna-accordion"
+    );
+
+    expect(accordion).toHaveStyle({
+      "--luna-accordion-gap": "1.25rem",
+      "--luna-accordion-item-gap": "0.5rem",
+      "--luna-accordion-panel-padding": "1.5rem"
+    });
+  });
+
+  it("renders the requested heading level", () => {
+    renderWithTheme(<LunaAccordion items={items} headingLevel={4} />);
+
+    expect(screen.getByRole("button", { name: /Systems check/i }).closest("h4")).toBeInTheDocument();
+  });
+});

--- a/src/components/luna-accordion/LunaAccordion.tsx
+++ b/src/components/luna-accordion/LunaAccordion.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import { LunaText } from "../luna-text";
+import type {
+  LunaAccordionItem,
+  LunaAccordionProps,
+  LunaAccordionValue
+} from "./LunaAccordion.props";
+import "./LunaAccordion.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function clampHeadingLevel(level: number | undefined) {
+  if (!level) {
+    return 3;
+  }
+
+  return Math.min(6, Math.max(2, level)) as 2 | 3 | 4 | 5 | 6;
+}
+
+function normalizeValue(value: LunaAccordionValue | undefined, multiple: boolean): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value.filter((entry) => typeof entry === "string");
+    return multiple ? normalized : normalized.slice(0, 1);
+  }
+
+  return value ? [value] : [];
+}
+
+function toPublicValue(values: string[], multiple: boolean): LunaAccordionValue {
+  if (multiple) {
+    return values;
+  }
+
+  return values[0] ?? null;
+}
+
+function nextOpenValues(
+  currentValues: string[],
+  item: LunaAccordionItem,
+  multiple: boolean,
+  collapsible: boolean
+) {
+  if (item.disabled) {
+    return currentValues;
+  }
+
+  const isOpen = currentValues.includes(item.value);
+
+  if (multiple) {
+    if (isOpen) {
+      return collapsible ? currentValues.filter((value) => value !== item.value) : currentValues;
+    }
+
+    return [...currentValues, item.value];
+  }
+
+  if (isOpen) {
+    return collapsible ? [] : currentValues;
+  }
+
+  return [item.value];
+}
+
+export const LunaAccordion = React.forwardRef<HTMLDivElement, LunaAccordionProps>(
+  function LunaAccordion(
+    {
+      className,
+      collapsible = true,
+      defaultValue,
+      gap,
+      headingLevel = 3,
+      itemGap,
+      items,
+      multiple = false,
+      onValueChange,
+      panelPadding,
+      rounded,
+      style,
+      value,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const { theme } = useTheme();
+    const resolvedHeadingLevel = clampHeadingLevel(headingLevel);
+    const HeadingTag = `h${resolvedHeadingLevel}` as keyof React.JSX.IntrinsicElements;
+    const isControlled = value !== undefined;
+    const resolvedGap = resolveSpacingValue(gap, theme);
+    const resolvedItemGap = resolveSpacingValue(itemGap, theme);
+    const resolvedPanelPadding = resolveSpacingValue(panelPadding, theme);
+    const [internalValue, setInternalValue] = React.useState<LunaAccordionValue>(() =>
+      toPublicValue(normalizeValue(defaultValue, multiple), multiple)
+    );
+    const openValues = normalizeValue(isControlled ? value : internalValue, multiple);
+
+    React.useEffect(() => {
+      if (!isControlled) {
+        setInternalValue(toPublicValue(normalizeValue(defaultValue, multiple), multiple));
+      }
+    }, [defaultValue, isControlled, multiple]);
+
+    const resolvedStyle = {
+      ...(resolvedGap ? { ["--luna-accordion-gap" as const]: resolvedGap } : {}),
+      ...(resolvedItemGap ? { ["--luna-accordion-item-gap" as const]: resolvedItemGap } : {}),
+      ...(resolvedPanelPadding
+        ? { ["--luna-accordion-panel-padding" as const]: resolvedPanelPadding }
+        : {}),
+      ...style
+    };
+
+    function handleToggle(item: LunaAccordionItem) {
+      const nextValue = toPublicValue(
+        nextOpenValues(openValues, item, multiple, collapsible),
+        multiple
+      );
+
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+    }
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={toClassName([
+          "luna-accordion",
+          rounded && "luna-accordion--rounded",
+          className
+        ])}
+        style={resolvedStyle}
+      >
+        {items.map((item, index) => {
+          const itemId = `${reactId.replace(/:/g, "")}-${item.value || index}`;
+          const triggerId = `${itemId}-trigger`;
+          const panelId = `${itemId}-panel`;
+          const isOpen = openValues.includes(item.value);
+
+          return (
+            <div
+              key={item.value}
+              className="luna-accordion__item"
+              data-disabled={item.disabled ? "true" : undefined}
+              data-state={isOpen ? "open" : "closed"}
+            >
+              <HeadingTag className="luna-accordion__heading">
+                <button
+                  id={triggerId}
+                  type="button"
+                  className="luna-accordion__trigger"
+                  aria-controls={panelId}
+                  aria-expanded={isOpen}
+                  disabled={item.disabled}
+                  onClick={() => handleToggle(item)}
+                >
+                  <span className="luna-accordion__trigger-content">
+                    {typeof item.title === "string" ? (
+                      <LunaText as="span" variant="label" className="luna-accordion__title">
+                        {item.title}
+                      </LunaText>
+                    ) : (
+                      <span className="luna-accordion__title">{item.title}</span>
+                    )}
+                    {item.description !== undefined && item.description !== null
+                      ? typeof item.description === "string"
+                        ? (
+                          <LunaText
+                            as="span"
+                            variant="body-small"
+                            className="luna-accordion__description"
+                          >
+                            {item.description}
+                          </LunaText>
+                        )
+                        : (
+                          <span className="luna-accordion__description">{item.description}</span>
+                        )
+                      : null}
+                  </span>
+                  <span aria-hidden="true" className="luna-accordion__indicator">
+                    <svg viewBox="0 0 16 16" width="16" height="16" focusable="false">
+                      <path
+                        d="M4 6.5 8 10l4-3.5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.6"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </HeadingTag>
+              <div
+                id={panelId}
+                role="region"
+                aria-labelledby={triggerId}
+                className="luna-accordion__panel"
+                hidden={!isOpen}
+              >
+                {item.content}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+);

--- a/src/components/luna-accordion/index.ts
+++ b/src/components/luna-accordion/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaAccordion";
+export * from "./LunaAccordion.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -452,6 +452,34 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    accordion: {
+      defaultGap: "3",
+      defaultItemGap: "0.375rem",
+      defaultPanelPadding: "4",
+      radius: "lg",
+      modes: {
+        light: {
+          itemBg: "neutral.50",
+          itemBorder: "neutral.200",
+          itemHoverBg: "neutral.100",
+          itemActiveBg: "primary.50",
+          itemFg: "neutral.900",
+          itemMutedFg: "neutral.600",
+          itemIndicatorFg: "primary.600",
+          panelFg: "neutral.800"
+        },
+        dark: {
+          itemBg: "neutral.800",
+          itemBorder: "neutral.700",
+          itemHoverBg: "neutral.700",
+          itemActiveBg: "neutral.700",
+          itemFg: "neutral.50",
+          itemMutedFg: "neutral.300",
+          itemIndicatorFg: "primary.300",
+          panelFg: "neutral.100"
+        }
+      }
+    },
     alert: {
       defaultPadding: "4",
       defaultGap: "3",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -261,6 +261,17 @@ export type ThemeTooltipModeTokens = {
   shadow?: string;
 };
 
+export type ThemeAccordionModeTokens = {
+  itemBg?: string;
+  itemBorder?: string;
+  itemHoverBg?: string;
+  itemActiveBg?: string;
+  itemFg?: string;
+  itemMutedFg?: string;
+  itemIndicatorFg?: string;
+  panelFg?: string;
+};
+
 export type ThemeComponents = {
   button?: {
     defaultSize?: string;
@@ -412,6 +423,13 @@ export type ThemeComponents = {
     paddingX?: string;
     paddingY?: string;
     modes?: Partial<Record<ThemeMode, ThemeTooltipModeTokens>>;
+  };
+  accordion?: {
+    defaultGap?: string;
+    defaultItemGap?: string;
+    defaultPanelPadding?: string;
+    radius?: string;
+    modes?: Partial<Record<ThemeMode, ThemeAccordionModeTokens>>;
   };
 };
 

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -201,6 +201,53 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
       resolveTokenValue(theme, cardMode.hoverShadow);
   }
 
+  const accordion = theme.components.accordion;
+  if (accordion?.defaultGap) {
+    vars["--luna-accordion-gap-default"] =
+      resolveScaleValue(theme.spacing, accordion.defaultGap) ?? accordion.defaultGap;
+  }
+  if (accordion?.defaultItemGap) {
+    vars["--luna-accordion-item-gap-default"] =
+      resolveScaleValue(theme.spacing, accordion.defaultItemGap) ?? accordion.defaultItemGap;
+  }
+  if (accordion?.defaultPanelPadding) {
+    vars["--luna-accordion-panel-padding-default"] =
+      resolveScaleValue(theme.spacing, accordion.defaultPanelPadding) ??
+      accordion.defaultPanelPadding;
+  }
+  if (accordion?.radius) {
+    vars["--luna-accordion-radius"] =
+      resolveScaleValue(theme.radii, accordion.radius) ?? accordion.radius;
+  }
+  const accordionMode = accordion?.modes?.[mode];
+  if (accordionMode?.itemBg) {
+    vars["--luna-accordion-item-bg"] = resolveTokenValue(theme, accordionMode.itemBg);
+  }
+  if (accordionMode?.itemBorder) {
+    vars["--luna-accordion-item-border"] = resolveTokenValue(theme, accordionMode.itemBorder);
+  }
+  if (accordionMode?.itemHoverBg) {
+    vars["--luna-accordion-item-hover-bg"] = resolveTokenValue(theme, accordionMode.itemHoverBg);
+  }
+  if (accordionMode?.itemActiveBg) {
+    vars["--luna-accordion-item-active-bg"] = resolveTokenValue(theme, accordionMode.itemActiveBg);
+  }
+  if (accordionMode?.itemFg) {
+    vars["--luna-accordion-item-fg"] = resolveTokenValue(theme, accordionMode.itemFg);
+  }
+  if (accordionMode?.itemMutedFg) {
+    vars["--luna-accordion-item-muted-fg"] = resolveTokenValue(theme, accordionMode.itemMutedFg);
+  }
+  if (accordionMode?.itemIndicatorFg) {
+    vars["--luna-accordion-item-indicator-fg"] = resolveTokenValue(
+      theme,
+      accordionMode.itemIndicatorFg
+    );
+  }
+  if (accordionMode?.panelFg) {
+    vars["--luna-accordion-panel-fg"] = resolveTokenValue(theme, accordionMode.panelFg);
+  }
+
   const emptyState = theme.components.emptyState;
   if (emptyState?.defaultPadding) {
     vars["--luna-empty-state-padding-default"] =


### PR DESCRIPTION
storybook-component: luna-accordion

Closes #23

## Summary
Implemented `LunaAccordion` as a prop-driven composite with controlled and uncontrolled open state, single or multiple expansion, semantic heading levels, Storybook coverage, tests, docs, and theme-aware styling.

This branch also uses a branch-local Storybook manifest for accordion screenshots instead of rewriting the shared manifest.

## Verification
- `npm test -- src/components/luna-accordion/LunaAccordion.test.tsx`
- `npm run build`
- `npm run storybook:build`
