### PR TITLE
Resolve #75: Build LunaEmptyState composite

### DIFF
--- a/.changeset/luna-empty-state.md
+++ b/.changeset/luna-empty-state.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaEmptyState` composite with theme-driven media, body, alignment, and action regions.

--- a/docs/v1/components/LunaEmptyState.md
+++ b/docs/v1/components/LunaEmptyState.md
@@ -1,0 +1,51 @@
+# LunaEmptyState
+
+`LunaEmptyState` is the standard reusable no-data and first-run composite for `react-luna`.
+
+It owns:
+- optional media region for an icon or illustration
+- title region
+- body region
+- action region
+- theme-driven framing and spacing
+
+Default element:
+- `section`
+
+## Props
+
+- `as?: React.ElementType`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `media?: React.ReactNode`
+- `actions?: React.ReactNode`
+- `align?: "left" | "center" | "right"`
+- `padding?: string`
+- `gap?: string`
+- `actionsGap?: string`
+- `maxWidth?: string`
+- `rounded?: boolean`
+- `framed?: boolean`
+
+## Contract
+
+- `description` is the simple body prop for common text-only usage
+- `children` can replace `description` when richer body content is needed
+- `media` accepts either a small icon treatment or a larger illustration
+- `actions` accepts one or more call-to-action controls
+- `align` drives layout alignment, text alignment, and action alignment together
+- `framed` controls whether the component renders its own surface treatment
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaEmptyState` consumes the existing `ThemeProvider` for:
+- surface background
+- foreground and muted text color
+- border treatment
+- spacing
+- radius
+- max width
+- media size and media surface treatment
+
+`padding`, `gap`, `actionsGap`, and `maxWidth` resolve through theme spacing first, then raw CSS values.

--- a/docs/v1/design/LunaEmptyState.md
+++ b/docs/v1/design/LunaEmptyState.md
@@ -1,0 +1,119 @@
+# Empty State Design
+
+This document defines the design direction for `LunaEmptyState` before implementation.
+
+`LunaEmptyState` should be the standard composite for no-data and first-run moments in `react-luna`. It should prevent one-off page-level empty states while staying flexible enough for different downstream product tones.
+
+## Design Stance
+
+- Favor one durable composite over several narrow empty-state variants in V1.
+- Keep the content model slot-like and easy to scan.
+- Let theme tokens own framing, spacing, and media treatment.
+- Support both icon-scale and illustration-scale media without hard-coding either approach into the API.
+
+## Role In The System
+
+`LunaEmptyState` should own:
+- optional media treatment
+- title and body content
+- primary action area
+- theme-driven framing
+- alignment across content and actions
+
+`LunaEmptyState` should not own:
+- data fetching
+- routing behavior
+- page layout composition beyond its own block
+- specialized onboarding workflows
+
+## Base Element
+
+Default element:
+- `section`
+
+Support:
+- `as?: React.ElementType`
+
+Rules:
+- related no-data guidance should default to a semantic section
+- `as` remains the escape hatch for `article`, `div`, or another element when needed
+
+## Content Model
+
+V1 should support four logical regions:
+- `media`
+- `title`
+- `body`
+- `actions`
+
+Public inputs:
+- `media?: React.ReactNode`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `children?: React.ReactNode`
+- `actions?: React.ReactNode`
+
+Rules:
+- `description` is the direct path for common short body copy
+- `children` can replace `description` when richer body content is needed
+- `media` must accept either an icon or an illustration
+- `actions` should allow one or more controls without prescribing button semantics
+
+## Alignment
+
+Recommended prop:
+- `align?: "left" | "center" | "right"`
+
+Rules:
+- a single alignment prop should keep title, body, and actions visually coherent
+- center alignment should be the default for standalone empty-state use
+- left and right alignment remain available for denser embedded layouts
+
+## Surface And Layout
+
+Recommended props:
+- `framed?: boolean`
+- `rounded?: boolean`
+- `padding?: string`
+- `gap?: string`
+- `actionsGap?: string`
+- `maxWidth?: string`
+
+Rules:
+- framed should default on so the component can stand alone
+- framed false should support placement inside an existing parent surface
+- spacing and width must resolve through theme scales first
+- the component should size itself as a content block rather than forcing full-width layout
+
+## Theme Provider Integration
+
+`LunaEmptyState` must use the existing `ThemeProvider` and `useTheme()` path.
+
+Recommended theme direction:
+- `components.emptyState`
+
+Likely theme tokens:
+- `defaultPadding`
+- `defaultGap`
+- `defaultActionsGap`
+- `maxWidth`
+- `mediaSize`
+- `radius`
+- `mediaRadius`
+- mode-aware `bg`
+- mode-aware `fg`
+- mode-aware `mutedFg`
+- mode-aware `border`
+- mode-aware `mediaBg`
+- mode-aware `mediaBorder`
+
+## Recommended Testing Focus
+
+When implemented, tests should cover:
+- default semantic tag
+- `as` override
+- media, body, and actions rendering
+- alignment behavior
+- theme-driven spacing and width tokens
+- body fallback from `children`
+- root passthrough behavior

