### PR TITLE
Resolve #29: Build LunaMenu composite

### DIFF
--- a/.changeset/icy-taxis-leave.md
+++ b/.changeset/icy-taxis-leave.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the LunaMenu composite with keyboard navigation, Storybook coverage, tests, and public docs.

--- a/docs/v1/components/LunaMenu.md
+++ b/docs/v1/components/LunaMenu.md
@@ -1,0 +1,56 @@
+# LunaMenu
+
+`LunaMenu` is the lightweight action menu composite for `react-luna`.
+
+It owns:
+- trigger-driven open and close behavior
+- keyboard navigation across menu actions
+- outside-click and `Escape` dismissal
+- theme-aware floating surface and item states
+
+It does not own:
+- portals
+- collision detection
+- nested submenus
+- section headers or dividers
+
+## Props
+
+- `children: React.ReactElement`
+- `items: Array<{ value: string; label: React.ReactNode; description?: React.ReactNode; shortcut?: React.ReactNode; disabled?: boolean; destructive?: boolean; onSelect?: (value: string) => void }>`
+- `open?: boolean`
+- `defaultOpen?: boolean`
+- `onOpenChange?: (open: boolean) => void`
+- `onSelect?: (value: string, item: LunaMenuItem) => void`
+- `placement?: "bottom-start" | "bottom-end"`
+- `menuLabel?: string`
+
+Native `HTMLAttributes<HTMLSpanElement>` continue to pass through to the root wrapper, including `className` and `style`.
+
+## Contract
+
+- `children` must be a single React element trigger
+- the trigger receives `aria-haspopup="menu"` and open-state wiring
+- clicking the trigger toggles the menu
+- `ArrowDown` opens the menu and focuses the first enabled item
+- `ArrowUp` opens the menu and focuses the last enabled item
+- `Escape` closes the menu and returns focus to the trigger
+- disabled items remain visible but are skipped during arrow-key navigation
+- selecting an item closes the menu, restores focus to the trigger, then calls item and menu selection handlers
+- `open` and `onOpenChange` support controlled usage
+- `defaultOpen` supports uncontrolled initial state
+
+## Accessibility Notes
+
+- the surface renders with `role="menu"`
+- each action renders as a button with `role="menuitem"`
+- `menuLabel` provides the accessible name for the menu surface
+- disabled actions use the native button disabled state
+
+## Theme Integration
+
+`LunaMenu` inherits the global theme tokens for:
+- surface background, border, radius, and shadow
+- foreground and muted text colors
+- accent focus styling
+- spacing and motion timing

--- a/playwright/storybook/manifests/luna-menu.json
+++ b/playwright/storybook/manifests/luna-menu.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunamenu--basic",
+    "fileName": "luna-menu-basic",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamenu--controlled",
+    "fileName": "luna-menu-controlled",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamenu--dark-mode",
+    "fileName": "luna-menu-dark-mode",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunamenu--placements",
+    "fileName": "luna-menu-placements",
+    "backgrounds": ["light"]
+  }
+]

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { storybookCaptures } from "./manifest";
 
@@ -7,6 +7,22 @@ const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
 const requestedComponent = process.env.STORYBOOK_COMPONENT?.trim();
 
 type StoryCapture = (typeof storybookCaptures)[number];
