### PR TITLE
Resolve #59: Build LunaHoverText primitive

### DIFF
--- a/.changeset/lazy-mails-joke.md
+++ b/.changeset/lazy-mails-joke.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaHoverText` primitive with inline hover and focus copy swapping, Storybook coverage, tests, and docs.

--- a/docs/v1/components/LunaHoverText.md
+++ b/docs/v1/components/LunaHoverText.md
@@ -1,0 +1,62 @@
+# LunaHoverText
+
+`LunaHoverText` is the inline alternate-copy primitive for `react-luna`.
+
+It owns:
+- inline text swaps on hover and focus
+- preserved document flow while the copy changes
+- optional keyboard reachability for otherwise static text
+- theme-resolved base and hover colors
+
+It does not own:
+- floating overlays
+- explanatory tooltip semantics
+- interactive popover content
+- disclosure or click-to-open behavior
+
+## Contract
+
+`LunaHoverText` renders one inline root element and shows alternate copy in place when it becomes active.
+
+Core rules:
+- `children` is the resting copy
+- `hoverContent` is the alternate inline copy
+- the active state opens on pointer hover and focus
+- the component stays inline and never renders `role="tooltip"`
+- `focusable` adds `tabIndex={0}` when the root would otherwise be static text
+- `disabled` suppresses hover and focus activation
+
+## Props
+
+- `as?: React.ElementType`
+- `hoverContent: React.ReactNode`
+- `disabled?: boolean`
+- `focusable?: boolean`
+- `color?: string`
+- `hoverColor?: string`
+
+Native `HTMLAttributes<HTMLElement>` continue to pass through to the root, including `className`, `style`, and event handlers.
+
+## Accessibility Notes
+
+- `LunaHoverText` is not a tooltip and does not wire `aria-describedby`
+- focus behavior only applies when the root can receive focus naturally or through `focusable`
+- the resting and active copy are toggled with `aria-hidden` so only the current inline state is exposed
+
+## Color
+
+`color` and `hoverColor` accept:
+- raw CSS colors such as hex, `rgb`, `hsl`, and `var(...)`
+- theme custom colors
+- theme tokens such as `primary.500`
+
+If omitted, the component inherits the surrounding text color.
+
+## Theme Expectations
+
+`LunaHoverText` does not require a dedicated theme component slice.
+
+It relies on:
+- the shared typography and font-family variables
+- inherited text color by default
+- token resolution when `color` or `hoverColor` are provided

--- a/docs/v1/design/LunaHoverText.md
+++ b/docs/v1/design/LunaHoverText.md
@@ -1,0 +1,33 @@
+# LunaHoverText
+
+## Purpose
+
+`LunaHoverText` provides an inline way to reveal alternate copy without leaving the text flow or creating a floating surface.
+
+## Distinction From Nearby Primitives
+
+The intended split is:
+
+- `LunaHoverText` swaps copy in place
+- `LunaTooltip` describes another element with a floating overlay
+- future popover-style primitives can handle larger or interactive content
+
+That boundary matters because hover text should remain typographic and local, not drift into general overlay behavior.
+
+## Design Rules
+
+- keep the primitive inline by default
+- make hover and focus produce the same content change when the element is keyboard reachable
+- preserve layout stability while copy changes
+- let downstream consumers restyle color through inherited styles or token props
+- do not add placement, arrows, or floating-surface configuration
+
+## Contract Shape
+
+The primitive only needs:
+
+- one resting copy slot
+- one alternate copy slot
+- one optional `focusable` escape hatch for keyboard reachability
+
+Anything beyond that starts to overlap with tooltip or popover responsibilities.

--- a/playwright/storybook/manifests/luna-hover-text.json
+++ b/playwright/storybook/manifests/luna-hover-text.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunahovertext--playground",
+    "fileName": "luna-hover-text-playground",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunahovertext--focusable-inline-copy",
+    "fileName": "luna-hover-text-focusable-inline-copy",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunahovertext--themed-color-shift",
+    "fileName": "luna-hover-text-themed-color-shift",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunahovertext--disabled-state",
+    "fileName": "luna-hover-text-disabled-state",
+    "backgrounds": ["light"]
+  }
+]

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { storybookCaptures } from "./manifest";
 
@@ -7,6 +7,22 @@ const screenshotDir = join(process.cwd(), "artifacts", "storybook-screenshots");
 const requestedComponent = process.env.STORYBOOK_COMPONENT?.trim();
 
 type StoryCapture = (typeof storybookCaptures)[number];
+
+function loadBranchManifest(componentSlug: string): StoryCapture[] | null {
+  const manifestPath = join(
+    process.cwd(),
+    "playwright",
+    "storybook",
+    "manifests",
+    `${componentSlug}.json`
+  );
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as StoryCapture[];
+}
 
 function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] {
   const normalizedComponent = componentSlug.replace(/-/g, "");
@@ -31,7 +47,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 
 const captures =
   requestedComponent && requestedComponent.length > 0
-    ? buildCapturesFromStorybookIndex(requestedComponent)
+    ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
     : storybookCaptures;
 
 for (const capture of captures) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./luna-radio";
 export * from "./luna-divider";
 export * from "./luna-empty-state";
 export * from "./luna-header";
+export * from "./luna-hover-text";
 export * from "./luna-input";
 export * from "./luna-progress";
 export * from "./luna-slider";

--- a/src/components/luna-hover-text/LunaHoverText.css
+++ b/src/components/luna-hover-text/LunaHoverText.css
@@ -1,0 +1,50 @@
+.luna-hover-text {
+  display: inline-grid;
+  grid-template-areas: "content";
+  align-items: center;
+  color: var(--luna-hover-text-color, currentColor);
+  font-family: var(--luna-font-family, inherit);
+  line-height: inherit;
+  vertical-align: middle;
+  cursor: default;
+}
+
+.luna-hover-text[data-focusable="true"] {
+  cursor: pointer;
+}
+
+.luna-hover-text__default,
+.luna-hover-text__hover {
+  grid-area: content;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    color 180ms ease;
+}
+
+.luna-hover-text__default {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.luna-hover-text__hover {
+  opacity: 0;
+  transform: translateY(0.2em);
+  color: var(--luna-hover-text-hover-color, var(--luna-hover-text-color, currentColor));
+}
+
+.luna-hover-text[data-active="true"] .luna-hover-text__default {
+  opacity: 0;
+  transform: translateY(-0.2em);
+}
+
+.luna-hover-text[data-active="true"] .luna-hover-text__hover {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.luna-hover-text:focus-visible {
+  outline: 2px solid var(--luna-focus-ring, rgba(96, 165, 250, 0.45));
+  outline-offset: 0.2em;
+  border-radius: 0.2em;
+}

--- a/src/components/luna-hover-text/LunaHoverText.props.ts
+++ b/src/components/luna-hover-text/LunaHoverText.props.ts
@@ -1,0 +1,10 @@
+import type React from "react";
+
+export type LunaHoverTextProps = Omit<React.HTMLAttributes<HTMLElement>, "color"> & {
+  as?: React.ElementType;
+  hoverContent: React.ReactNode;
+  disabled?: boolean;
+  focusable?: boolean;
+  color?: string;
+  hoverColor?: string;
+};

--- a/src/components/luna-hover-text/LunaHoverText.stories.tsx
+++ b/src/components/luna-hover-text/LunaHoverText.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaHoverText } from "./LunaHoverText";
+
+const meta = {
+  title: "Components/LunaHoverText",
+  component: LunaHoverText,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    children: "Signal stable",
+    hoverContent: "Signal wavering"
+  }
+} satisfies Meta<typeof LunaHoverText>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const FocusableInlineCopy: Story = {
+  args: {
+    focusable: true,
+    children: "Hover or tab to inspect",
+    hoverContent: "Keyboard focus uses the same inline swap"
+  }
+};
+
+export const ThemedColorShift: Story = {
+  args: {
+    focusable: true,
+    color: "neutral.500",
+    hoverColor: "primary.500",
+    children: "Orbit alignment nominal",
+    hoverContent: "Orbit alignment drifting"
+  }
+};
+
+export const DisabledState: Story = {
+  args: {
+    disabled: true,
+    children: "Static readout",
+    hoverContent: "This copy stays hidden while disabled"
+  }
+};

--- a/src/components/luna-hover-text/LunaHoverText.test.tsx
+++ b/src/components/luna-hover-text/LunaHoverText.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaHoverText } from "./LunaHoverText";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaHoverText", () => {
+  it("swaps inline content on hover without tooltip semantics", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(<LunaHoverText hoverContent="Signal wavering">Signal stable</LunaHoverText>);
+
+    const hoverText = screen.getByText("Signal stable").closest(".luna-hover-text");
+
+    if (!hoverText) {
+      throw new Error("Expected LunaHoverText root.");
+    }
+
+    expect(hoverText).toHaveAttribute("data-active", "false");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await user.hover(hoverText);
+
+    expect(hoverText).toHaveAttribute("data-active", "true");
+    expect(screen.getByText("Signal stable")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("Signal wavering")).toHaveAttribute("aria-hidden", "false");
+
+    await user.unhover(hoverText);
+
+    expect(hoverText).toHaveAttribute("data-active", "false");
+  });
+
+  it("supports keyboard activation when focusable is enabled", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaHoverText focusable hoverContent="Keyboard focus activates the swap">
+        Tab to inspect
+      </LunaHoverText>
+    );
+
+    const hoverText = screen.getByText("Tab to inspect").closest(".luna-hover-text");
+
+    if (!hoverText) {
+      throw new Error("Expected LunaHoverText root.");
+    }
+
+    expect(hoverText).toHaveAttribute("tabindex", "0");
+
+    await user.tab();
+
+    expect(hoverText).toHaveFocus();
+    expect(hoverText).toHaveAttribute("data-active", "true");
+
+    await user.tab();
+
+    expect(hoverText).toHaveAttribute("data-active", "false");
+  });
+
+  it("does not activate while disabled", async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(
+      <LunaHoverText disabled focusable hoverContent="Hidden alternate">
+        Static copy
+      </LunaHoverText>
+    );
+
+    const hoverText = screen.getByText("Static copy").closest(".luna-hover-text");
+
+    if (!hoverText) {
+      throw new Error("Expected LunaHoverText root.");
+    }
+
+    await user.hover(hoverText);
+    await user.tab();
+
+    expect(hoverText).toHaveAttribute("data-active", "false");
+  });
+
+  it("resolves theme tokens for base and hover colors", () => {
+    const { container } = renderWithTheme(
+      <LunaHoverText color="primary.500" hoverColor="accent.500" hoverContent="Alternate copy">
+        Base copy
+      </LunaHoverText>
+    );
+
+    const hoverText = container.querySelector(".luna-hover-text");
+
+    expect(hoverText).toHaveStyle({
+      "--luna-hover-text-color": "#6366f1",
+      "--luna-hover-text-hover-color": "#8b5cf6"
+    });
+  });
+});

--- a/src/components/luna-hover-text/LunaHoverText.tsx
+++ b/src/components/luna-hover-text/LunaHoverText.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveTokenValue } from "../../theme/resolve";
+import type { LunaHoverTextProps } from "./LunaHoverText.props";
+import "./LunaHoverText.css";
+
+type HoverTextCssVariable = "--luna-hover-text-color" | "--luna-hover-text-hover-color";
+
+type LunaHoverTextStyle = React.CSSProperties &
+  Partial<Record<HoverTextCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function composeEventHandlers<EventType extends React.SyntheticEvent>(
+  originalHandler: ((event: EventType) => void) | undefined,
+  nextHandler: (event: EventType) => void
+) {
+  return (event: EventType) => {
+    originalHandler?.(event);
+
+    if (!event.defaultPrevented) {
+      nextHandler(event);
+    }
+  };
+}
+
+function resolveColor(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveTokenValue(theme, value);
+}
+
+export const LunaHoverText = React.forwardRef<HTMLElement, LunaHoverTextProps>(function LunaHoverText(
+  {
+    as,
+    children,
+    className,
+    color,
+    disabled = false,
+    focusable = false,
+    hoverColor,
+    hoverContent,
+    onBlur,
+    onFocus,
+    onMouseEnter,
+    onMouseLeave,
+    style,
+    tabIndex,
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const Component = (as ?? "span") as React.ElementType;
+  const [hovered, setHovered] = React.useState(false);
+  const [focused, setFocused] = React.useState(false);
+  const hasHoverContent = hoverContent !== undefined && hoverContent !== null && hoverContent !== false;
+  const active = !disabled && hasHoverContent && (hovered || focused);
+  const resolvedColor = resolveColor(color, theme);
+  const resolvedHoverColor = resolveColor(hoverColor, theme);
+  const resolvedStyle: LunaHoverTextStyle = {
+    ...(resolvedColor ? { ["--luna-hover-text-color" as const]: resolvedColor } : {}),
+    ...(resolvedHoverColor
+      ? { ["--luna-hover-text-hover-color" as const]: resolvedHoverColor }
+      : {}),
+    ...style
+  };
+  const resolvedTabIndex = !disabled && focusable && tabIndex === undefined ? 0 : tabIndex;
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      className={toClassName(["luna-hover-text", className])}
+      data-active={active ? "true" : "false"}
+      data-focusable={focusable ? "true" : "false"}
+      onMouseEnter={composeEventHandlers(onMouseEnter, () => {
+        if (!disabled && hasHoverContent) {
+          setHovered(true);
+        }
+      })}
+      onMouseLeave={composeEventHandlers(onMouseLeave, () => {
+        setHovered(false);
+      })}
+      onFocus={composeEventHandlers(onFocus, () => {
+        if (!disabled && hasHoverContent) {
+          setFocused(true);
+        }
+      })}
+      onBlur={composeEventHandlers(onBlur, (event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          return;
+        }
+
+        setFocused(false);
+      })}
+      style={resolvedStyle}
+      tabIndex={resolvedTabIndex}
+    >
+      <span aria-hidden={active} className="luna-hover-text__default">
+        {children}
+      </span>
+      <span aria-hidden={!active} className="luna-hover-text__hover">
+        {hoverContent}
+      </span>
+    </Component>
+  );
+});

--- a/src/components/luna-hover-text/index.ts
+++ b/src/components/luna-hover-text/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaHoverText";
+export * from "./LunaHoverText.props";


### PR DESCRIPTION
storybook-component: luna-hover-text

Closes #59

## Summary
Implemented `LunaHoverText` as a narrow inline primitive that swaps resting and alternate copy in place on hover or focus, preserves document flow, and stays distinct from tooltip semantics.

This branch also uses a branch-local Storybook manifest for hover-text screenshots instead of rewriting the shared manifest.

## Verification
- `npm test -- src/components/luna-hover-text/LunaHoverText.test.tsx`
- `npm run build`
- `npm run storybook:build`