--- a/playwright/storybook/manifest.ts
+++ b/playwright/storybook/manifest.ts
@@ -6,23 +6,28 @@ export type StoryCapture = {
 
 export const storybookCaptures: StoryCapture[] = [
   {
-    storyId: "components-lunabadge--playground",
-    fileName: "luna-badge-playground",
+    storyId: "components-lunaemptystate--playground",
+    fileName: "luna-empty-state-playground",
     backgrounds: ["light", "dark"]
   },
   {
-    storyId: "components-lunabadge--tone-and-variant-matrix",
-    fileName: "luna-badge-tone-and-variant-matrix",
+    storyId: "components-lunaemptystate--standard-no-data",
+    fileName: "luna-empty-state-standard-no-data",
     backgrounds: ["light"]
   },
   {
-    storyId: "components-lunabadge--size-scale",
-    fileName: "luna-badge-size-scale",
+    storyId: "components-lunaemptystate--first-run-flow",
+    fileName: "luna-empty-state-first-run-flow",
     backgrounds: ["light"]
   },
   {
-    storyId: "components-lunabadge--rounded-and-semantic-markup",
-    fileName: "luna-badge-rounded-and-semantic-markup",
+    storyId: "components-lunaemptystate--alignment-and-surface-variants",
+    fileName: "luna-empty-state-alignment-and-surface-variants",
+    backgrounds: ["light"]
+  },
+  {
+    storyId: "components-lunaemptystate--custom-content",
+    fileName: "luna-empty-state-custom-content",
     backgrounds: ["light"]
   }
 ];

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export * from "./luna-date-input";
 export * from "./luna-date-picker";
 export * from "./luna-radio";
 export * from "./luna-divider";
+export * from "./luna-empty-state";
 export * from "./luna-header";
 export * from "./luna-input";
 export * from "./luna-progress";

--- a/src/components/luna-empty-state/LunaEmptyState.css
+++ b/src/components/luna-empty-state/LunaEmptyState.css
@@ -1,0 +1,80 @@
+.luna-empty-state {
+  display: grid;
+  justify-items: var(--luna-empty-state-align, center);
+  gap: var(--luna-empty-state-gap, var(--luna-empty-state-gap-default, var(--luna-space-4)));
+  width: min(100%, var(--luna-empty-state-max-width, 32rem));
+  padding: var(
+    --luna-empty-state-padding,
+    var(--luna-empty-state-padding-default, var(--luna-space-6))
+  );
+  border: 1px solid transparent;
+  border-radius: var(--luna-empty-state-radius, var(--luna-radius-lg));
+  background: transparent;
+  color: var(--luna-empty-state-fg, var(--luna-foreground));
+  text-align: var(--luna-empty-state-text-align, center);
+}
+
+.luna-empty-state--framed {
+  border-color: var(--luna-empty-state-border, var(--luna-border));
+  background: var(--luna-empty-state-bg, var(--luna-surface));
+}
+
+.luna-empty-state--rounded {
+  border-radius: calc(var(--luna-empty-state-radius, var(--luna-radius-lg)) * 1.5);
+}
+
+.luna-empty-state__media {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--luna-empty-state-media-size, 5rem);
+  min-width: var(--luna-empty-state-media-size, 5rem);
+  height: var(--luna-empty-state-media-size, 5rem);
+  min-height: var(--luna-empty-state-media-size, 5rem);
+  padding: calc(var(--luna-empty-state-media-size, 5rem) * 0.2);
+  border: 1px solid var(--luna-empty-state-media-border, var(--luna-border));
+  border-radius: var(--luna-empty-state-media-radius, var(--luna-radius-pill));
+  background: var(--luna-empty-state-media-bg, var(--luna-surface));
+  color: inherit;
+}
+
+.luna-empty-state__media > * {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.luna-empty-state__content {
+  display: grid;
+  gap: calc(
+    var(--luna-empty-state-gap, var(--luna-empty-state-gap-default, var(--luna-space-4))) * 0.5
+  );
+  min-width: 0;
+  width: 100%;
+}
+
+.luna-empty-state--title-only .luna-empty-state__content {
+  gap: 0;
+}
+
+.luna-empty-state__title,
+.luna-empty-state__description {
+  margin: 0;
+}
+
+.luna-empty-state__description {
+  color: var(--luna-empty-state-muted-fg, var(--luna-muted));
+}
+
+.luna-empty-state__title > :first-child,
+.luna-empty-state__description > :first-child {
+  margin-top: 0;
+}
+
+.luna-empty-state__title > :last-child,
+.luna-empty-state__description > :last-child {
+  margin-bottom: 0;
+}
+
+.luna-empty-state__actions {
+  width: 100%;
+}

--- a/src/components/luna-empty-state/LunaEmptyState.props.ts
+++ b/src/components/luna-empty-state/LunaEmptyState.props.ts
@@ -1,0 +1,18 @@
+import type React from "react";
+
+export type LunaEmptyStateAlign = "left" | "center" | "right";
+
+export type LunaEmptyStateProps = Omit<React.HTMLAttributes<HTMLElement>, "title" | "color"> & {
+  as?: React.ElementType;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  media?: React.ReactNode;
+  actions?: React.ReactNode;
+  align?: LunaEmptyStateAlign;
+  padding?: string;
+  gap?: string;
+  actionsGap?: string;
+  maxWidth?: string;
+  rounded?: boolean;
+  framed?: boolean;
+};

--- a/src/components/luna-empty-state/LunaEmptyState.stories.tsx
+++ b/src/components/luna-empty-state/LunaEmptyState.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { LunaButton } from "../luna-button";
 import { LunaColumn } from "../luna-column";
+import { LunaRow } from "../luna-row";
 import { LunaText } from "../luna-text";
 import { LunaEmptyState } from "./LunaEmptyState";
 
@@ -45,10 +46,10 @@ export const StandardNoData: Story = {
       {...args}
       media={<EmptyOrbitIllustration />}
       actions={
-        <>
+        <LunaRow gap="3" justify="center">
           <LunaButton flat>Import data</LunaButton>
           <LunaButton>Create mission</LunaButton>
-        </>
+        </LunaRow>
       }
     />
   )
@@ -61,10 +62,10 @@ export const FirstRunFlow: Story = {
       description="Connect a source or create a draft mission to turn this workspace into your launch board."
       media={<EmptyOrbitIllustration />}
       actions={
-        <>
+        <LunaRow gap="3" justify="center">
           <LunaButton flat>View guide</LunaButton>
           <LunaButton>Connect source</LunaButton>
-        </>
+        </LunaRow>
       }
     />
   )
@@ -86,10 +87,10 @@ export const AlignmentAndSurfaceVariants: Story = {
         title="Unframed variant"
         description="The contract can sit inside an existing parent surface without stacking extra chrome."
         actions={
-          <>
+          <LunaRow gap="3" justify="end">
             <LunaButton flat>Dismiss</LunaButton>
             <LunaButton>Review options</LunaButton>
-          </>
+          </LunaRow>
         }
       />
     </LunaColumn>

--- a/src/components/luna-empty-state/LunaEmptyState.stories.tsx
+++ b/src/components/luna-empty-state/LunaEmptyState.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaButton } from "../luna-button";
+import { LunaColumn } from "../luna-column";
+import { LunaText } from "../luna-text";
+import { LunaEmptyState } from "./LunaEmptyState";
+
+function EmptyOrbitIllustration() {
+  return (
+    <svg viewBox="0 0 120 120" width="72" height="72" fill="none" aria-hidden="true">
+      <circle cx="60" cy="60" r="42" stroke="currentColor" strokeWidth="6" opacity="0.24" />
+      <circle cx="60" cy="60" r="12" fill="currentColor" opacity="0.16" />
+      <path
+        d="M60 30c10 0 18 8 18 18"
+        stroke="currentColor"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      <circle cx="82" cy="42" r="6" fill="currentColor" />
+    </svg>
+  );
+}
+
+const meta = {
+  title: "Components/LunaEmptyState",
+  component: LunaEmptyState,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    title: "No missions yet",
+    description: "Create your first mission to start tracking launches, crews, and destination notes."
+  }
+} satisfies Meta<typeof LunaEmptyState>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const StandardNoData: Story = {
+  render: (args) => (
+    <LunaEmptyState
+      {...args}
+      media={<EmptyOrbitIllustration />}
+      actions={
+        <>
+          <LunaButton flat>Import data</LunaButton>
+          <LunaButton>Create mission</LunaButton>
+        </>
+      }
+    />
+  )
+};
+
+export const FirstRunFlow: Story = {
+  render: () => (
+    <LunaEmptyState
+      title="Welcome to mission control"
+      description="Connect a source or create a draft mission to turn this workspace into your launch board."
+      media={<EmptyOrbitIllustration />}
+      actions={
+        <>
+          <LunaButton flat>View guide</LunaButton>
+          <LunaButton>Connect source</LunaButton>
+        </>
+      }
+    />
+  )
+};
+
+export const AlignmentAndSurfaceVariants: Story = {
+  render: () => (
+    <LunaColumn gap="4" style={{ width: "min(100%, 42rem)" }}>
+      <LunaEmptyState
+        align="left"
+        title="Left-aligned guidance"
+        description="Useful when the empty state lives inside a larger document flow."
+        media={<span style={{ fontSize: "2rem", lineHeight: 1 }}>+</span>}
+        actions={<LunaButton>Create collection</LunaButton>}
+      />
+      <LunaEmptyState
+        align="right"
+        framed={false}
+        title="Unframed variant"
+        description="The contract can sit inside an existing parent surface without stacking extra chrome."
+        actions={
+          <>
+            <LunaButton flat>Dismiss</LunaButton>
+            <LunaButton>Review options</LunaButton>
+          </>
+        }
+      />
+    </LunaColumn>
+  )
+};
+
+export const CustomContent: Story = {
+  render: () => (
+    <LunaEmptyState
+      media={<span style={{ fontSize: "2rem", lineHeight: 1 }}>*</span>}
+      title={<span>Nothing has reached this orbit</span>}
+      actions={<LunaButton>Open scanner</LunaButton>}
+    >
+      <LunaText variant="body-small" muted align="center">
+        Custom body content can include richer markup without leaving the component contract.
+      </LunaText>
+    </LunaEmptyState>
+  )
+};