+
+function loadBranchManifest(componentSlug: string): StoryCapture[] | null {
+  const manifestPath = join(
+    process.cwd(),
+    "playwright",
+    "storybook",
+    "manifests",
+    `${componentSlug}.json`
+  );
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as StoryCapture[];
+}
 
 function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] {
   const normalizedComponent = componentSlug.replace(/-/g, "");
@@ -31,7 +47,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 
 const captures =
   requestedComponent && requestedComponent.length > 0
-    ? buildCapturesFromStorybookIndex(requestedComponent)
+    ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
     : storybookCaptures;
 
 for (const capture of captures) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export * from "./luna-divider";
 export * from "./luna-empty-state";
 export * from "./luna-header";
 export * from "./luna-input";
+export * from "./luna-menu";
 export * from "./luna-progress";
 export * from "./luna-slider";
 export * from "./luna-textarea";

--- a/src/components/luna-menu/LunaMenu.css
+++ b/src/components/luna-menu/LunaMenu.css
@@ -1,0 +1,100 @@
+.luna-menu {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.luna-menu__surface {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + var(--luna-menu-offset, var(--luna-space-2)));
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: max(12rem, 100%);
+  padding: 0.375rem;
+  border: 1px solid var(--luna-menu-border, var(--luna-border));
+  border-radius: var(--luna-menu-radius, var(--luna-radius-lg));
+  background: var(--luna-menu-bg, var(--luna-surface));
+  box-shadow: var(--luna-menu-shadow, var(--luna-shadow-lg));
+}
+
+.luna-menu[data-placement="bottom-end"] .luna-menu__surface {
+  left: auto;
+  right: 0;
+}
+
+.luna-menu__item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--luna-space-3);
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 0;
+  border-radius: var(--luna-radius-md);
+  background: transparent;
+  color: var(--luna-menu-item-fg, var(--luna-foreground));
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color var(--luna-motion-fast),
+    color var(--luna-motion-fast);
+}
+
+.luna-menu__item:hover,
+.luna-menu__item[data-highlighted="true"] {
+  background: var(
+    --luna-menu-item-hover-bg,
+    color-mix(in srgb, var(--luna-menu-bg, var(--luna-surface)) 86%, var(--luna-color-primary-500))
+  );
+}
+
+.luna-menu__item:focus-visible {
+  outline: 2px solid var(--luna-color-accent-400);
+  outline-offset: 2px;
+}
+
+.luna-menu__item:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.luna-menu__item--destructive {
+  color: var(--luna-menu-item-destructive-fg, var(--luna-color-danger-600, #dc2626));
+}
+
+.luna-menu__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.luna-menu__label {
+  font-family: var(--luna-font-family);
+  font-size: var(--luna-font-size-sm, 0.875rem);
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.luna-menu__description {
+  color: var(--luna-menu-description-fg, var(--luna-muted));
+  font-family: var(--luna-font-family);
+  font-size: var(--luna-text-variant-caption-font-size, 0.75rem);
+  font-weight: var(--luna-text-variant-caption-font-weight, 500);
+  line-height: var(--luna-text-variant-caption-line-height, 1.4);
+}
+
+.luna-menu__shortcut {
+  flex: 0 0 auto;
+  color: var(--luna-menu-shortcut-fg, var(--luna-muted));
+  font-family: var(--luna-font-family);
+  font-size: var(--luna-text-variant-caption-font-size, 0.75rem);
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+}

--- a/src/components/luna-menu/LunaMenu.props.ts
+++ b/src/components/luna-menu/LunaMenu.props.ts
@@ -1,0 +1,27 @@
+import type React from "react";
+
+export type LunaMenuPlacement = "bottom-start" | "bottom-end";
+
+export type LunaMenuItem = {
+  value: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  shortcut?: React.ReactNode;
+  disabled?: boolean;
+  destructive?: boolean;
+  onSelect?: (value: string) => void;
+};
+
+export type LunaMenuProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children" | "onSelect"
+> & {
+  children: React.ReactElement;
+  items: LunaMenuItem[];
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSelect?: (value: string, item: LunaMenuItem) => void;
+  placement?: LunaMenuPlacement;
+  menuLabel?: string;
+};

--- a/src/components/luna-menu/LunaMenu.stories.tsx
+++ b/src/components/luna-menu/LunaMenu.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ThemeProvider } from "../../theme";
+import { LunaButton } from "../luna-button";
+import { LunaColumn } from "../luna-column";
+import { LunaMenu } from "./LunaMenu";
+
+const items = [
+  {
+    value: "rename",
+    label: "Rename mission",
+    description: "Update the shared mission title for the whole crew.",
+    shortcut: "Shift+R"
+  },
+  {
+    value: "duplicate",
+    label: "Duplicate briefing",
+    description: "Create a fresh copy with all current details."
+  },
+  {
+    value: "share",
+    label: "Share logbook",
+    description: "Invite another reviewer to the current workspace.",
+    disabled: true,
+    shortcut: "Cmd+S"
+  },
+  {
+    value: "archive",
+    label: "Archive mission",
+    description: "Move this mission into long-term storage.",
+    destructive: true
+  }
+];
+
+const meta = {
+  title: "Components/LunaMenu",
+  component: LunaMenu,
+  args: {
+    items,
+    children: <LunaButton>Open menu</LunaButton>
+  }
+} satisfies Meta<typeof LunaMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const Placements: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: "1rem",
+        width: "100%",
+        maxWidth: "40rem"
+      }}
+    >
+      <LunaMenu items={items} placement="bottom-start">
+        <LunaButton>Start aligned</LunaButton>
+      </LunaMenu>
+      <LunaMenu items={items} placement="bottom-end">
+        <LunaButton>End aligned</LunaButton>
+      </LunaMenu>
+    </div>
+  )
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [open, setOpen] = React.useState(false);
+    const [lastAction, setLastAction] = React.useState("No action selected yet.");
+
+    return (
+      <LunaColumn gap="4">
+        <LunaMenu
+          items={items}
+          open={open}
+          onOpenChange={setOpen}
+          onSelect={(value) => {
+            setLastAction(`Selected action: ${value}`);
+          }}
+        >
+          <LunaButton>{open ? "Close menu" : "Open menu"}</LunaButton>
+        </LunaMenu>
+        <div style={{ color: "var(--luna-muted)" }}>{lastAction}</div>
+      </LunaColumn>
+    );
+  }
+};
+
+export const DarkMode: Story = {
+  render: () => (
+    <ThemeProvider mode="dark">
+      <div style={{ padding: "1rem", background: "var(--luna-background)" }}>
+        <LunaMenu items={items}>
+          <LunaButton>Dark surface</LunaButton>
+        </LunaMenu>
+      </div>
+    </ThemeProvider>
+  )
+};

