### PR TITLE
Resolve #25: Build LunaPagination composite

### DIFF
--- a/.changeset/luna-pagination-composite.md
+++ b/.changeset/luna-pagination-composite.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaPagination` composite with Storybook coverage, tests, and public documentation.

--- a/docs/v1/components/LunaPagination.md
+++ b/docs/v1/components/LunaPagination.md
@@ -1,0 +1,48 @@
+# LunaPagination
+
+`LunaPagination` is the controlled page-navigation composite for `react-luna`.
+
+It owns:
+- navigation landmark semantics
+- collapsed page-range rendering with ellipsis gaps
+- previous and next page controls
+- current-page treatment
+- size-aware pagination control layout
+
+## Props
+
+- `currentPage: number`
+- `totalPages: number`
+- `onPageChange?: (page: number) => void`
+- `siblingCount?: number`
+- `boundaryCount?: number`
+- `showPreviousNext?: boolean`
+- `disabled?: boolean`
+- `size?: "sm" | "md" | "lg"`
+- `ariaLabel?: string`
+- `previousLabel?: React.ReactNode`
+- `nextLabel?: React.ReactNode`
+
+`className`, `style`, and other root `nav` attributes pass through to the navigation element.
+
+## Contract
+
+- `LunaPagination` is controlled; `currentPage` is the active page and `onPageChange` reports requested page changes
+- `totalPages <= 0` renders nothing
+- page ranges collapse with ellipsis when the full set would be too wide
+- `siblingCount` controls how many pages stay visible on each side of the current page
+- `boundaryCount` controls how many pages stay visible at the beginning and end of the range
+- a single hidden page is shown directly instead of replaced by an ellipsis
+- the current page sets `aria-current="page"`
+- previous and next controls disable at the range boundaries
+- `showPreviousNext={false}` renders the page list without directional controls
+- `disabled` disables all interactive controls without changing the visible range
+
+## Theme Integration
+
+`LunaPagination` is styled through local CSS variables layered on top of the shared button and theme tokens for:
+- page-control gap
+- inactive control background, border, and foreground
+- current-page background and foreground
+- compact and large control minimum widths
+- ellipsis color

--- a/playwright/storybook/manifests/luna-pagination.json
+++ b/playwright/storybook/manifests/luna-pagination.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunapagination--basic",
+    "fileName": "luna-pagination-basic",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunapagination--compact",
+    "fileName": "luna-pagination-compact",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunapagination--dense-range",
+    "fileName": "luna-pagination-dense-range",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunapagination--disabled",
+    "fileName": "luna-pagination-disabled",
+    "backgrounds": ["light"]
+  }
+]

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { storybookCaptures } from "./manifest";
 
@@ -7,6 +7,22 @@ const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
 const requestedComponent = process.env.STORYBOOK_COMPONENT?.trim();
 
 type StoryCapture = (typeof storybookCaptures)[number];
+
+function loadBranchManifest(componentSlug: string): StoryCapture[] | null {
+  const manifestPath = join(
+    process.cwd(),
+    "playwright",
+    "storybook",
+    "manifests",
+    `${componentSlug}.json`
+  );
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as StoryCapture[];
+}
 
 function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] {
   const normalizedComponent = componentSlug.replace(/-/g, "");
@@ -31,7 +47,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 
 const captures =
   requestedComponent && requestedComponent.length > 0
-    ? buildCapturesFromStorybookIndex(requestedComponent)
+    ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
     : storybookCaptures;
 
 for (const capture of captures) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,3 +26,4 @@ export * from "./luna-text";
 export * from "./luna-row";
 export * from "./luna-column";
 export * from "./luna-grid";
+export * from "./luna-pagination";

--- a/src/components/luna-pagination/LunaPagination.css
+++ b/src/components/luna-pagination/LunaPagination.css
@@ -1,0 +1,74 @@
+.luna-pagination {
+  display: flex;
+  width: 100%;
+}
+
+.luna-pagination__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--luna-pagination-gap, var(--luna-space-2, 0.5rem));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.luna-pagination__item {
+  display: flex;
+  align-items: center;
+}
+
+.luna-pagination__control {
+  --luna-btn-bg: var(--luna-pagination-control-bg, transparent);
+  --luna-btn-hover-bg: var(
+    --luna-pagination-control-hover-bg,
+    color-mix(in srgb, var(--luna-foreground, #101828) 8%, transparent)
+  );
+  --luna-btn-outline-border: var(--luna-pagination-control-border, var(--luna-border, #d0d5dd));
+  --luna-btn-outline-fg: var(--luna-pagination-control-fg, var(--luna-foreground, #101828));
+  min-width: var(--luna-pagination-control-min-width, 2.5rem);
+  box-shadow: none;
+}
+
+.luna-pagination__control--current {
+  --luna-btn-bg: var(
+    --luna-pagination-current-bg,
+    var(--luna-btn-bg-default, var(--luna-color-primary-600, #4f46e5))
+  );
+  --luna-btn-hover-bg: var(
+    --luna-pagination-current-hover-bg,
+    color-mix(in srgb, var(--luna-pagination-current-bg, var(--luna-btn-bg-default, var(--luna-color-primary-600, #4f46e5))) 88%, #000000)
+  );
+  color: var(--luna-pagination-current-fg, var(--luna-btn-fg-default, #ffffff));
+}
+
+.luna-pagination__control--direction {
+  min-width: var(--luna-pagination-direction-min-width, 5.75rem);
+}
+
+.luna-pagination__ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--luna-pagination-control-min-width, 2.5rem);
+  color: var(--luna-pagination-ellipsis-fg, var(--luna-muted-foreground, var(--luna-foreground, #101828)));
+  font-size: var(--luna-pagination-ellipsis-font-size, var(--luna-font-size-sm, 0.875rem));
+}
+
+.luna-pagination[data-size="sm"] .luna-pagination__control,
+.luna-pagination[data-size="sm"] .luna-pagination__ellipsis {
+  min-width: var(--luna-pagination-control-min-width-sm, 2rem);
+}
+
+.luna-pagination[data-size="sm"] .luna-pagination__control--direction {
+  min-width: var(--luna-pagination-direction-min-width-sm, 4.75rem);
+}
+
+.luna-pagination[data-size="lg"] .luna-pagination__control,
+.luna-pagination[data-size="lg"] .luna-pagination__ellipsis {
+  min-width: var(--luna-pagination-control-min-width-lg, 3rem);
+}
+
+.luna-pagination[data-size="lg"] .luna-pagination__control--direction {
+  min-width: var(--luna-pagination-direction-min-width-lg, 6.5rem);
+}

--- a/src/components/luna-pagination/LunaPagination.props.ts
+++ b/src/components/luna-pagination/LunaPagination.props.ts
@@ -1,0 +1,17 @@
+import type React from "react";
+
+export type LunaPaginationSize = "sm" | "md" | "lg";
+
+export type LunaPaginationProps = Omit<React.HTMLAttributes<HTMLElement>, "children"> & {
+  currentPage: number;
+  totalPages: number;
+  onPageChange?: (page: number) => void;
+  siblingCount?: number;
+  boundaryCount?: number;
+  showPreviousNext?: boolean;
+  disabled?: boolean;
+  size?: LunaPaginationSize;
+  ariaLabel?: string;
+  previousLabel?: React.ReactNode;
+  nextLabel?: React.ReactNode;
+};

--- a/src/components/luna-pagination/LunaPagination.stories.tsx
+++ b/src/components/luna-pagination/LunaPagination.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaColumn } from "../luna-column";
+import { LunaText } from "../luna-text";
+import { LunaPagination } from "./LunaPagination";
+
+const meta = {
+  title: "Components/LunaPagination",
+  component: LunaPagination,
+  args: {
+    currentPage: 1,
+    totalPages: 8,
+    siblingCount: 1,
+    boundaryCount: 1,
+    showPreviousNext: true,
+    size: "md"
+  }
+} satisfies Meta<typeof LunaPagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function StatefulPagination(args: React.ComponentProps<typeof LunaPagination>) {
+  const [page, setPage] = React.useState(args.currentPage);
+
+  React.useEffect(() => {
+    setPage(args.currentPage);
+  }, [args.currentPage]);
+
+  return (
+    <LunaColumn gap="3">
+      <LunaPagination {...args} currentPage={page} onPageChange={setPage} />
+      <LunaText variant="body-small" muted>
+        Current page: {page}
+      </LunaText>
+    </LunaColumn>
+  );
+}
+
+export const Basic: Story = {
+  render: (args) => <StatefulPagination {...args} />
+};
+
+export const DenseRange: Story = {
+  args: {
+    currentPage: 9,
+    totalPages: 18,
+    boundaryCount: 2,
+    siblingCount: 2
+  },
+  render: (args) => <StatefulPagination {...args} />
+};
+
+export const Compact: Story = {
+  args: {
+    currentPage: 3,
+    totalPages: 7,
+    size: "sm",
+    showPreviousNext: false
+  },
+  render: (args) => (
+    <div style={{ maxWidth: "18rem" }}>
+      <StatefulPagination {...args} />
+    </div>
+  )
+};
+
+export const Disabled: Story = {
+  args: {
+    currentPage: 4,
+    totalPages: 12,
+    disabled: true
+  }
+};

--- a/src/components/luna-pagination/LunaPagination.test.tsx
+++ b/src/components/luna-pagination/LunaPagination.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaPagination } from "./LunaPagination";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("LunaPagination", () => {
+  it("renders a collapsed page range with the current page marked", () => {
+    renderWithTheme(<LunaPagination currentPage={5} totalPages={10} />);
+
+    const navigation = screen.getByRole("navigation", { name: "Pagination" });
+    const currentPage = screen.getByRole("button", { name: "Current page, page 5" });
+
+    expect(navigation).toBeInTheDocument();
+    expect(currentPage).toHaveAttribute("aria-current", "page");
+    expect(screen.getAllByText("…")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Go to page 2" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to page 4" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to page 10" })).toBeInTheDocument();
+  });
+
+  it("calls onPageChange for previous, next, and direct page selection", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    renderWithTheme(
+      <LunaPagination currentPage={3} totalPages={6} onPageChange={onPageChange} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Go to previous page" }));
+    await user.click(screen.getByRole("button", { name: "Go to next page" }));
+    await user.click(screen.getByRole("button", { name: "Go to page 6" }));
+
+    expect(onPageChange).toHaveBeenCalledTimes(3);
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 2);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 4);
+    expect(onPageChange).toHaveBeenNthCalledWith(3, 6);
+  });
+
+  it("does not fire changes for the current page or disabled boundary controls", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    renderWithTheme(
+      <LunaPagination currentPage={1} totalPages={4} onPageChange={onPageChange} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Current page, page 1" }));
+    await user.click(screen.getByRole("button", { name: "Go to previous page" }));
+
+    expect(onPageChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Go to previous page" })).toBeDisabled();
+  });
+
+  it("supports compact sizing and hiding the directional controls", () => {
+    renderWithTheme(
+      <LunaPagination
+        currentPage={2}
+        totalPages={5}
+        size="sm"
+        showPreviousNext={false}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Go to previous page" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Current page, page 2" })).toHaveAttribute(
+      "data-size",
+      "small"
+    );
+  });
+
+  it("returns nothing when there are no pages to render", () => {
+    renderWithTheme(<LunaPagination currentPage={1} totalPages={0} />);
+
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/luna-pagination/LunaPagination.tsx
+++ b/src/components/luna-pagination/LunaPagination.tsx
@@ -1,0 +1,225 @@
+import React from "react";
+import { LunaButton } from "../luna-button";
+import type { LunaPaginationProps, LunaPaginationSize } from "./LunaPagination.props";
+import "./LunaPagination.css";
+
+type PaginationItem = number | "ellipsis";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function normalizeInteger(value: number, fallback: number) {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.trunc(value);
+}
+
+function normalizeNonNegativeInteger(value: number, fallback: number) {
+  return Math.max(0, normalizeInteger(value, fallback));
+}
+
+function clampPage(page: number, totalPages: number) {
+  if (totalPages < 1) {
+    return 0;
+  }
+
+  return Math.min(Math.max(page, 1), totalPages);
+}
+
+function buildPaginationItems(
+  currentPage: number,
+  totalPages: number,
+  siblingCount: number,
+  boundaryCount: number
+) {
+  const pages = new Set<number>();
+
+  for (let page = 1; page <= Math.min(boundaryCount, totalPages); page += 1) {
+    pages.add(page);
+  }
+
+  for (
+    let page = Math.max(totalPages - boundaryCount + 1, 1);
+    page <= totalPages;
+    page += 1
+  ) {
+    pages.add(page);
+  }
+
+  for (
+    let page = Math.max(currentPage - siblingCount, 1);
+    page <= Math.min(currentPage + siblingCount, totalPages);
+    page += 1
+  ) {
+    pages.add(page);
+  }
+
+  pages.add(1);
+  pages.add(totalPages);
+
+  const sortedPages = [...pages].sort((left, right) => left - right);
+  const items: PaginationItem[] = [];
+
+  sortedPages.forEach((page, index) => {
+    if (index === 0) {
+      items.push(page);
+      return;
+    }
+
+    const previousPage = sortedPages[index - 1];
+    const gap = page - previousPage;
+
+    if (gap === 2) {
+      items.push(previousPage + 1);
+    } else if (gap > 2) {
+      items.push("ellipsis");
+    }
+
+    items.push(page);
+  });
+
+  return items;
+}
+
+function resolveButtonSize(size: LunaPaginationSize | undefined) {
+  if (size === "sm") {
+    return "small";
+  }
+
+  if (size === "lg") {
+    return "large";
+  }
+
+  return "medium";
+}
+
+export const LunaPagination = React.forwardRef<HTMLElement, LunaPaginationProps>(
+  function LunaPagination(
+    {
+      ariaLabel = "Pagination",
+      boundaryCount = 1,
+      className,
+      currentPage,
+      disabled = false,
+      nextLabel = "Next",
+      onPageChange,
+      previousLabel = "Previous",
+      showPreviousNext = true,
+      siblingCount = 1,
+      size = "md",
+      style,
+      totalPages,
+      ...props
+    },
+    ref
+  ) {
+    const resolvedTotalPages = normalizeNonNegativeInteger(totalPages, 0);
+
+    if (resolvedTotalPages === 0) {
+      return null;
+    }
+
+    const resolvedCurrentPage = clampPage(normalizeInteger(currentPage, 1), resolvedTotalPages);
+    const resolvedSiblingCount = normalizeNonNegativeInteger(siblingCount, 1);
+    const resolvedBoundaryCount = normalizeNonNegativeInteger(boundaryCount, 1);
+    const buttonSize = resolveButtonSize(size);
+    const items = buildPaginationItems(
+      resolvedCurrentPage,
+      resolvedTotalPages,
+      resolvedSiblingCount,
+      resolvedBoundaryCount
+    );
+
+    function handlePageChange(page: number) {
+      if (!onPageChange || disabled || page === resolvedCurrentPage) {
+        return;
+      }
+
+      const nextPage = clampPage(page, resolvedTotalPages);
+
+      if (nextPage !== resolvedCurrentPage) {
+        onPageChange(nextPage);
+      }
+    }
+
+    return (
+      <nav
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-pagination", className])}
+        aria-label={ariaLabel}
+        data-size={size}
+        style={style}
+      >
+        <ul className="luna-pagination__list">
+          {showPreviousNext ? (
+            <li className="luna-pagination__item">
+              <LunaButton
+                outline
+                className="luna-pagination__control luna-pagination__control--direction"
+                size={buttonSize}
+                onClick={() => handlePageChange(resolvedCurrentPage - 1)}
+                disabled={disabled || resolvedCurrentPage <= 1}
+                aria-label="Go to previous page"
+              >
+                {previousLabel}
+              </LunaButton>
+            </li>
+          ) : null}
+          {items.map((item, index) => {
+            if (item === "ellipsis") {
+              return (
+                <li className="luna-pagination__item" key={`ellipsis-${index}`}>
+                  <span
+                    aria-hidden="true"
+                    className="luna-pagination__ellipsis"
+                  >
+                    …
+                  </span>
+                </li>
+              );
+            }
+
+            const isCurrent = item === resolvedCurrentPage;
+
+            return (
+              <li className="luna-pagination__item" key={item}>
+                <LunaButton
+                  className={toClassName([
+                    "luna-pagination__control",
+                    isCurrent && "luna-pagination__control--current"
+                  ])}
+                  outline={!isCurrent}
+                  size={buttonSize}
+                  onClick={() => handlePageChange(item)}
+                  disabled={disabled}
+                  aria-current={isCurrent ? "page" : undefined}
+                  aria-label={isCurrent ? `Current page, page ${item}` : `Go to page ${item}`}
+                >
+                  {item}
+                </LunaButton>
+              </li>
+            );
+          })}
+          {showPreviousNext ? (
+            <li className="luna-pagination__item">
+              <LunaButton
+                outline
+                className="luna-pagination__control luna-pagination__control--direction"
+                size={buttonSize}
+                onClick={() => handlePageChange(resolvedCurrentPage + 1)}
+                disabled={disabled || resolvedCurrentPage >= resolvedTotalPages}
+                aria-label="Go to next page"
+              >
+                {nextLabel}
+              </LunaButton>
+            </li>
+          ) : null}
+        </ul>
+      </nav>
+    );
+  }
+);

--- a/src/components/luna-pagination/index.ts
+++ b/src/components/luna-pagination/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaPagination";
+export * from "./LunaPagination.props";


### PR DESCRIPTION
storybook-component: luna-pagination

Closes #25

## Summary
Implemented `LunaPagination` as a controlled pagination composite with previous/next controls, page windowing with ellipses, compact and dense-range states, disabled behavior, Storybook coverage, tests, and docs.

This branch also uses a branch-local Storybook manifest for pagination screenshots instead of rewriting the shared manifest.

## Verification
- `npm test -- src/components/luna-pagination/LunaPagination.test.tsx`
- `npm run build`
- `npm run storybook:build`