--- a/src/components/luna-empty-state/LunaEmptyState.test.tsx
+++ b/src/components/luna-empty-state/LunaEmptyState.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaEmptyState } from "./LunaEmptyState";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaEmptyState", () => {
+  it("renders a section by default", () => {
+    renderWithTheme(<LunaEmptyState title="No missions" description="Add one to continue." />);
+
+    const emptyState = screen.getByText("No missions").closest("section");
+
+    expect(emptyState).toBeInTheDocument();
+  });
+
+  it("supports semantic overrides through as", () => {
+    renderWithTheme(
+      <LunaEmptyState as="article" title="No signals" description="Connect a source." />
+    );
+
+    const emptyState = screen.getByText("No signals").closest("article");
+
+    expect(emptyState).toBeInTheDocument();
+  });
+
+  it("renders media, description, and actions regions", () => {
+    renderWithTheme(
+      <LunaEmptyState
+        title="Nothing here yet"
+        description="Create a record to get started."
+        media={<span data-testid="empty-state-media">*</span>}
+        actions={<button type="button">Create record</button>}
+      />
+    );
+
+    expect(
+      screen.getByTestId("empty-state-media").closest(".luna-empty-state__media")
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("Create a record to get started.")
+        .closest(".luna-empty-state__description")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create record" }).closest(".luna-empty-state__actions")
+    ).toBeInTheDocument();
+  });
+
+  it("supports alignment and spacing props", () => {
+    renderWithTheme(
+      <LunaEmptyState
+        title="Alignment"
+        description="Check positioning."
+        align="right"
+        padding="6"
+        gap="3"
+        actionsGap="4"
+        maxWidth="16"
+        actions={<button type="button">Launch</button>}
+      />
+    );
+
+    const emptyState = document.querySelector(".luna-empty-state");
+    const actions = document.querySelector(".luna-empty-state__actions");
+
+    expect(emptyState).toHaveStyle({
+      "--luna-empty-state-padding": "1.5rem",
+      "--luna-empty-state-gap": "0.75rem",
+      "--luna-empty-state-max-width": "4rem",
+      "--luna-empty-state-align": "end",
+      "--luna-empty-state-text-align": "right"
+    });
+    expect(actions).toHaveStyle({
+      "--luna-layout-justify": "flex-end",
+      "--luna-layout-gap": "1rem"
+    });
+  });
+
+  it("treats children as the body region when provided", () => {
+    renderWithTheme(
+      <LunaEmptyState title="Custom body">
+        <p>Use richer markup for the empty-state body.</p>
+      </LunaEmptyState>
+    );
+
+    expect(screen.getByText("Use richer markup for the empty-state body.")).toBeInTheDocument();
+  });
+
+  it("uses theme overrides for empty-state defaults", () => {
+    const { container } = renderWithTheme(
+      <LunaEmptyState title="Theme override" description="Custom surface defaults." />,
+      {
+        theme: {
+          components: {
+            emptyState: {
+              defaultPadding: "8",
+              maxWidth: "16",
+              modes: {
+                light: {
+                  mediaBg: "accent.100"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-empty-state-padding-default": "2rem",
+      "--luna-empty-state-max-width": "4rem",
+      "--luna-empty-state-media-bg": "#ede9fe"
+    });
+  });
+});

--- a/src/components/luna-empty-state/LunaEmptyState.tsx
+++ b/src/components/luna-empty-state/LunaEmptyState.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import { LunaRow } from "../luna-row";
+import { LunaText } from "../luna-text";
+import type { LunaEmptyStateProps } from "./LunaEmptyState.props";
+import "./LunaEmptyState.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveAlign(align: LunaEmptyStateProps["align"]) {
+  if (align === "center") {
+    return { items: "center", text: "center", actions: "center" } as const;
+  }
+
+  if (align === "right") {
+    return { items: "end", text: "right", actions: "end" } as const;
+  }
+
+  return { items: "start", text: "left", actions: "start" } as const;
+}
+
+export const LunaEmptyState = React.forwardRef<HTMLElement, LunaEmptyStateProps>(
+  function LunaEmptyState(
+    {
+      actions,
+      actionsGap,
+      align = "center",
+      as,
+      children,
+      className,
+      description,
+      framed = true,
+      gap,
+      maxWidth,
+      media,
+      padding,
+      rounded,
+      style,
+      title,
+      ...props
+    },
+    ref
+  ) {
+    const { theme } = useTheme();
+    const Component = (as ?? "section") as React.ElementType;
+    const resolvedPadding = resolveSpacingValue(padding, theme);
+    const resolvedGap = resolveSpacingValue(gap, theme);
+    const resolvedActionsGap = resolveSpacingValue(actionsGap, theme);
+    const resolvedMaxWidth = resolveSpacingValue(maxWidth, theme);
+    const resolvedAlign = resolveAlign(align);
+    const body = children ?? description;
+    const hasBody = body !== undefined && body !== null;
+
+    const resolvedStyle = {
+      ...(resolvedPadding ? { ["--luna-empty-state-padding" as const]: resolvedPadding } : {}),
+      ...(resolvedGap ? { ["--luna-empty-state-gap" as const]: resolvedGap } : {}),
+      ...(resolvedActionsGap
+        ? { ["--luna-empty-state-actions-gap" as const]: resolvedActionsGap }
+        : {}),
+      ...(resolvedMaxWidth ? { ["--luna-empty-state-max-width" as const]: resolvedMaxWidth } : {}),
+      ["--luna-empty-state-align" as const]: resolvedAlign.items,
+      ["--luna-empty-state-text-align" as const]: resolvedAlign.text,
+      ...style
+    };
+
+    return (
+      <Component
+        {...props}
+        ref={ref}
+        className={toClassName([
+          "luna-empty-state",
+          rounded && "luna-empty-state--rounded",
+          framed && "luna-empty-state--framed",
+          !hasBody && "luna-empty-state--title-only",
+          className
+        ])}
+        style={resolvedStyle}
+      >
+        {media ? (
+          <div aria-hidden="true" className="luna-empty-state__media">
+            {media}
+          </div>
+        ) : null}
+        <div className="luna-empty-state__content">
+          {title !== undefined && title !== null
+            ? typeof title === "string"
+              ? (
+                <LunaText
+                  as="h2"
+                  variant="title"
+                  className="luna-empty-state__title"
+                  align={resolvedAlign.text}
+                >
+                  {title}
+                </LunaText>
+              )
+              : (
+                <div className="luna-empty-state__title">{title}</div>
+              )
+            : null}
+          {hasBody
+            ? typeof body === "string"
+              ? (
+                <LunaText
+                  variant="body"
+                  muted
+                  className="luna-empty-state__description"
+                  align={resolvedAlign.text}
+                >
+                  {body}
+                </LunaText>
+              )
+              : (
+                <div className="luna-empty-state__description">{body}</div>
+              )
+            : null}
+        </div>
+        {actions ? (
+          <LunaRow
+            className="luna-empty-state__actions"
+            align="center"
+            justify={resolvedAlign.actions}
+            gap={resolvedActionsGap}
+          >
+            {actions}
+          </LunaRow>
+        ) : null}
+      </Component>
+    );
+  }
+);

--- a/src/components/luna-empty-state/index.ts
+++ b/src/components/luna-empty-state/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaEmptyState";
+export * from "./LunaEmptyState.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -425,6 +425,33 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    emptyState: {
+      defaultPadding: "6",
+      defaultGap: "4",
+      defaultActionsGap: "3",
+      maxWidth: "32rem",
+      mediaSize: "5rem",
+      radius: "lg",
+      mediaRadius: "pill",
+      modes: {
+        light: {
+          bg: "neutral.100",
+          fg: "neutral.900",
+          border: "neutral.200",
+          mutedFg: "neutral.600",
+          mediaBg: "primary.50",
+          mediaBorder: "primary.100"
+        },
+        dark: {
+          bg: "neutral.800",
+          fg: "neutral.50",
+          border: "neutral.700",
+          mutedFg: "neutral.300",
+          mediaBg: "neutral.700",
+          mediaBorder: "neutral.600"
+        }
+      }
+    },
     alert: {
       defaultPadding: "4",
       defaultGap: "3",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -112,6 +112,15 @@ export type ThemeCardModeTokens = {
   hoverShadow?: string;
 };
 
+export type ThemeEmptyStateModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  mutedFg?: string;
+  mediaBg?: string;
+  mediaBorder?: string;
+};
+
 export type ThemeAlertTone = "neutral" | "info" | "success" | "warning" | "danger";
 export type ThemeAlertEmphasis = "soft" | "solid" | "outline";
 export type ThemeBadgeTone = "neutral" | "info" | "success" | "warning" | "danger";
@@ -281,6 +290,16 @@ export type ThemeComponents = {
     defaultGap?: string;
     radius?: string;
     modes?: Partial<Record<ThemeMode, ThemeCardModeTokens>>;
+  };
+  emptyState?: {
+    defaultPadding?: string;
+    defaultGap?: string;
+    defaultActionsGap?: string;
+    maxWidth?: string;
+    mediaSize?: string;
+    radius?: string;
+    mediaRadius?: string;
+    modes?: Partial<Record<ThemeMode, ThemeEmptyStateModeTokens>>;
   };
   alert?: {
     defaultPadding?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -201,6 +201,55 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
       resolveTokenValue(theme, cardMode.hoverShadow);
   }
 
+  const emptyState = theme.components.emptyState;
+  if (emptyState?.defaultPadding) {
+    vars["--luna-empty-state-padding-default"] =
+      resolveScaleValue(theme.spacing, emptyState.defaultPadding) ?? emptyState.defaultPadding;
+  }
+  if (emptyState?.defaultGap) {
+    vars["--luna-empty-state-gap-default"] =
+      resolveScaleValue(theme.spacing, emptyState.defaultGap) ?? emptyState.defaultGap;
+  }
+  if (emptyState?.defaultActionsGap) {
+    vars["--luna-empty-state-actions-gap-default"] =
+      resolveScaleValue(theme.spacing, emptyState.defaultActionsGap) ?? emptyState.defaultActionsGap;
+  }
+  if (emptyState?.maxWidth) {
+    vars["--luna-empty-state-max-width"] =
+      resolveScaleValue(theme.spacing, emptyState.maxWidth) ?? emptyState.maxWidth;
+  }
+  if (emptyState?.mediaSize) {
+    vars["--luna-empty-state-media-size"] =
+      resolveScaleValue(theme.spacing, emptyState.mediaSize) ?? emptyState.mediaSize;
+  }
+  if (emptyState?.radius) {
+    vars["--luna-empty-state-radius"] =
+      resolveScaleValue(theme.radii, emptyState.radius) ?? emptyState.radius;
+  }
+  if (emptyState?.mediaRadius) {
+    vars["--luna-empty-state-media-radius"] =
+      resolveScaleValue(theme.radii, emptyState.mediaRadius) ?? emptyState.mediaRadius;
+  }
+  const emptyStateMode = emptyState?.modes?.[mode];
+  if (emptyStateMode?.bg) {
+    vars["--luna-empty-state-bg"] = resolveTokenValue(theme, emptyStateMode.bg);
+  }
+  if (emptyStateMode?.fg) {
+    vars["--luna-empty-state-fg"] = resolveTokenValue(theme, emptyStateMode.fg);
+  }
+  if (emptyStateMode?.border) {
+    vars["--luna-empty-state-border"] = resolveTokenValue(theme, emptyStateMode.border);
+  }
+  if (emptyStateMode?.mutedFg) {
+    vars["--luna-empty-state-muted-fg"] = resolveTokenValue(theme, emptyStateMode.mutedFg);
+  }
+  if (emptyStateMode?.mediaBg) {
+    vars["--luna-empty-state-media-bg"] = resolveTokenValue(theme, emptyStateMode.mediaBg);
+  }
+  if (emptyStateMode?.mediaBorder) {
+    vars["--luna-empty-state-media-border"] = resolveTokenValue(theme, emptyStateMode.mediaBorder);
+  }
+
   const alert = theme.components.alert;
   if (alert?.defaultPadding) {
     vars["--luna-alert-padding-default"] =


### PR DESCRIPTION
Closes #75

## Summary
Implemented `LunaEmptyState` as a scoped `#75` composite with a slot-like contract for `title`, `description` or `children`, `media`, and `actions`, plus unified alignment and theme-driven framing. The core component lives in [src/components/luna-empty-state/LunaEmptyState.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-empty-state/LunaEmptyState.tsx#L36), with its public props in [src/components/luna-empty-state/LunaEmptyState.props.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-empty-state/LunaEmptyState.props.ts#L5). I added theme support under `components.emptyState` in [src/theme/types.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/types.ts#L115), [src/theme/base.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/base.ts#L428), and [src/theme/vars.ts](/Users/jordanb/Documents/workspace/react-luna/src/theme/vars.ts#L204), and exported it from [src/components/index.ts](/Users/jordanb/Documents/workspace/react-luna/src/components/index.ts#L7).

Storybook, tests, docs, and release metadata were included in the same slice: [src/components/luna-empty-state/LunaEmptyState.stories.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-empty-state/LunaEmptyState.stories.tsx#L24), [src/components/luna-empty-state/LunaEmptyState.test.tsx](/Users/jordanb/Documents/workspace/react-luna/src/components/luna-empty-state/LunaEmptyState.test.tsx#L19), [docs/v1/components/LunaEmptyState.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/components/LunaEmptyState.md#L1), [docs/v1/design/LunaEmptyState.md](/Users/jordanb/Documents/workspace/react-luna/docs/v1/design/LunaEmptyState.md#L1), and [.changeset/luna-empty-state.md](/Users/jordanb/Documents/workspace/react-luna/.changeset/luna-empty-state.md#L1).

Verification ran successfully:
- `npm test -- LunaEmptyState`
- `npm test`
- `npm run build`
- `npm run storybook:build`

`storybook:build` passed with existing Storybook warnings about `eval` in Storybook runtime and chunk-size warnings.

I could not create the required git commit because the sandbox blocks writes to `.git` and `git commit` failed with `Unable to create '.git/index.lock': Operation not permitted`. The worktree changes are ready for review and commit as the `#75` step.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`