--- a/src/components/luna-menu/LunaMenu.test.tsx
+++ b/src/components/luna-menu/LunaMenu.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaButton } from "../luna-button";
+import { LunaMenu } from "./LunaMenu";
+
+const items = [
+  {
+    value: "rename",
+    label: "Rename mission",
+    description: "Update the mission title."
+  },
+  {
+    value: "share",
+    label: "Share logbook",
+    disabled: true
+  },
+  {
+    value: "archive",
+    label: "Archive mission",
+    destructive: true
+  }
+];
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaMenu", () => {
+  it("opens from the trigger and focuses the first enabled item", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaMenu items={items}>
+        <LunaButton>Open menu</LunaButton>
+      </LunaMenu>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const menu = screen.getByRole("menu", { name: "Menu" });
+    const firstItem = screen.getByRole("menuitem", { name: /Rename mission/i });
+
+    expect(menu).toBeInTheDocument();
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("moves through enabled items with the keyboard and skips disabled entries", async () => {
+    renderWithTheme(
+      <LunaMenu items={items}>
+        <LunaButton>Open menu</LunaButton>
+      </LunaMenu>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const renameItem = screen.getByRole("menuitem", { name: /Rename mission/i });
+    expect(renameItem).toHaveFocus();
+
+    fireEvent.keyDown(renameItem, { key: "ArrowDown" });
+
+    expect(screen.getByRole("menuitem", { name: /Archive mission/i })).toHaveFocus();
+  });
+
+  it("calls selection handlers, closes the menu, and restores focus to the trigger", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onItemSelect = vi.fn();
+
+    renderWithTheme(
+      <LunaMenu
+        items={[
+          {
+            value: "rename",
+            label: "Rename mission",
+            onSelect: onItemSelect
+          }
+        ]}
+        onSelect={onSelect}
+      >
+        <LunaButton>Open menu</LunaButton>
+      </LunaMenu>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("menuitem", { name: "Rename mission" }));
+
+    expect(onItemSelect).toHaveBeenCalledWith("rename");
+    expect(onSelect).toHaveBeenCalledWith("rename", expect.objectContaining({ value: "rename" }));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("supports controlled open state and outside click dismissal", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    renderWithTheme(
+      <div>
+        <LunaMenu items={items} open onOpenChange={onOpenChange}>
+          <LunaButton>Open menu</LunaButton>
+        </LunaMenu>
+        <button type="button">Outside</button>
+      </div>
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("closes on Escape and returns focus to the trigger", () => {
+    renderWithTheme(
+      <LunaMenu items={items}>
+        <LunaButton>Open menu</LunaButton>
+      </LunaMenu>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+
+    fireEvent.click(trigger);
+
+    const renameItem = screen.getByRole("menuitem", { name: /Rename mission/i });
+
+    fireEvent.keyDown(renameItem, { key: "Escape" });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/src/components/luna-menu/LunaMenu.tsx
+++ b/src/components/luna-menu/LunaMenu.tsx
@@ -1,0 +1,332 @@
+import React from "react";
+import type { LunaMenuItem, LunaMenuProps } from "./LunaMenu.props";
+import "./LunaMenu.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function composeEventHandlers<EventType extends React.SyntheticEvent>(
+  originalHandler: ((event: EventType) => void) | undefined,
+  nextHandler: (event: EventType) => void
+) {
+  return (event: EventType) => {
+    originalHandler?.(event);
+
+    if (!event.defaultPrevented) {
+      nextHandler(event);
+    }
+  };
+}
+
+function assignRef<ValueType>(
+  ref: React.ForwardedRef<ValueType> | React.Ref<ValueType> | undefined,
+  value: ValueType | null
+) {
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+
+  if (ref && "current" in ref) {
+    (ref as React.MutableRefObject<ValueType | null>).current = value;
+  }
+}
+
+function getFirstEnabledItemIndex(items: LunaMenuItem[]) {
+  return items.findIndex((item) => !item.disabled);
+}
+
+function getLastEnabledItemIndex(items: LunaMenuItem[]) {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (!items[index]?.disabled) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function getNextEnabledItemIndex(
+  items: LunaMenuItem[],
+  startIndex: number,
+  direction: 1 | -1
+) {
+  if (!items.length) {
+    return -1;
+  }
+
+  let index = startIndex;
+
+  for (let step = 0; step < items.length; step += 1) {
+    index = (index + direction + items.length) % items.length;
+
+    if (!items[index]?.disabled) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+export const LunaMenu = React.forwardRef<HTMLSpanElement, LunaMenuProps>(function LunaMenu(
+  {
+    children,
+    className,
+    defaultOpen = false,
+    items,
+    menuLabel = "Menu",
+    onOpenChange,
+    onSelect,
+    open,
+    placement = "bottom-start",
+    ...props
+  },
+  ref
+) {
+  const rootRef = React.useRef<HTMLSpanElement | null>(null);
+  const triggerRef = React.useRef<HTMLElement | null>(null);
+  const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+  const reactId = React.useId();
+  const menuId = `luna-menu-${reactId.replace(/:/g, "")}`;
+  const isControlled = typeof open === "boolean";
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+  const isOpen = isControlled ? Boolean(open) : internalOpen;
+  const [highlightedIndex, setHighlightedIndex] = React.useState(() =>
+    getFirstEnabledItemIndex(items)
+  );
+
+  const child = React.Children.only(children) as React.ReactElement<any>;
+
+  if (!React.isValidElement(child)) {
+    throw new Error("LunaMenu expects a single React element child.");
+  }
+
+  const childProps = child.props as {
+    disabled?: boolean;
+    onClick?: React.MouseEventHandler<HTMLElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
+    ["aria-disabled"]?: boolean | "true" | "false";
+  };
+  const childIsDisabled =
+    childProps.disabled === true ||
+    childProps["aria-disabled"] === true ||
+    childProps["aria-disabled"] === "true";
+
+  function setMenuOpen(nextOpen: boolean) {
+    if (!isControlled) {
+      setInternalOpen(nextOpen);
+    }
+
+    if (nextOpen !== isOpen) {
+      onOpenChange?.(nextOpen);
+    }
+  }
+
+  function openMenu(targetIndex: number) {
+    if (childIsDisabled) {
+      return;
+    }
+
+    setHighlightedIndex(targetIndex);
+    setMenuOpen(true);
+  }
+
+  function closeMenu({ restoreFocus = false }: { restoreFocus?: boolean } = {}) {
+    setMenuOpen(false);
+
+    if (restoreFocus) {
+      triggerRef.current?.focus();
+    }
+  }
+
+  function selectItem(item: LunaMenuItem) {
+    if (item.disabled) {
+      return;
+    }
+
+    closeMenu({ restoreFocus: true });
+    item.onSelect?.(item.value);
+    onSelect?.(item.value, item);
+  }
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      const target = event.target as Node;
+
+      if (!rootRef.current?.contains(target)) {
+        closeMenu();
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const fallbackIndex = getFirstEnabledItemIndex(items);
+    const nextIndex =
+      highlightedIndex >= 0 && !items[highlightedIndex]?.disabled
+        ? highlightedIndex
+        : fallbackIndex;
+
+    setHighlightedIndex(nextIndex);
+
+    if (nextIndex >= 0) {
+      itemRefs.current[nextIndex]?.focus();
+    }
+  }, [highlightedIndex, isOpen, items]);
+
+  const firstEnabledIndex = getFirstEnabledItemIndex(items);
+  const lastEnabledIndex = getLastEnabledItemIndex(items);
+
+  const trigger = React.cloneElement(child, {
+    "aria-controls": isOpen ? menuId : undefined,
+    "aria-expanded": isOpen ? true : undefined,
+    "aria-haspopup": "menu",
+    onClick: composeEventHandlers(childProps.onClick, (event: React.MouseEvent<HTMLElement>) => {
+      triggerRef.current = event.currentTarget;
+
+      if (isOpen) {
+        closeMenu();
+        return;
+      }
+
+      openMenu(firstEnabledIndex);
+    }),
+    onKeyDown: composeEventHandlers(childProps.onKeyDown, (event: React.KeyboardEvent<HTMLElement>) => {
+      triggerRef.current = event.currentTarget;
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          openMenu(firstEnabledIndex);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          openMenu(lastEnabledIndex);
+          break;
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          if (isOpen) {
+            closeMenu();
+            return;
+          }
+          openMenu(firstEnabledIndex);
+          break;
+        case "Escape":
+          if (isOpen) {
+            event.preventDefault();
+            closeMenu();
+          }
+          break;
+        default:
+          break;
+      }
+    })
+  } as Record<string, unknown>);
+
+  return (
+    <span
+      {...props}
+      ref={(value) => {
+        rootRef.current = value;
+        assignRef(ref, value);
+      }}
+      className={toClassName(["luna-menu", className])}
+      data-open={isOpen ? "true" : "false"}
+      data-placement={placement}
+    >
+      {trigger}
+      {isOpen ? (
+        <div id={menuId} className="luna-menu__surface" role="menu" aria-label={menuLabel}>
+          {items.map((item, index) => (
+            <button
+              key={item.value}
+              ref={(value) => {
+                itemRefs.current[index] = value;
+              }}
+              type="button"
+              role="menuitem"
+              className={toClassName([
+                "luna-menu__item",
+                item.destructive && "luna-menu__item--destructive"
+              ])}
+              data-highlighted={highlightedIndex === index ? "true" : "false"}
+              disabled={item.disabled}
+              tabIndex={highlightedIndex === index ? 0 : -1}
+              onMouseEnter={() => {
+                if (!item.disabled) {
+                  setHighlightedIndex(index);
+                }
+              }}
+              onClick={() => {
+                selectItem(item);
+              }}
+              onKeyDown={(event) => {
+                switch (event.key) {
+                  case "ArrowDown":
+                    event.preventDefault();
+                    setHighlightedIndex((current) =>
+                      getNextEnabledItemIndex(items, current < 0 ? -1 : current, 1)
+                    );
+                    break;
+                  case "ArrowUp":
+                    event.preventDefault();
+                    setHighlightedIndex((current) =>
+                      getNextEnabledItemIndex(
+                        items,
+                        current < 0 ? items.length : current,
+                        -1
+                      )
+                    );
+                    break;
+                  case "Home":
+                    event.preventDefault();
+                    setHighlightedIndex(firstEnabledIndex);
+                    break;
+                  case "End":
+                    event.preventDefault();
+                    setHighlightedIndex(lastEnabledIndex);
+                    break;
+                  case "Escape":
+                    event.preventDefault();
+                    closeMenu({ restoreFocus: true });
+                    break;
+                  case "Tab":
+                    closeMenu();
+                    break;
+                  default:
+                    break;
+                }
+              }}
+            >
+              <span className="luna-menu__body">
+                <span className="luna-menu__label">{item.label}</span>
+                {item.description ? (
+                  <span className="luna-menu__description">{item.description}</span>
+                ) : null}
+              </span>
+              {item.shortcut ? (
+                <span className="luna-menu__shortcut" aria-hidden="true">
+                  {item.shortcut}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </span>
+  );
+});

--- a/src/components/luna-menu/index.ts
+++ b/src/components/luna-menu/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaMenu";
+export * from "./LunaMenu.props";


### PR DESCRIPTION
storybook-component: luna-menu

Closes #29

## Summary
Implemented `LunaMenu` as a scoped composite with a single trigger element, item-array contract, controlled or uncontrolled open state, keyboard navigation, outside-click dismissal, destructive and disabled item states, and focus restoration to the trigger after close.

This branch also uses a branch-local Storybook manifest for menu screenshots instead of rewriting the shared manifest.

## Verification
- `npm test -- src/components/luna-menu/LunaMenu.test.tsx`
- `npm run build`
- `npm run storybook:build`
