### PR TITLE
Resolve #26: Build LunaBreadcrumb composite

### DIFF
--- a/.changeset/luna-breadcrumb.md
+++ b/.changeset/luna-breadcrumb.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaBreadcrumb` composite with Storybook coverage, theme support, tests, and docs.

--- a/docs/v1/components/LunaBreadcrumb.md
+++ b/docs/v1/components/LunaBreadcrumb.md
@@ -1,0 +1,50 @@
+# LunaBreadcrumb
+
+`LunaBreadcrumb` is the compact trail composite for showing the current location inside a deeper page hierarchy without taking ownership of routing.
+
+It owns:
+- breadcrumb landmark semantics
+- ordered trail rendering
+- current-page treatment
+- optional middle collapse for long trails
+- link, button, and static item presentation
+- theme-aware spacing and state styling
+
+It does not own:
+- routing
+- history state
+- nested navigation menus
+- overflow menus for hidden segments
+
+## Props
+
+- `items: Array<{ label: React.ReactNode; href?: string; onClick?: MouseEventHandler; current?: boolean; disabled?: boolean; ariaLabel?: string; target?: string; rel?: string; key?: React.Key }>`
+- `ariaLabel?: string`
+- `separator?: React.ReactNode`
+- `maxItems?: number`
+- `size?: "sm" | "md" | "lg"`
+- `collapseLabel?: string`
+
+Native `HTMLAttributes<HTMLElement>` continue to pass through to the root `nav`.
+
+## Contract
+
+- `LunaBreadcrumb` renders `nav > ol` semantics and defaults the navigation label to `"Breadcrumb"`
+- `items` is required and an empty list renders nothing
+- the current page is the first item marked with `current`, otherwise the last item in the list
+- the current item renders as static text with `aria-current="page"` even when `href` or `onClick` is provided
+- non-current items render as links when `href` is provided, buttons when only `onClick` is provided, and text otherwise
+- `disabled` prevents interaction and renders the item as muted text
+- `maxItems` collapses the middle of long trails around the current page; values below `3` do not collapse
+- `separator` is decorative and hidden from assistive technology
+- `className` and `style` pass through to the root shell
+
+## Theme Integration
+
+`LunaBreadcrumb` consumes the theme system for:
+- radius
+- size-based gap, separator gap, font size, minimum height, and item padding
+- link, current, muted, and separator colors
+- hover and focus treatments
+
+Downstream consumers can override the breadcrumb feel without changing the list semantics or item contract.

--- a/playwright/storybook/manifests/luna-breadcrumb.json
+++ b/playwright/storybook/manifests/luna-breadcrumb.json
@@ -1,0 +1,22 @@
+[
+  {
+    "storyId": "components-lunabreadcrumb--basic",
+    "fileName": "luna-breadcrumb-basic",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunabreadcrumb--collapsed-trail",
+    "fileName": "luna-breadcrumb-collapsed-trail",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunabreadcrumb--custom-separator",
+    "fileName": "luna-breadcrumb-custom-separator",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunabreadcrumb--action-trail",
+    "fileName": "luna-breadcrumb-action-trail",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export * from "./luna-alert";
 export * from "./luna-accordion";
 export * from "./luna-badge";
 export * from "./luna-button";
+export * from "./luna-breadcrumb";
 export * from "./luna-card";
 export * from "./luna-checkbox";
 export * from "./luna-date-input";

--- a/src/components/luna-breadcrumb/LunaBreadcrumb.css
+++ b/src/components/luna-breadcrumb/LunaBreadcrumb.css
@@ -1,0 +1,117 @@
+.luna-breadcrumb {
+  display: block;
+}
+
+.luna-breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--luna-breadcrumb-current-gap);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.luna-breadcrumb__entry {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--luna-breadcrumb-current-separator-gap);
+  min-width: 0;
+}
+
+.luna-breadcrumb__item,
+.luna-breadcrumb__ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--luna-breadcrumb-current-min-height);
+  padding: var(--luna-breadcrumb-current-padding-y) var(--luna-breadcrumb-current-padding-x);
+  border-radius: var(--luna-breadcrumb-radius, var(--luna-radius-sm, 0.375rem));
+  font: inherit;
+  font-size: var(--luna-breadcrumb-current-font-size);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.luna-breadcrumb__item {
+  color: var(--luna-breadcrumb-link-fg, var(--luna-foreground));
+  text-decoration: none;
+  background: transparent;
+  border: none;
+}
+
+a.luna-breadcrumb__item,
+button.luna-breadcrumb__item {
+  cursor: pointer;
+  transition:
+    background-color var(--luna-motion-fast, 120ms) ease,
+    color var(--luna-motion-fast, 120ms) ease,
+    box-shadow var(--luna-motion-fast, 120ms) ease;
+}
+
+a.luna-breadcrumb__item:hover,
+button.luna-breadcrumb__item:hover {
+  background: var(--luna-breadcrumb-hover-bg, color-mix(in srgb, var(--luna-surface) 72%, transparent));
+}
+
+a.luna-breadcrumb__item:focus-visible,
+button.luna-breadcrumb__item:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--luna-breadcrumb-focus-ring, rgba(99, 102, 241, 0.18));
+}
+
+.luna-breadcrumb__item--current {
+  color: var(--luna-breadcrumb-current-fg, var(--luna-foreground));
+  font-weight: 600;
+}
+
+.luna-breadcrumb__item--disabled {
+  color: var(--luna-breadcrumb-muted-fg, var(--luna-muted));
+  opacity: 0.72;
+}
+
+.luna-breadcrumb__separator,
+.luna-breadcrumb__ellipsis {
+  color: var(--luna-breadcrumb-separator-fg, var(--luna-muted));
+}
+
+.luna-breadcrumb__separator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--luna-breadcrumb-current-min-height);
+  font-size: var(--luna-breadcrumb-current-font-size);
+  line-height: 1;
+  user-select: none;
+}
+
+.luna-breadcrumb__ellipsis {
+  color: var(--luna-breadcrumb-muted-fg, var(--luna-muted));
+}
+
+.luna-breadcrumb[data-size="sm"] {
+  --luna-breadcrumb-current-gap: var(--luna-breadcrumb-size-sm-gap, var(--luna-space-1, 0.25rem));
+  --luna-breadcrumb-current-separator-gap: var(--luna-breadcrumb-size-sm-separator-gap, var(--luna-space-1, 0.25rem));
+  --luna-breadcrumb-current-font-size: var(--luna-breadcrumb-size-sm-font-size, 0.75rem);
+  --luna-breadcrumb-current-min-height: var(--luna-breadcrumb-size-sm-min-height, 1.5rem);
+  --luna-breadcrumb-current-padding-x: var(--luna-breadcrumb-size-sm-padding-x, var(--luna-space-1, 0.25rem));
+  --luna-breadcrumb-current-padding-y: var(--luna-breadcrumb-size-sm-padding-y, 0);
+}
+
+.luna-breadcrumb[data-size="md"] {
+  --luna-breadcrumb-current-gap: var(--luna-breadcrumb-size-md-gap, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-separator-gap: var(--luna-breadcrumb-size-md-separator-gap, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-font-size: var(--luna-breadcrumb-size-md-font-size, 0.875rem);
+  --luna-breadcrumb-current-min-height: var(--luna-breadcrumb-size-md-min-height, 2rem);
+  --luna-breadcrumb-current-padding-x: var(--luna-breadcrumb-size-md-padding-x, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-padding-y: var(--luna-breadcrumb-size-md-padding-y, 0);
+}
+
+.luna-breadcrumb[data-size="lg"] {
+  --luna-breadcrumb-current-gap: var(--luna-breadcrumb-size-lg-gap, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-separator-gap: var(--luna-breadcrumb-size-lg-separator-gap, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-font-size: var(--luna-breadcrumb-size-lg-font-size, 1rem);
+  --luna-breadcrumb-current-min-height: var(--luna-breadcrumb-size-lg-min-height, 2.5rem);
+  --luna-breadcrumb-current-padding-x: var(--luna-breadcrumb-size-lg-padding-x, var(--luna-space-2, 0.5rem));
+  --luna-breadcrumb-current-padding-y: var(--luna-breadcrumb-size-lg-padding-y, 0);
+}

--- a/src/components/luna-breadcrumb/LunaBreadcrumb.props.ts
+++ b/src/components/luna-breadcrumb/LunaBreadcrumb.props.ts
@@ -1,0 +1,24 @@
+import type React from "react";
+
+export type LunaBreadcrumbSize = "sm" | "md" | "lg";
+
+export type LunaBreadcrumbItem = {
+  key?: React.Key;
+  label: React.ReactNode;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  current?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+  target?: React.HTMLAttributeAnchorTarget;
+  rel?: string;
+};
+
+export type LunaBreadcrumbProps = Omit<React.HTMLAttributes<HTMLElement>, "children"> & {
+  items: LunaBreadcrumbItem[];
+  ariaLabel?: string;
+  separator?: React.ReactNode;
+  maxItems?: number;
+  size?: LunaBreadcrumbSize;
+  collapseLabel?: string;
+};

--- a/src/components/luna-breadcrumb/LunaBreadcrumb.stories.tsx
+++ b/src/components/luna-breadcrumb/LunaBreadcrumb.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaColumn } from "../luna-column";
+import { LunaText } from "../luna-text";
+import { LunaBreadcrumb } from "./LunaBreadcrumb";
+
+const items = [
+  { label: "Mission control", href: "#" },
+  { label: "Flights", href: "#" },
+  { label: "Europa relay", href: "#" },
+  { label: "Telemetry", current: true }
+];
+
+const meta = {
+  title: "Components/LunaBreadcrumb",
+  component: LunaBreadcrumb,
+  args: {
+    items,
+    size: "md",
+    separator: "/"
+  }
+} satisfies Meta<typeof LunaBreadcrumb>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const CollapsedTrail: Story = {
+  args: {
+    maxItems: 4,
+    items: [
+      { label: "Mission control", href: "#" },
+      { label: "Flights", href: "#" },
+      { label: "Outer system", href: "#" },
+      { label: "Europa relay", href: "#" },
+      { label: "Telemetry", href: "#" },
+      { label: "Packet detail", current: true }
+    ]
+  }
+};
+
+export const CustomSeparator: Story = {
+  args: {
+    separator: "•",
+    items: [
+      { label: "System map", href: "#" },
+      { label: "Habitat ring", href: "#" },
+      { label: "Life support", current: true }
+    ]
+  }
+};
+
+export const ActionTrail: Story = {
+  render: () => {
+    function ActionTrailStory() {
+      const [currentStep, setCurrentStep] = React.useState("Payload");
+
+      const actionItems = [
+        {
+          label: "Assembly",
+          current: currentStep === "Assembly",
+          onClick: () => setCurrentStep("Assembly")
+        },
+        {
+          label: "Fueling",
+          current: currentStep === "Fueling",
+          onClick: () => setCurrentStep("Fueling")
+        },
+        { label: "Payload", current: currentStep === "Payload" },
+        { label: "Launch window", disabled: true }
+      ];
+
+      return (
+        <LunaColumn gap="3">
+          <LunaBreadcrumb items={actionItems} separator=">" />
+          <LunaText variant="body-small" muted>
+            Current step: {currentStep}
+          </LunaText>
+        </LunaColumn>
+      );
+    }
+
+    return <ActionTrailStory />;
+  }
+};

--- a/src/components/luna-breadcrumb/LunaBreadcrumb.test.tsx
+++ b/src/components/luna-breadcrumb/LunaBreadcrumb.test.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaBreadcrumb } from "./LunaBreadcrumb";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("LunaBreadcrumb", () => {
+  it("renders navigation semantics and marks the current page", () => {
+    renderWithTheme(
+      <LunaBreadcrumb
+        items={[
+          { label: "Mission control", href: "#" },
+          { label: "Flights", href: "#" },
+          { label: "Telemetry", current: true }
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Mission control" })).toHaveAttribute("href", "#");
+    expect(screen.getByText("Telemetry")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("uses the last item as current when no explicit current item is provided", () => {
+    renderWithTheme(
+      <LunaBreadcrumb
+        items={[
+          { label: "Mission control", href: "#" },
+          { label: "Flights", href: "#" },
+          { label: "Telemetry" }
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Telemetry")).toHaveAttribute("aria-current", "page");
+    expect(screen.queryByRole("link", { name: "Telemetry" })).not.toBeInTheDocument();
+  });
+
+  it("collapses long trails around the current item", () => {
+    renderWithTheme(
+      <LunaBreadcrumb
+        maxItems={4}
+        items={[
+          { label: "Mission control", href: "#" },
+          { label: "Flights", href: "#" },
+          { label: "Outer system", href: "#" },
+          { label: "Europa relay", href: "#" },
+          { label: "Telemetry", href: "#" },
+          { label: "Packet detail", current: true }
+        ]}
+      />
+    );
+
+    expect(screen.getByLabelText("Collapsed breadcrumb items")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Flights" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Telemetry" })).toBeInTheDocument();
+    expect(screen.getByText("Packet detail")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("supports button actions for non-link items", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    renderWithTheme(
+      <LunaBreadcrumb
+        items={[
+          { label: "Mission control", onClick },
+          { label: "Telemetry", current: true }
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Mission control" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves breadcrumb theme tokens through the theme system", () => {
+    const { container } = renderWithTheme(
+      <LunaBreadcrumb
+        size="lg"
+        items={[
+          { label: "Mission control", href: "#" },
+          { label: "Telemetry", current: true }
+        ]}
+      />,
+      {
+        theme: {
+          components: {
+            breadcrumb: {
+              radius: "pill",
+              modes: {
+                light: {
+                  linkFg: "accent.500",
+                  currentFg: "neutral.900",
+                  mutedFg: "neutral.500",
+                  separatorFg: "warning.500",
+                  hoverBg: "neutral.100",
+                  focusRing: "rgba(139, 92, 246, 0.24)"
+                }
+              },
+              sizes: {
+                lg: {
+                  gap: "3",
+                  separatorGap: "2",
+                  fontSize: "lg",
+                  minHeight: "12",
+                  paddingX: "3",
+                  paddingY: "1"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const providerRoot = container.querySelector("[data-luna-theme]");
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+
+    expect(providerRoot).toHaveStyle({
+      "--luna-breadcrumb-radius": "999px",
+      "--luna-breadcrumb-link-fg": "#8b5cf6",
+      "--luna-breadcrumb-separator-fg": "#f97316",
+      "--luna-breadcrumb-size-lg-gap": "0.75rem",
+      "--luna-breadcrumb-size-lg-min-height": "3rem"
+    });
+    expect(breadcrumb).toHaveAttribute("data-size", "lg");
+  });
+});

--- a/src/components/luna-breadcrumb/LunaBreadcrumb.tsx
+++ b/src/components/luna-breadcrumb/LunaBreadcrumb.tsx
@@ -1,0 +1,173 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import type { LunaBreadcrumbItem, LunaBreadcrumbProps } from "./LunaBreadcrumb.props";
+import "./LunaBreadcrumb.css";
+
+type DisplayItem =
+  | { kind: "item"; item: LunaBreadcrumbItem; index: number }
+  | { kind: "ellipsis"; key: string };
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getCurrentIndex(items: LunaBreadcrumbItem[]) {
+  const explicitIndex = items.findIndex((item) => item.current);
+
+  if (explicitIndex >= 0) {
+    return explicitIndex;
+  }
+
+  return items.length > 0 ? items.length - 1 : -1;
+}
+
+function buildDisplayItems(items: LunaBreadcrumbItem[], currentIndex: number, maxItems?: number) {
+  if (!Number.isFinite(maxItems) || maxItems === undefined) {
+    return items.map<DisplayItem>((item, index) => ({ kind: "item", item, index }));
+  }
+
+  const resolvedMaxItems = Math.trunc(maxItems);
+
+  if (resolvedMaxItems < 3 || items.length <= resolvedMaxItems) {
+    return items.map<DisplayItem>((item, index) => ({ kind: "item", item, index }));
+  }
+
+  const middleSlots = resolvedMaxItems - 2;
+  const middleStart = 1;
+  const middleEnd = items.length - 2;
+  const centeredStart = currentIndex - Math.floor((middleSlots - 1) / 2);
+  const start = clamp(centeredStart, middleStart, middleEnd - middleSlots + 1);
+  const end = start + middleSlots - 1;
+  const displayItems: DisplayItem[] = [{ kind: "item", item: items[0], index: 0 }];
+
+  if (start > middleStart) {
+    displayItems.push({ kind: "ellipsis", key: "start" });
+  }
+
+  for (let index = start; index <= end; index += 1) {
+    displayItems.push({ kind: "item", item: items[index], index });
+  }
+
+  if (end < middleEnd) {
+    displayItems.push({ kind: "ellipsis", key: "end" });
+  }
+
+  displayItems.push({
+    kind: "item",
+    item: items[items.length - 1],
+    index: items.length - 1
+  });
+
+  return displayItems;
+}
+
+function getItemKey(item: LunaBreadcrumbItem, index: number) {
+  if (item.key !== undefined && item.key !== null) {
+    return item.key;
+  }
+
+  return `breadcrumb-item-${index}`;
+}
+
+export const LunaBreadcrumb = React.forwardRef<HTMLElement, LunaBreadcrumbProps>(
+  function LunaBreadcrumb(
+    {
+      ariaLabel = "Breadcrumb",
+      className,
+      collapseLabel = "Collapsed breadcrumb items",
+      items,
+      maxItems,
+      separator = "/",
+      size,
+      style,
+      ...props
+    },
+    ref
+  ) {
+    const { theme } = useTheme();
+
+    if (items.length === 0) {
+      return null;
+    }
+
+    const currentIndex = getCurrentIndex(items);
+    const displayItems = buildDisplayItems(items, currentIndex, maxItems);
+    const resolvedSize = size ?? theme.components.breadcrumb?.defaultSize ?? "md";
+
+    return (
+      <nav
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-breadcrumb", className])}
+        aria-label={ariaLabel}
+        data-size={resolvedSize}
+        style={style}
+      >
+        <ol className="luna-breadcrumb__list">
+          {displayItems.map((entry, displayIndex) => {
+            if (entry.kind === "ellipsis") {
+              return (
+                <li className="luna-breadcrumb__entry" key={`ellipsis-${entry.key}`}>
+                  <span className="luna-breadcrumb__separator" aria-hidden="true">
+                    {separator}
+                  </span>
+                  <span className="luna-breadcrumb__ellipsis" aria-label={collapseLabel} role="img">
+                    …
+                  </span>
+                </li>
+              );
+            }
+
+            const { item, index } = entry;
+            const isCurrent = index === currentIndex;
+            const isInteractive = !item.disabled && !isCurrent && (Boolean(item.href) || Boolean(item.onClick));
+            const commonProps = {
+              className: toClassName([
+                "luna-breadcrumb__item",
+                isCurrent && "luna-breadcrumb__item--current",
+                item.disabled && "luna-breadcrumb__item--disabled"
+              ]),
+              "aria-current": isCurrent ? ("page" as const) : undefined,
+              "aria-label": item.ariaLabel
+            };
+
+            return (
+              <li className="luna-breadcrumb__entry" key={getItemKey(item, index)}>
+                {displayIndex > 0 ? (
+                  <span className="luna-breadcrumb__separator" aria-hidden="true">
+                    {separator}
+                  </span>
+                ) : null}
+                {isInteractive && item.href ? (
+                  <a
+                    {...commonProps}
+                    href={item.href}
+                    onClick={item.onClick as React.MouseEventHandler<HTMLAnchorElement> | undefined}
+                    target={item.target}
+                    rel={item.rel}
+                  >
+                    {item.label}
+                  </a>
+                ) : isInteractive ? (
+                  <button
+                    {...commonProps}
+                    type="button"
+                    onClick={item.onClick as React.MouseEventHandler<HTMLButtonElement> | undefined}
+                  >
+                    {item.label}
+                  </button>
+                ) : (
+                  <span {...commonProps}>{item.label}</span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    );
+  }
+);

--- a/src/components/luna-breadcrumb/index.ts
+++ b/src/components/luna-breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaBreadcrumb";
+export * from "./LunaBreadcrumb.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -73,6 +73,14 @@ describe("theme size contract", () => {
     expect(drawer?.defaultSize).toBe("28rem");
   });
 
+  it("defines breadcrumb defaults and size tiers", () => {
+    const breadcrumb = lunarTheme.components.breadcrumb;
+
+    expect(breadcrumb?.defaultSize).toBe("md");
+    expect(breadcrumb?.radius).toBe("sm");
+    expect(Object.keys(breadcrumb?.sizes ?? {})).toEqual(["sm", "md", "lg"]);
+  });
+
   it("defines modal defaults and supported size tiers", () => {
     const modal = lunarTheme.components.modal;
 

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1310,6 +1310,54 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    breadcrumb: {
+      defaultSize: "md",
+      radius: "sm",
+      sizes: {
+        sm: {
+          gap: "1",
+          separatorGap: "1",
+          fontSize: "xs",
+          minHeight: "6",
+          paddingX: "1",
+          paddingY: "0"
+        },
+        md: {
+          gap: "2",
+          separatorGap: "2",
+          fontSize: "sm",
+          minHeight: "8",
+          paddingX: "2",
+          paddingY: "0"
+        },
+        lg: {
+          gap: "2",
+          separatorGap: "2",
+          fontSize: "md",
+          minHeight: "10",
+          paddingX: "2",
+          paddingY: "0"
+        }
+      },
+      modes: {
+        light: {
+          linkFg: "neutral.700",
+          currentFg: "neutral.900",
+          mutedFg: "neutral.500",
+          separatorFg: "neutral.400",
+          hoverBg: "neutral.100",
+          focusRing: "rgba(99, 102, 241, 0.18)"
+        },
+        dark: {
+          linkFg: "neutral.200",
+          currentFg: "neutral.50",
+          mutedFg: "neutral.400",
+          separatorFg: "neutral.500",
+          hoverBg: "neutral.800",
+          focusRing: "rgba(129, 140, 248, 0.24)"
+        }
+      }
+    },
     modal: {
       defaultSize: "medium",
       defaultPadding: "5",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -303,6 +303,24 @@ export type ThemeDrawerModeTokens = {
   backdrop?: string;
 };
 
+export type ThemeBreadcrumbSizeProfile = {
+  gap?: string;
+  separatorGap?: string;
+  fontSize?: string;
+  minHeight?: string;
+  paddingX?: string;
+  paddingY?: string;
+};
+
+export type ThemeBreadcrumbModeTokens = {
+  linkFg?: string;
+  currentFg?: string;
+  mutedFg?: string;
+  separatorFg?: string;
+  hoverBg?: string;
+  focusRing?: string;
+};
+
 export type ThemeModalSizeProfile = {
   maxWidth?: string;
 };
@@ -426,6 +444,12 @@ export type ThemeComponents = {
     radius?: string;
     shadow?: string;
     modes?: Partial<Record<ThemeMode, ThemeDrawerModeTokens>>;
+  };
+  breadcrumb?: {
+    defaultSize?: "sm" | "md" | "lg";
+    radius?: string;
+    sizes?: Record<string, ThemeBreadcrumbSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemeBreadcrumbModeTokens>>;
   };
 
   modal?: {

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -541,6 +541,62 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     vars["--luna-drawer-backdrop"] = resolveTokenValue(theme, drawerMode.backdrop);
   }
 
+  const breadcrumb = theme.components.breadcrumb;
+  if (breadcrumb?.defaultSize) {
+    vars["--luna-breadcrumb-size-default"] = breadcrumb.defaultSize;
+  }
+  if (breadcrumb?.radius) {
+    vars["--luna-breadcrumb-radius"] =
+      resolveScaleValue(theme.radii, breadcrumb.radius) ?? breadcrumb.radius;
+  }
+  const breadcrumbMode = breadcrumb?.modes?.[mode];
+  if (breadcrumbMode?.linkFg) {
+    vars["--luna-breadcrumb-link-fg"] = resolveTokenValue(theme, breadcrumbMode.linkFg);
+  }
+  if (breadcrumbMode?.currentFg) {
+    vars["--luna-breadcrumb-current-fg"] = resolveTokenValue(theme, breadcrumbMode.currentFg);
+  }
+  if (breadcrumbMode?.mutedFg) {
+    vars["--luna-breadcrumb-muted-fg"] = resolveTokenValue(theme, breadcrumbMode.mutedFg);
+  }
+  if (breadcrumbMode?.separatorFg) {
+    vars["--luna-breadcrumb-separator-fg"] = resolveTokenValue(theme, breadcrumbMode.separatorFg);
+  }
+  if (breadcrumbMode?.hoverBg) {
+    vars["--luna-breadcrumb-hover-bg"] = resolveTokenValue(theme, breadcrumbMode.hoverBg);
+  }
+  if (breadcrumbMode?.focusRing) {
+    vars["--luna-breadcrumb-focus-ring"] = breadcrumbMode.focusRing;
+  }
+  if (breadcrumb?.sizes) {
+    for (const [name, profile] of Object.entries(breadcrumb.sizes)) {
+      if (profile.gap) {
+        vars[`--luna-breadcrumb-size-${name}-gap`] =
+          resolveScaleValue(theme.spacing, profile.gap) ?? profile.gap;
+      }
+      if (profile.separatorGap) {
+        vars[`--luna-breadcrumb-size-${name}-separator-gap`] =
+          resolveScaleValue(theme.spacing, profile.separatorGap) ?? profile.separatorGap;
+      }
+      if (profile.fontSize) {
+        vars[`--luna-breadcrumb-size-${name}-font-size`] =
+          resolveScaleValue(theme.typography.sizes, profile.fontSize) ?? profile.fontSize;
+      }
+      if (profile.minHeight) {
+        vars[`--luna-breadcrumb-size-${name}-min-height`] =
+          resolveScaleValue(theme.spacing, profile.minHeight) ?? profile.minHeight;
+      }
+      if (profile.paddingX) {
+        vars[`--luna-breadcrumb-size-${name}-padding-x`] =
+          resolveScaleValue(theme.spacing, profile.paddingX) ?? profile.paddingX;
+      }
+      if (profile.paddingY) {
+        vars[`--luna-breadcrumb-size-${name}-padding-y`] =
+          resolveScaleValue(theme.spacing, profile.paddingY) ?? profile.paddingY;
+      }
+    }
+  }
+
   const modal = theme.components.modal;
   if (modal?.defaultSize) {
     vars["--luna-modal-size-default"] = modal.defaultSize;


### PR DESCRIPTION
Closes #26

storybook-component: luna-breadcrumb

## Summary
Implemented `LunaBreadcrumb` as an issue-scoped composite with docs, Storybook, tests, theme wiring, and release metadata.

- Added the component contract, collapsing logic, current-page semantics, and routing-agnostic link or button rendering in [LunaBreadcrumb.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/LunaBreadcrumb.tsx#L1), with styles and exports in [LunaBreadcrumb.css](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/LunaBreadcrumb.css), [LunaBreadcrumb.props.ts](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/LunaBreadcrumb.props.ts), and [index.ts](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/index.ts).
- Added Storybook coverage and visual-review metadata for the `luna-breadcrumb` slug in [LunaBreadcrumb.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/LunaBreadcrumb.stories.tsx#L1) and [luna-breadcrumb.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-breadcrumb.json).
- Added issue-facing docs and release metadata in [LunaBreadcrumb.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaBreadcrumb.md#L1) and [luna-breadcrumb.md](/Users/jordanb/.codex/automations/react-luna/.changeset/luna-breadcrumb.md).
- Wired theme support and public exports in [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts), [types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts), [vars.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/vars.ts), and [src/components/index.ts](/Users/jordanb/.codex/automations/react-luna/src/components/index.ts#L1).
- Added tests in [LunaBreadcrumb.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-breadcrumb/LunaBreadcrumb.test.tsx#L1) and a theme default assertion in [base.test.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.test.ts#L1).

Verification:
- Ran `npx vitest run src/components/luna-breadcrumb/LunaBreadcrumb.test.tsx src/theme/base.test.ts` and it passed.
- Ran `npm run build` and it passed.
- Ran `npm run storybook:build` and it passed.
- Ran `STORYBOOK_COMPONENT=luna-breadcrumb npm run screenshots:storybook:list` and it listed 5 breadcrumb captures from the manifest.
- Ran `STORYBOOK_COMPONENT=luna-breadcrumb npm run screenshots:storybook`, but Playwright could not start its local static server in this sandbox: `listen EPERM 127.0.0.1:6106`.

I could not make the workflow commit because the sandbox blocks `.git` writes: `Unable to create '.git/index.lock': Operation not permitted`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`