### PR TITLE
Add baseline Storybook manifests for existing components

### DIFF
--- a/playwright/storybook/manifests/luna-alert.json
+++ b/playwright/storybook/manifests/luna-alert.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunaalert--custom-spacing",
+    "fileName": "luna-alert-custom-spacing",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaalert--playground",
+    "fileName": "luna-alert-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaalert--tone-and-emphasis-matrix",
+    "fileName": "luna-alert-tone-and-emphasis-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaalert--with-icon-and-announcement-semantics",
+    "fileName": "luna-alert-with-icon-and-announcement-semantics",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-autocomplete.json
+++ b/playwright/storybook/manifests/luna-autocomplete.json
@@ -1,0 +1,51 @@
+[
+  {
+    "storyId": "components-lunaautocomplete--basic",
+    "fileName": "luna-autocomplete-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--dark-mode",
+    "fileName": "luna-autocomplete-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--label-modes",
+    "fileName": "luna-autocomplete-label-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--size-parity",
+    "fileName": "luna-autocomplete-size-parity",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--sizes",
+    "fileName": "luna-autocomplete-sizes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--states",
+    "fileName": "luna-autocomplete-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaautocomplete--supporting-text",
+    "fileName": "luna-autocomplete-supporting-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-avatar.json
+++ b/playwright/storybook/manifests/luna-avatar.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunaavatar--content-modes",
+    "fileName": "luna-avatar-content-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaavatar--playground",
+    "fileName": "luna-avatar-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaavatar--size-scale",
+    "fileName": "luna-avatar-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaavatar--theme-overrides",
+    "fileName": "luna-avatar-theme-overrides",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-badge.json
+++ b/playwright/storybook/manifests/luna-badge.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunabadge--playground",
+    "fileName": "luna-badge-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunabadge--rounded-and-semantic-markup",
+    "fileName": "luna-badge-rounded-and-semantic-markup",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabadge--size-scale",
+    "fileName": "luna-badge-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabadge--tone-and-variant-matrix",
+    "fileName": "luna-badge-tone-and-variant-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-button.json
+++ b/playwright/storybook/manifests/luna-button.json
@@ -1,0 +1,45 @@
+[
+  {
+    "storyId": "components-lunabutton--color-matrix",
+    "fileName": "luna-button-color-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabutton--info-and-iconography",
+    "fileName": "luna-button-info-and-iconography",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabutton--motion-and-state",
+    "fileName": "luna-button-motion-and-state",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabutton--playground",
+    "fileName": "luna-button-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunabutton--size-scale",
+    "fileName": "luna-button-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabutton--surface-treatments",
+    "fileName": "luna-button-surface-treatments",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-card.json
+++ b/playwright/storybook/manifests/luna-card.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunacard--basic",
+    "fileName": "luna-card-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacard--header-variants",
+    "fileName": "luna-card-header-variants",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacard--spacing",
+    "fileName": "luna-card-spacing",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacard--surface-treatments",
+    "fileName": "luna-card-surface-treatments",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-checkbox.json
+++ b/playwright/storybook/manifests/luna-checkbox.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunacheckbox--basic",
+    "fileName": "luna-checkbox-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckbox--dark-mode",
+    "fileName": "luna-checkbox-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckbox--states",
+    "fileName": "luna-checkbox-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckbox--support-text",
+    "fileName": "luna-checkbox-support-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-date-picker.json
+++ b/playwright/storybook/manifests/luna-date-picker.json
@@ -1,0 +1,44 @@
+[
+  {
+    "storyId": "components-lunadatepicker--action-regions",
+    "fileName": "luna-date-picker-action-regions",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadatepicker--dark-mode",
+    "fileName": "luna-date-picker-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadatepicker--picker",
+    "fileName": "luna-date-picker-picker",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadatepicker--range",
+    "fileName": "luna-date-picker-range",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadatepicker--simple",
+    "fileName": "luna-date-picker-simple",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadatepicker--states",
+    "fileName": "luna-date-picker-states",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-divider.json
+++ b/playwright/storybook/manifests/luna-divider.json
@@ -1,0 +1,37 @@
+[
+  {
+    "storyId": "components-lunadivider--basic",
+    "fileName": "luna-divider-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadivider--insets-and-spacing",
+    "fileName": "luna-divider-insets-and-spacing",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadivider--labeled",
+    "fileName": "luna-divider-labeled",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadivider--tones",
+    "fileName": "luna-divider-tones",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunadivider--vertical",
+    "fileName": "luna-divider-vertical",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-empty-state.json
+++ b/playwright/storybook/manifests/luna-empty-state.json
@@ -1,0 +1,38 @@
+[
+  {
+    "storyId": "components-lunaemptystate--alignment-and-surface-variants",
+    "fileName": "luna-empty-state-alignment-and-surface-variants",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaemptystate--custom-content",
+    "fileName": "luna-empty-state-custom-content",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaemptystate--first-run-flow",
+    "fileName": "luna-empty-state-first-run-flow",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaemptystate--playground",
+    "fileName": "luna-empty-state-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaemptystate--standard-no-data",
+    "fileName": "luna-empty-state-standard-no-data",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-header.json
+++ b/playwright/storybook/manifests/luna-header.json
@@ -1,0 +1,37 @@
+[
+  {
+    "storyId": "components-lunaheader--alignments",
+    "fileName": "luna-header-alignments",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaheader--basic",
+    "fileName": "luna-header-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaheader--custom-content",
+    "fileName": "luna-header-custom-content",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaheader--gap-control",
+    "fileName": "luna-header-gap-control",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaheader--sizes",
+    "fileName": "luna-header-sizes",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-input.json
+++ b/playwright/storybook/manifests/luna-input.json
@@ -1,0 +1,58 @@
+[
+  {
+    "storyId": "components-lunainput--basic",
+    "fileName": "luna-input-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--dark-mode",
+    "fileName": "luna-input-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--label-modes",
+    "fileName": "luna-input-label-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--leading-and-trailing",
+    "fileName": "luna-input-leading-and-trailing",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--native-states",
+    "fileName": "luna-input-native-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--size-parity",
+    "fileName": "luna-input-size-parity",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--sizes",
+    "fileName": "luna-input-sizes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunainput--supporting-text",
+    "fileName": "luna-input-supporting-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-multiselect.json
+++ b/playwright/storybook/manifests/luna-multiselect.json
@@ -1,0 +1,51 @@
+[
+  {
+    "storyId": "components-lunamultiselect--basic",
+    "fileName": "luna-multiselect-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--dark-mode",
+    "fileName": "luna-multiselect-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--label-modes",
+    "fileName": "luna-multiselect-label-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--size-parity",
+    "fileName": "luna-multiselect-size-parity",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--sizes",
+    "fileName": "luna-multiselect-sizes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--states",
+    "fileName": "luna-multiselect-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunamultiselect--supporting-text",
+    "fileName": "luna-multiselect-supporting-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-notification.json
+++ b/playwright/storybook/manifests/luna-notification.json
@@ -1,0 +1,38 @@
+[
+  {
+    "storyId": "components-lunanotification--controlled-visibility",
+    "fileName": "luna-notification-controlled-visibility",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunanotification--edge-varieties",
+    "fileName": "luna-notification-edge-varieties",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunanotification--playground",
+    "fileName": "luna-notification-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunanotification--tone-and-emphasis-matrix",
+    "fileName": "luna-notification-tone-and-emphasis-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunanotification--with-action-and-metadata",
+    "fileName": "luna-notification-with-action-and-metadata",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-progress.json
+++ b/playwright/storybook/manifests/luna-progress.json
@@ -1,0 +1,38 @@
+[
+  {
+    "storyId": "components-lunaprogress--custom-value-label",
+    "fileName": "luna-progress-custom-value-label",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaprogress--indeterminate",
+    "fileName": "luna-progress-indeterminate",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaprogress--playground",
+    "fileName": "luna-progress-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaprogress--size-scale",
+    "fileName": "luna-progress-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaprogress--tone-matrix",
+    "fileName": "luna-progress-tone-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-radio.json
+++ b/playwright/storybook/manifests/luna-radio.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunaradio--basic",
+    "fileName": "luna-radio-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradio--dark-mode",
+    "fileName": "luna-radio-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradio--grouped",
+    "fileName": "luna-radio-grouped",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradio--support-text",
+    "fileName": "luna-radio-support-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-select.json
+++ b/playwright/storybook/manifests/luna-select.json
@@ -1,0 +1,51 @@
+[
+  {
+    "storyId": "components-lunaselect--basic",
+    "fileName": "luna-select-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--dark-mode",
+    "fileName": "luna-select-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--label-modes",
+    "fileName": "luna-select-label-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--size-parity",
+    "fileName": "luna-select-size-parity",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--sizes",
+    "fileName": "luna-select-sizes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--states",
+    "fileName": "luna-select-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaselect--supporting-text",
+    "fileName": "luna-select-supporting-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-skeleton.json
+++ b/playwright/storybook/manifests/luna-skeleton.json
@@ -1,0 +1,38 @@
+[
+  {
+    "storyId": "components-lunaskeleton--animation-modes",
+    "fileName": "luna-skeleton-animation-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaskeleton--playground",
+    "fileName": "luna-skeleton-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaskeleton--shape-matrix",
+    "fileName": "luna-skeleton-shape-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaskeleton--size-scale",
+    "fileName": "luna-skeleton-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaskeleton--surface-composition",
+    "fileName": "luna-skeleton-surface-composition",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-slider.json
+++ b/playwright/storybook/manifests/luna-slider.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunaslider--basic",
+    "fileName": "luna-slider-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaslider--dark-mode",
+    "fileName": "luna-slider-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaslider--states",
+    "fileName": "luna-slider-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaslider--without-value",
+    "fileName": "luna-slider-without-value",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-spinner.json
+++ b/playwright/storybook/manifests/luna-spinner.json
@@ -1,0 +1,38 @@
+[
+  {
+    "storyId": "components-lunaspinner--playground",
+    "fileName": "luna-spinner-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunaspinner--semantic-usage",
+    "fileName": "luna-spinner-semantic-usage",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaspinner--size-scale",
+    "fileName": "luna-spinner-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaspinner--surface-modes",
+    "fileName": "luna-spinner-surface-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaspinner--theme-override",
+    "fileName": "luna-spinner-theme-override",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-switch.json
+++ b/playwright/storybook/manifests/luna-switch.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunaswitch--basic",
+    "fileName": "luna-switch-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaswitch--dark-mode",
+    "fileName": "luna-switch-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaswitch--states",
+    "fileName": "luna-switch-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaswitch--support-text",
+    "fileName": "luna-switch-support-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-tag.json
+++ b/playwright/storybook/manifests/luna-tag.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunatag--playground",
+    "fileName": "luna-tag-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunatag--semantic-overrides-and-color",
+    "fileName": "luna-tag-semantic-overrides-and-color",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatag--size-scale",
+    "fileName": "luna-tag-size-scale",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatag--variant-matrix",
+    "fileName": "luna-tag-variant-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-text.json
+++ b/playwright/storybook/manifests/luna-text.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunatext--color-and-alignment",
+    "fileName": "luna-text-color-and-alignment",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatext--decoration-and-overflow",
+    "fileName": "luna-text-decoration-and-overflow",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatext--semantics",
+    "fileName": "luna-text-semantics",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatext--variants",
+    "fileName": "luna-text-variants",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-textarea.json
+++ b/playwright/storybook/manifests/luna-textarea.json
@@ -1,0 +1,58 @@
+[
+  {
+    "storyId": "components-lunatextarea--auto-grow",
+    "fileName": "luna-textarea-auto-grow",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--basic",
+    "fileName": "luna-textarea-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--dark-mode",
+    "fileName": "luna-textarea-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--label-modes",
+    "fileName": "luna-textarea-label-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--resize-modes",
+    "fileName": "luna-textarea-resize-modes",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--size-parity",
+    "fileName": "luna-textarea-size-parity",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--states",
+    "fileName": "luna-textarea-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatextarea--supporting-text",
+    "fileName": "luna-textarea-supporting-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-toast.json
+++ b/playwright/storybook/manifests/luna-toast.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunatoast--auto-dismiss-and-action",
+    "fileName": "luna-toast-auto-dismiss-and-action",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatoast--controlled-visibility",
+    "fileName": "luna-toast-controlled-visibility",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatoast--playground",
+    "fileName": "luna-toast-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunatoast--tone-and-emphasis-matrix",
+    "fileName": "luna-toast-tone-and-emphasis-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/playwright/storybook/manifests/luna-tooltip.json
+++ b/playwright/storybook/manifests/luna-tooltip.json
@@ -1,0 +1,31 @@
+[
+  {
+    "storyId": "components-lunatooltip--disabled-tooltip",
+    "fileName": "luna-tooltip-disabled-tooltip",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatooltip--placement-matrix",
+    "fileName": "luna-tooltip-placement-matrix",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunatooltip--playground",
+    "fileName": "luna-tooltip-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunatooltip--rich-content-and-sizing",
+    "fileName": "luna-tooltip-rich-content-and-sizing",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Adds branch-local Storybook manifest files for the existing component story sets that were still relying on fallback discovery.

## Why
This gives hardening and future PR review work a uniform baseline, reduces screenshot-target ambiguity, and lowers the chance that automation or reviewers have to infer captures from dynamic fallback behavior.

## Verification
- 
- validated manifest story ids against 