### PR TITLE
Resolve #24: Build LunaTable composite

### DIFF
--- a/.changeset/silent-dryers-battle.md
+++ b/.changeset/silent-dryers-battle.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaTable` composite with Storybook coverage, tests, and component docs.

--- a/docs/v1/components/LunaTable.md
+++ b/docs/v1/components/LunaTable.md
@@ -1,0 +1,66 @@
+# LunaTable
+
+`LunaTable` is the base composite for structured row and column data in `react-luna`.
+
+It owns:
+- a semantic table inside a scroll shell
+- column headers and cell rendering
+- row striping and hover treatment
+- density control
+- sticky header treatment
+- empty-state rendering
+
+Default root element:
+- `div`
+
+## Props
+
+- `columns: Array<LunaTableColumn<RowData>>`
+- `rows: RowData[]`
+- `caption?: React.ReactNode`
+- `emptyState?: React.ReactNode`
+- `density?: "compact" | "default" | "comfortable"`
+- `striped?: boolean`
+- `hoverable?: boolean`
+- `stickyHeader?: boolean`
+- `getRowKey?: (row: RowData, rowIndex: number) => React.Key`
+- `getRowClassName?: (row: RowData, rowIndex: number) => string | undefined`
+
+`LunaTableColumn<RowData>` supports:
+- `id?: string`
+- `header: React.ReactNode`
+- `accessorKey?: Extract<keyof RowData, string>`
+- `renderCell?: (row: RowData, rowIndex: number) => React.ReactNode`
+- `align?: "left" | "center" | "right"`
+- `width?: string`
+- `headerClassName?: string`
+- `cellClassName?: string`
+
+## Contract
+
+- `columns` define the table header and the cell renderer for each column
+- `accessorKey` reads plain row values directly
+- `renderCell` handles richer cell content such as badges, actions, or stacked text
+- `getRowKey` should be supplied for stable row identity when the data has a natural key
+- `getRowClassName` decorates body rows without changing the base table contract
+- `emptyState` renders a single row that spans all columns
+- the root scroll shell allows horizontal overflow without changing the inner table semantics
+
+## Theme Integration
+
+`LunaTable` uses the shared theme tokens for:
+- surface background
+- foreground and muted text
+- borders and dividers
+- spacing
+- radius
+- shadow
+
+Consumers can override the component with table-specific custom properties such as:
+- `--luna-table-bg`
+- `--luna-table-border`
+- `--luna-table-header-bg`
+- `--luna-table-header-fg`
+- `--luna-table-divider`
+- `--luna-table-caption-fg`
+- `--luna-table-empty-fg`

--- a/playwright/storybook/manifests/luna-table.json
+++ b/playwright/storybook/manifests/luna-table.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunatable--basic",
+    "fileName": "luna-table-basic",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunatable--density",
+    "fileName": "luna-table-density",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunatable--empty-state",
+    "fileName": "luna-table-empty-state",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunatable--sticky-header",
+    "fileName": "luna-table-sticky-header",
+    "backgrounds": ["light"]
+  }
+]

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { storybookCaptures } from "./manifest";
 
@@ -7,6 +7,22 @@ const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
 const requestedComponent = process.env.STORYBOOK_COMPONENT?.trim();
 
 type StoryCapture = (typeof storybookCaptures)[number];
+
+function loadBranchManifest(componentSlug: string): StoryCapture[] | null {
+  const manifestPath = join(
+    process.cwd(),
+    "playwright",
+    "storybook",
+    "manifests",
+    `${componentSlug}.json`
+  );
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as StoryCapture[];
+}
 
 function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] {
   const normalizedComponent = componentSlug.replace(/-/g, "");
@@ -31,7 +47,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 
 const captures =
   requestedComponent && requestedComponent.length > 0
-    ? buildCapturesFromStorybookIndex(requestedComponent)
+    ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
     : storybookCaptures;
 
 for (const capture of captures) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,7 @@ export * from "./luna-autocomplete";
 export * from "./luna-skeleton";
 export * from "./luna-spinner";
 export * from "./luna-switch";
+export * from "./luna-table";
 export * from "./luna-tag";
 export * from "./luna-text";
 export * from "./luna-row";

--- a/src/components/luna-table/LunaTable.css
+++ b/src/components/luna-table/LunaTable.css
@@ -1,0 +1,103 @@
+.luna-table {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--luna-table-border, var(--luna-border));
+  border-radius: var(--luna-table-radius, var(--luna-radius-lg));
+  background: var(--luna-table-bg, var(--luna-surface));
+  box-shadow: var(--luna-table-shadow, var(--luna-shadow-sm));
+}
+
+.luna-table__table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  color: var(--luna-table-fg, var(--luna-foreground));
+}
+
+.luna-table__caption {
+  padding: var(--luna-space-4) var(--luna-space-4) var(--luna-space-3);
+  color: var(--luna-table-caption-fg, var(--luna-muted));
+  font-size: var(--luna-font-size-sm, 0.875rem);
+  text-align: left;
+  caption-side: top;
+}
+
+.luna-table__header,
+.luna-table__cell,
+.luna-table__empty {
+  padding: var(--luna-table-cell-padding-y, var(--luna-space-3))
+    var(--luna-table-cell-padding-x, var(--luna-space-4));
+  text-align: left;
+}
+
+.luna-table__header {
+  position: relative;
+  z-index: 1;
+  border-bottom: 1px solid var(--luna-table-divider, var(--luna-border));
+  background: var(
+    --luna-table-header-bg,
+    color-mix(in srgb, var(--luna-table-bg, var(--luna-surface)) 82%, var(--luna-background))
+  );
+  color: var(--luna-table-header-fg, var(--luna-foreground));
+  font-size: var(--luna-font-size-xs, 0.75rem);
+  font-weight: var(--luna-font-weight-semibold, 600);
+  letter-spacing: 0.04em;
+  line-height: var(--luna-line-height-normal, 1.4);
+  text-transform: uppercase;
+}
+
+.luna-table__cell,
+.luna-table__empty {
+  border-bottom: 1px solid var(--luna-table-divider, var(--luna-border));
+  font-size: var(--luna-font-size-sm, 0.875rem);
+  line-height: var(--luna-line-height-relaxed, 1.6);
+  vertical-align: middle;
+}
+
+.luna-table__body .luna-table__row:last-child .luna-table__cell,
+.luna-table__body .luna-table__row:last-child .luna-table__empty {
+  border-bottom: 0;
+}
+
+.luna-table__header[data-align="center"],
+.luna-table__cell[data-align="center"] {
+  text-align: center;
+}
+
+.luna-table__header[data-align="right"],
+.luna-table__cell[data-align="right"] {
+  text-align: right;
+}
+
+.luna-table--striped .luna-table__body .luna-table__row:nth-child(even) .luna-table__cell {
+  background: color-mix(in srgb, var(--luna-table-bg, var(--luna-surface)) 88%, var(--luna-foreground) 4%);
+}
+
+.luna-table--hoverable .luna-table__body .luna-table__row:hover .luna-table__cell {
+  background: color-mix(in srgb, var(--luna-table-bg, var(--luna-surface)) 76%, var(--luna-color-primary-500) 10%);
+}
+
+.luna-table--sticky-header .luna-table__header {
+  position: sticky;
+  top: 0;
+}
+
+.luna-table__empty {
+  color: var(--luna-table-empty-fg, var(--luna-muted));
+  text-align: center;
+}
+
+.luna-table[data-density="compact"] .luna-table__header,
+.luna-table[data-density="compact"] .luna-table__cell,
+.luna-table[data-density="compact"] .luna-table__empty {
+  --luna-table-cell-padding-y: var(--luna-space-2);
+  --luna-table-cell-padding-x: var(--luna-space-3);
+}
+
+.luna-table[data-density="comfortable"] .luna-table__header,
+.luna-table[data-density="comfortable"] .luna-table__cell,
+.luna-table[data-density="comfortable"] .luna-table__empty {
+  --luna-table-cell-padding-y: var(--luna-space-4);
+  --luna-table-cell-padding-x: var(--luna-space-5);
+}

--- a/src/components/luna-table/LunaTable.props.ts
+++ b/src/components/luna-table/LunaTable.props.ts
@@ -1,0 +1,31 @@
+import type React from "react";
+
+export type LunaTableAlign = "left" | "center" | "right";
+export type LunaTableDensity = "compact" | "default" | "comfortable";
+
+export type LunaTableColumn<RowData extends Record<string, unknown>> = {
+  id?: string;
+  header: React.ReactNode;
+  accessorKey?: Extract<keyof RowData, string>;
+  renderCell?: (row: RowData, rowIndex: number) => React.ReactNode;
+  align?: LunaTableAlign;
+  width?: string;
+  headerClassName?: string;
+  cellClassName?: string;
+};
+
+export type LunaTableProps<RowData extends Record<string, unknown>> = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> & {
+  columns: Array<LunaTableColumn<RowData>>;
+  rows: RowData[];
+  caption?: React.ReactNode;
+  emptyState?: React.ReactNode;
+  density?: LunaTableDensity;
+  striped?: boolean;
+  hoverable?: boolean;
+  stickyHeader?: boolean;
+  getRowKey?: (row: RowData, rowIndex: number) => React.Key;
+  getRowClassName?: (row: RowData, rowIndex: number) => string | undefined;
+};

--- a/src/components/luna-table/LunaTable.stories.tsx
+++ b/src/components/luna-table/LunaTable.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaBadge } from "../luna-badge";
+import { LunaButton } from "../luna-button";
+import { LunaColumn } from "../luna-column";
+import { LunaText } from "../luna-text";
+import { LunaTable } from "./LunaTable";
+import type { LunaTableColumn } from "./LunaTable.props";
+
+type MissionRow = {
+  id: string;
+  pilot: string;
+  status: "Ready" | "Holding" | "Delayed";
+  window: string;
+  cargo: string;
+};
+
+const rows: MissionRow[] = [
+  {
+    id: "mission-1",
+    pilot: "Aria Sol",
+    status: "Ready",
+    window: "03:10 UTC",
+    cargo: "Navigation relays"
+  },
+  {
+    id: "mission-2",
+    pilot: "Kellan Voss",
+    status: "Holding",
+    window: "05:40 UTC",
+    cargo: "Thermal batteries"
+  },
+  {
+    id: "mission-3",
+    pilot: "Mira Quill",
+    status: "Delayed",
+    window: "08:15 UTC",
+    cargo: "Orbital survey kits"
+  }
+];
+
+const columns: Array<LunaTableColumn<MissionRow>> = [
+  {
+    accessorKey: "pilot",
+    header: "Pilot",
+    width: "22%"
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    renderCell: (row) => (
+      <LunaBadge
+        tone={
+          row.status === "Ready"
+            ? "success"
+            : row.status === "Holding"
+              ? "warning"
+              : "danger"
+        }
+        variant="soft"
+      >
+        {row.status}
+      </LunaBadge>
+    )
+  },
+  {
+    accessorKey: "window",
+    header: "Launch window",
+    align: "center"
+  },
+  {
+    accessorKey: "cargo",
+    header: "Cargo"
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    align: "right",
+    renderCell: (row) => (
+      <LunaButton flat size="small">
+        View {row.id}
+      </LunaButton>
+    )
+  }
+];
+
+const meta = {
+  title: "Components/LunaTable",
+  component: LunaTable,
+  args: {
+    caption: "Launch coordination roster for the next departure block.",
+    columns,
+    rows
+  }
+} satisfies Meta<typeof LunaTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: (args) => <LunaTable {...args} getRowKey={(row) => row.id} hoverable striped />
+};
+
+export const Density: Story = {
+  render: () => (
+    <LunaColumn gap="4">
+      <LunaTable caption="Compact density" columns={columns} density="compact" rows={rows} />
+      <LunaTable caption="Default density" columns={columns} density="default" rows={rows} />
+      <LunaTable
+        caption="Comfortable density"
+        columns={columns}
+        density="comfortable"
+        rows={rows}
+      />
+    </LunaColumn>
+  )
+};
+
+export const EmptyState: Story = {
+  render: () => (
+    <LunaTable
+      caption="No missions are queued for this window."
+      columns={columns}
+      emptyState={
+        <LunaText variant="body-small" muted>
+          No departures are scheduled yet. Assign a pilot to begin the roster.
+        </LunaText>
+      }
+      rows={[]}
+    />
+  )
+};
+
+export const StickyHeader: Story = {
+  render: () => {
+    const extendedRows = Array.from({ length: 10 }, (_, index) => ({
+      ...rows[index % rows.length],
+      id: `${rows[index % rows.length].id}-${index + 1}`
+    }));
+
+    return (
+      <div style={{ maxHeight: "20rem", overflow: "auto" }}>
+        <LunaTable
+          caption="Sticky headers stay visible inside a bounded scroll region."
+          columns={columns}
+          getRowKey={(row) => row.id}
+          rows={extendedRows}
+          stickyHeader
+        />
+      </div>
+    );
+  }
+};

--- a/src/components/luna-table/LunaTable.test.tsx
+++ b/src/components/luna-table/LunaTable.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaTable } from "./LunaTable";
+import type { LunaTableColumn } from "./LunaTable.props";
+
+type MissionRow = {
+  id: string;
+  pilot: string;
+  status: string;
+  window: string;
+};
+
+const columns: Array<LunaTableColumn<MissionRow>> = [
+  { accessorKey: "pilot", header: "Pilot" },
+  { accessorKey: "status", header: "Status", align: "center" },
+  { accessorKey: "window", header: "Window", align: "right", width: "10rem" },
+  {
+    id: "actions",
+    header: "Actions",
+    align: "right",
+    renderCell: (row) => <button type="button">View {row.id}</button>
+  }
+];
+
+const rows: MissionRow[] = [
+  {
+    id: "mission-1",
+    pilot: "Aria Sol",
+    status: "Ready",
+    window: "03:10 UTC"
+  }
+];
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaTable", () => {
+  it("renders semantic table markup with caption, headers, and cells", () => {
+    renderWithTheme(
+      <LunaTable caption="Launch roster" columns={columns} getRowKey={(row) => row.id} rows={rows} />
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("Launch roster").tagName).toBe("CAPTION");
+    expect(screen.getByRole("columnheader", { name: "Pilot" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Aria Sol" })).toBeInTheDocument();
+  });
+
+  it("uses renderCell when provided", () => {
+    renderWithTheme(
+      <LunaTable columns={columns} getRowKey={(row) => row.id} rows={rows} />
+    );
+
+    expect(screen.getByRole("button", { name: "View mission-1" })).toBeInTheDocument();
+  });
+
+  it("renders the empty state across all columns", () => {
+    renderWithTheme(
+      <LunaTable columns={columns} emptyState="No missions queued." rows={[]} />
+    );
+
+    const emptyCell = screen.getByText("No missions queued.");
+
+    expect(emptyCell).toHaveAttribute("colspan", String(columns.length));
+  });
+
+  it("applies density and modifier flags to the root", () => {
+    renderWithTheme(
+      <LunaTable
+        columns={columns}
+        density="comfortable"
+        hoverable
+        rows={rows}
+        stickyHeader
+        striped
+      />
+    );
+
+    const root = screen.getByRole("table").closest(".luna-table");
+
+    expect(root).toHaveAttribute("data-density", "comfortable");
+    expect(root?.className).toContain("luna-table--hoverable");
+    expect(root?.className).toContain("luna-table--striped");
+    expect(root?.className).toContain("luna-table--sticky-header");
+  });
+
+  it("applies alignment and width styles to the configured column", () => {
+    renderWithTheme(<LunaTable columns={columns} rows={rows} />);
+
+    const rightAlignedHeader = screen.getByRole("columnheader", { name: "Window" });
+    const bodyRow = screen.getByRole("row", { name: /Aria Sol/ });
+    const rightAlignedCell = within(bodyRow).getByRole("cell", { name: "03:10 UTC" });
+
+    expect(rightAlignedHeader).toHaveAttribute("data-align", "right");
+    expect(rightAlignedHeader).toHaveStyle({ width: "10rem" });
+    expect(rightAlignedCell).toHaveAttribute("data-align", "right");
+    expect(rightAlignedCell).toHaveStyle({ width: "10rem" });
+  });
+
+  it("uses getRowClassName to decorate rendered rows", () => {
+    renderWithTheme(
+      <LunaTable
+        columns={columns}
+        getRowClassName={(row) => (row.status === "Ready" ? "mission-ready" : undefined)}
+        rows={rows}
+      />
+    );
+
+    expect(screen.getByRole("row", { name: /Aria Sol/ })).toHaveClass("mission-ready");
+  });
+});

--- a/src/components/luna-table/LunaTable.tsx
+++ b/src/components/luna-table/LunaTable.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import type { LunaTableColumn, LunaTableProps } from "./LunaTable.props";
+import "./LunaTable.css";
+
+type LunaTableComponent = <RowData extends Record<string, unknown>>(
+  props: LunaTableProps<RowData> & React.RefAttributes<HTMLDivElement>
+) => React.ReactElement | null;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function getColumnId<RowData extends Record<string, unknown>>(
+  column: LunaTableColumn<RowData>,
+  index: number
+) {
+  return column.id ?? column.accessorKey ?? `column-${index}`;
+}
+
+function getCellContent<RowData extends Record<string, unknown>>(
+  column: LunaTableColumn<RowData>,
+  row: RowData,
+  rowIndex: number
+) {
+  if (column.renderCell) {
+    return column.renderCell(row, rowIndex);
+  }
+
+  if (column.accessorKey) {
+    return row[column.accessorKey] as React.ReactNode;
+  }
+
+  return null;
+}
+
+export const LunaTable = React.forwardRef(function LunaTableInner<
+  RowData extends Record<string, unknown>
+>(
+  {
+    caption,
+    className,
+    columns,
+    density = "default",
+    emptyState = "No rows to display.",
+    getRowClassName,
+    getRowKey,
+    hoverable,
+    rows,
+    stickyHeader,
+    striped,
+    style,
+    ...props
+  }: LunaTableProps<RowData>,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
+  const rootClassName = toClassName([
+    "luna-table",
+    striped && "luna-table--striped",
+    hoverable && "luna-table--hoverable",
+    stickyHeader && "luna-table--sticky-header",
+    className
+  ]);
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      className={rootClassName}
+      data-density={density}
+      style={style}
+    >
+      <table className="luna-table__table">
+        {caption ? <caption className="luna-table__caption">{caption}</caption> : null}
+        <thead className="luna-table__head">
+          <tr className="luna-table__row luna-table__row--head">
+            {columns.map((column, columnIndex) => (
+              <th
+                className={toClassName([
+                  "luna-table__header",
+                  column.headerClassName
+                ])}
+                data-align={column.align ?? "left"}
+                key={getColumnId(column, columnIndex)}
+                scope="col"
+                style={column.width ? { width: column.width } : undefined}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="luna-table__body">
+          {rows.length > 0 ? (
+            rows.map((row, rowIndex) => (
+              <tr
+                className={toClassName([
+                  "luna-table__row",
+                  getRowClassName?.(row, rowIndex)
+                ])}
+                key={getRowKey?.(row, rowIndex) ?? rowIndex}
+              >
+                {columns.map((column, columnIndex) => (
+                  <td
+                    className={toClassName([
+                      "luna-table__cell",
+                      column.cellClassName
+                    ])}
+                    data-align={column.align ?? "left"}
+                    key={`${getColumnId(column, columnIndex)}-${rowIndex}`}
+                    style={column.width ? { width: column.width } : undefined}
+                  >
+                    {getCellContent(column, row, rowIndex)}
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : (
+            <tr className="luna-table__row luna-table__row--empty">
+              <td className="luna-table__empty" colSpan={columns.length || 1}>
+                {emptyState}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}) as LunaTableComponent;

--- a/src/components/luna-table/index.ts
+++ b/src/components/luna-table/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaTable";
+export * from "./LunaTable.props";


### PR DESCRIPTION
storybook-component: luna-table

Closes #24

## Summary
Implemented `LunaTable` as a bounded V1 composite with semantic table markup inside a scroll shell, column definitions, custom cell rendering, row keys, density options, sticky headers, and empty-state coverage.

This branch also uses a branch-local Storybook manifest for table screenshots instead of rewriting the shared manifest.

## Verification
- `npm test -- src/components/luna-table/LunaTable.test.tsx`
- `npm run build`
- `npm run storybook:build`
