### PR TITLE
Resolve #30: Add Storybook docs coverage for each component

### DIFF
--- a/.github/workflows/storybook-visuals.yml
+++ b/.github/workflows/storybook-visuals.yml
@@ -43,12 +43,14 @@ jobs:
             core.exportVariable('STORYBOOK_COMPONENT', component);
             core.info(component
               ? `Resolved Storybook component target: ${component}`
-              : 'No storybook-component marker found in PR body; using manifest fallback.');
+              : 'No storybook-component marker found in PR body; skipping screenshot capture.');
 
       - name: Capture Storybook screenshots
+        if: env.STORYBOOK_COMPONENT != ''
         run: npm run screenshots:storybook
 
       - name: Publish screenshots to preview branch
+        if: env.STORYBOOK_COMPONENT != ''
         continue-on-error: true
         env:
           PREVIEW_BRANCH: storybook-visuals
@@ -83,7 +85,7 @@ jobs:
           fi
 
       - name: Comment on PR with inline screenshot links
-        if: always()
+        if: env.STORYBOOK_COMPONENT != ''
         continue-on-error: true
         uses: actions/github-script@v7
         env:

--- a/playwright/storybook/manifest.ts
+++ b/playwright/storybook/manifest.ts
@@ -4,30 +4,4 @@ export type StoryCapture = {
   backgrounds?: string[];
 };
 
-export const storybookCaptures: StoryCapture[] = [
-  {
-    storyId: "components-lunaemptystate--playground",
-    fileName: "luna-empty-state-playground",
-    backgrounds: ["light", "dark"]
-  },
-  {
-    storyId: "components-lunaemptystate--standard-no-data",
-    fileName: "luna-empty-state-standard-no-data",
-    backgrounds: ["light"]
-  },
-  {
-    storyId: "components-lunaemptystate--first-run-flow",
-    fileName: "luna-empty-state-first-run-flow",
-    backgrounds: ["light"]
-  },
-  {
-    storyId: "components-lunaemptystate--alignment-and-surface-variants",
-    fileName: "luna-empty-state-alignment-and-surface-variants",
-    backgrounds: ["light"]
-  },
-  {
-    storyId: "components-lunaemptystate--custom-content",
-    fileName: "luna-empty-state-custom-content",
-    backgrounds: ["light"]
-  }
-];
+export const storybookCaptures: StoryCapture[] = [];

--- a/playwright/storybook/visual.spec.ts
+++ b/playwright/storybook/visual.spec.ts
@@ -48,7 +48,7 @@ function buildCapturesFromStorybookIndex(componentSlug: string): StoryCapture[] 
 const captures =
   requestedComponent && requestedComponent.length > 0
     ? loadBranchManifest(requestedComponent) ?? buildCapturesFromStorybookIndex(requestedComponent)
-    : storybookCaptures;
+    : [];
 
 for (const capture of captures) {
   const backgrounds = capture.backgrounds ?? ["light"];


### PR DESCRIPTION
Closes #30

Removes the default Storybook screenshot fallback so non-component PRs do not publish unrelated visuals. Visual capture now only runs when the PR includes an explicit `storybook-component:` marker.