### PR TITLE
Resolve #27: Build LunaSidebar composite

### DIFF
--- a/.changeset/luna-sidebar-composite.md
+++ b/.changeset/luna-sidebar-composite.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaSidebar` composite with theme support, Storybook coverage, tests, screenshot metadata, and public documentation.

--- a/docs/v1/components/LunaSidebar.md
+++ b/docs/v1/components/LunaSidebar.md
@@ -1,0 +1,60 @@
+# LunaSidebar
+
+`LunaSidebar` is the persistent side-surface composite for secondary page structure in `react-luna`.
+
+It owns:
+- one sidebar surface with optional header and footer regions
+- theme-driven width and spacing
+- optional sticky positioning relative to the viewport
+
+It does not own:
+- navigation state
+- route awareness
+- active-link styling rules
+- responsive page-shell orchestration
+
+Default element:
+- `aside`
+
+## Props
+
+- `as?: React.ElementType`
+- `header?: React.ReactNode`
+- `footer?: React.ReactNode`
+- `width?: string`
+- `padding?: string`
+- `gap?: string`
+- `sticky?: boolean`
+- `stickyOffset?: string`
+
+Native `HTMLAttributes<HTMLElement>` continue to pass through to the root. Use `aria-label` or `aria-labelledby` when the sidebar provides navigation or landmark semantics that need a specific announcement.
+
+## Contract
+
+- the default root element is `aside`
+- `header` renders above the body region without forcing title or action prop shapes
+- `children` render in the main content region
+- `footer` renders below the body region with a subtle divider
+- `width`, `padding`, `gap`, and `stickyOffset` resolve through theme spacing first, then raw CSS values
+- `sticky` enables `position: sticky` on the root and uses the resolved sticky offset
+- `className` and `style` pass through to the root
+
+## Theme Integration
+
+`LunaSidebar` consumes the existing theme system for:
+- default width
+- default padding
+- default gap
+- default sticky offset
+- radius
+- shadow
+- light and dark surface tokens
+
+## Accessibility Notes
+
+`LunaSidebar` is a structural composite, not a navigation manager.
+
+Consumers remain responsible for:
+- choosing the correct landmark element with `as`
+- providing `aria-label` or `aria-labelledby` when needed
+- marking active links or actions inside the sidebar

--- a/docs/v1/design/LunaSidebar.md
+++ b/docs/v1/design/LunaSidebar.md
@@ -1,0 +1,41 @@
+# LunaSidebar
+
+## Purpose
+
+`LunaSidebar` provides one persistent side-surface for supporting page context without turning that surface into a route-aware application shell.
+
+It is the right place for:
+- grouped navigation links
+- filters and secondary controls
+- pinned status, metadata, or utility actions
+
+## Design Rules
+
+- keep the contract narrower than a full layout shell
+- let `LunaHeader`, `LunaButton`, `LunaMenu`, and layout primitives compose inside it
+- make width and spacing theme-driven
+- allow sticky behavior without forcing it
+- keep responsive page rearrangement in application code
+
+## Distinction From Neighboring Components
+
+The intended split is:
+
+- `LunaCard` handles general-purpose grouped surfaces
+- `LunaDrawer` handles temporary edge overlays
+- `LunaSidebar` handles persistent secondary structure inside the normal page flow
+
+That keeps `LunaSidebar` focused on structural persistence instead of overlay behavior or route orchestration.
+
+## Theme Expectations
+
+The sidebar theme slice should remain responsible for:
+- default width
+- default padding
+- default gap
+- default sticky offset
+- radius
+- shadow
+- light and dark surface tokens
+
+Future work can build navigation patterns on top of the sidebar, but the base contract should stay content-agnostic and easy to override.

--- a/playwright/storybook/manifests/luna-sidebar.json
+++ b/playwright/storybook/manifests/luna-sidebar.json
@@ -1,0 +1,12 @@
+[
+  {
+    "storyId": "components-lunasidebar--playground",
+    "fileName": "luna-sidebar-playground",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunasidebar--layout-preview",
+    "fileName": "luna-sidebar-layout-preview",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,7 @@ export * from "./luna-input";
 export * from "./luna-menu";
 export * from "./luna-progress";
 export * from "./luna-slider";
+export * from "./luna-sidebar";
 export * from "./luna-textarea";
 export * from "./luna-select";
 export * from "./luna-multiselect";

--- a/src/components/luna-sidebar/LunaSidebar.css
+++ b/src/components/luna-sidebar/LunaSidebar.css
@@ -1,0 +1,48 @@
+.luna-sidebar {
+  display: grid;
+  align-content: start;
+  gap: var(--luna-sidebar-gap, var(--luna-sidebar-gap-default, var(--luna-space-4)));
+  width: min(var(--luna-sidebar-width, var(--luna-sidebar-width-default, 18rem)), 100%);
+  min-width: 0;
+  padding: var(--luna-sidebar-padding, var(--luna-sidebar-padding-default, var(--luna-space-5)));
+  border: 1px solid var(--luna-sidebar-border, var(--luna-border));
+  border-radius: var(--luna-sidebar-radius, var(--luna-radius-lg));
+  background: var(--luna-sidebar-bg, var(--luna-surface));
+  color: var(--luna-sidebar-fg, var(--luna-foreground));
+  box-shadow: var(--luna-sidebar-shadow, var(--luna-shadow-sm));
+}
+
+.luna-sidebar[data-sticky="true"] {
+  position: sticky;
+  top: var(
+    --luna-sidebar-sticky-offset,
+    var(--luna-sidebar-sticky-offset-default, var(--luna-space-4))
+  );
+  align-self: start;
+}
+
+.luna-sidebar__header,
+.luna-sidebar__content,
+.luna-sidebar__footer {
+  min-width: 0;
+}
+
+.luna-sidebar__content {
+  display: grid;
+  gap: calc(var(--luna-sidebar-gap, var(--luna-sidebar-gap-default, var(--luna-space-4))) * 0.75);
+  align-content: start;
+}
+
+.luna-sidebar__footer {
+  padding-top: calc(
+    var(--luna-sidebar-gap, var(--luna-sidebar-gap-default, var(--luna-space-4))) * 0.5
+  );
+  border-top: 1px solid
+    color-mix(in srgb, var(--luna-sidebar-border, var(--luna-border)) 72%, transparent);
+}
+
+@media (max-width: 768px) {
+  .luna-sidebar {
+    width: 100%;
+  }
+}

--- a/src/components/luna-sidebar/LunaSidebar.props.ts
+++ b/src/components/luna-sidebar/LunaSidebar.props.ts
@@ -1,0 +1,12 @@
+import type React from "react";
+
+export type LunaSidebarProps = Omit<React.HTMLAttributes<HTMLElement>, "color"> & {
+  as?: React.ElementType;
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  width?: string;
+  padding?: string;
+  gap?: string;
+  sticky?: boolean;
+  stickyOffset?: string;
+};

--- a/src/components/luna-sidebar/LunaSidebar.stories.tsx
+++ b/src/components/luna-sidebar/LunaSidebar.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaButton } from "../luna-button";
+import { LunaHeader } from "../luna-header";
+import { LunaSidebar } from "./LunaSidebar";
+
+const meta = {
+  title: "Components/LunaSidebar",
+  component: LunaSidebar,
+  args: {
+    sticky: true,
+    header: (
+      <LunaHeader
+        title="Operations"
+        subtitle="Keep persistent actions and status grouped beside the main page flow."
+      />
+    ),
+    children: (
+      <nav aria-label="Sidebar sections" style={{ display: "grid", gap: "0.75rem" }}>
+        <a href="#overview">Overview</a>
+        <a href="#activity">Activity</a>
+        <a href="#alerts">Alerts</a>
+        <a href="#team">Team</a>
+      </nav>
+    ),
+    footer: (
+      <div style={{ display: "grid", gap: "0.75rem" }}>
+        <LunaButton>Primary action</LunaButton>
+        <LunaButton flat>Secondary action</LunaButton>
+      </div>
+    )
+  }
+} satisfies Meta<typeof LunaSidebar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const LayoutPreview: Story = {
+  parameters: {
+    layout: "fullscreen"
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 20rem) minmax(0, 1fr)",
+        gap: "1.5rem",
+        minHeight: "100vh",
+        padding: "2rem",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--luna-background) 96%, white) 0%, var(--luna-background) 100%)"
+      }}
+    >
+      <LunaSidebar {...args} />
+      <main
+        style={{
+          display: "grid",
+          alignContent: "start",
+          gap: "1rem",
+          padding: "2rem",
+          border: "1px solid var(--luna-border)",
+          borderRadius: "1rem",
+          background: "var(--luna-surface)"
+        }}
+      >
+        <LunaHeader
+          title="Mission control"
+          subtitle="The sidebar stays visible while the main content scrolls independently."
+        />
+        {Array.from({ length: 6 }, (_, index) => (
+          <section
+            key={index}
+            style={{
+              minHeight: "7rem",
+              padding: "1rem",
+              borderRadius: "0.75rem",
+              background: "color-mix(in srgb, var(--luna-surface) 84%, var(--luna-background))",
+              border: "1px solid color-mix(in srgb, var(--luna-border) 80%, transparent)"
+            }}
+          >
+            Content section {index + 1}
+          </section>
+        ))}
+      </main>
+    </div>
+  )
+};
+
+export const CustomWidth: Story = {
+  args: {
+    sticky: false,
+    width: "22rem"
+  }
+};

--- a/src/components/luna-sidebar/LunaSidebar.test.tsx
+++ b/src/components/luna-sidebar/LunaSidebar.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaHeader } from "../luna-header";
+import { LunaSidebar } from "./LunaSidebar";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaSidebar", () => {
+  it("renders as an aside by default with header, content, and footer regions", () => {
+    renderWithTheme(
+      <LunaSidebar
+        header={<LunaHeader title="Workspace" subtitle="Primary navigation" />}
+        footer={<button type="button">Invite</button>}
+      >
+        <nav aria-label="Workspace sections">
+          <a href="#overview">Overview</a>
+        </nav>
+      </LunaSidebar>
+    );
+
+    const sidebar = screen.getByText("Workspace").closest(".luna-sidebar");
+
+    expect(sidebar?.tagName).toBe("ASIDE");
+    expect(sidebar?.querySelector(".luna-sidebar__header")).not.toBeNull();
+    expect(sidebar?.querySelector(".luna-sidebar__content")).not.toBeNull();
+    expect(sidebar?.querySelector(".luna-sidebar__footer")).not.toBeNull();
+    expect(screen.getByRole("navigation", { name: "Workspace sections" })).toBeInTheDocument();
+  });
+
+  it("supports semantic element overrides and forwards refs", () => {
+    const ref = React.createRef<HTMLElement>();
+
+    renderWithTheme(
+      <LunaSidebar as="nav" ref={ref} aria-label="Primary sidebar">
+        Links
+      </LunaSidebar>
+    );
+
+    const sidebar = screen.getByRole("navigation", { name: "Primary sidebar" });
+
+    expect(sidebar.tagName).toBe("NAV");
+    expect(ref.current).toBe(sidebar);
+  });
+
+  it("resolves spacing overrides and sticky offset through theme spacing", () => {
+    renderWithTheme(
+      <LunaSidebar
+        data-testid="sidebar"
+        gap="6"
+        padding="8"
+        sticky
+        stickyOffset="10"
+        width="16"
+      >
+        Content
+      </LunaSidebar>
+    );
+
+    expect(screen.getByTestId("sidebar")).toHaveStyle({
+      "--luna-sidebar-gap": "1.5rem",
+      "--luna-sidebar-padding": "2rem",
+      "--luna-sidebar-sticky-offset": "2.5rem",
+      "--luna-sidebar-width": "4rem"
+    });
+    expect(screen.getByTestId("sidebar")).toHaveAttribute("data-sticky", "true");
+  });
+
+  it("omits empty header and footer wrappers when they are not provided", () => {
+    renderWithTheme(<LunaSidebar data-testid="sidebar">Content</LunaSidebar>);
+
+    const sidebar = screen.getByTestId("sidebar");
+
+    expect(sidebar.querySelector(".luna-sidebar__header")).toBeNull();
+    expect(sidebar.querySelector(".luna-sidebar__footer")).toBeNull();
+    expect(sidebar.querySelector(".luna-sidebar__content")).not.toBeNull();
+  });
+});

--- a/src/components/luna-sidebar/LunaSidebar.tsx
+++ b/src/components/luna-sidebar/LunaSidebar.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import type { LunaSidebarProps } from "./LunaSidebar.props";
+import "./LunaSidebar.css";
+
+type SidebarCssVariable =
+  | "--luna-sidebar-width"
+  | "--luna-sidebar-padding"
+  | "--luna-sidebar-gap"
+  | "--luna-sidebar-sticky-offset";
+
+type LunaSidebarStyle = React.CSSProperties &
+  Partial<Record<SidebarCssVariable, string | number | undefined>>;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+export const LunaSidebar = React.forwardRef<HTMLElement, LunaSidebarProps>(function LunaSidebar(
+  {
+    as,
+    children,
+    className,
+    footer,
+    gap,
+    header,
+    padding,
+    sticky = false,
+    stickyOffset,
+    style,
+    width,
+    ...props
+  },
+  ref
+) {
+  const { theme } = useTheme();
+  const Component = (as ?? "aside") as React.ElementType;
+  const resolvedWidth = resolveSpacingValue(width, theme) ?? width ?? theme.components.sidebar?.defaultWidth;
+  const resolvedPadding =
+    resolveSpacingValue(padding, theme) ??
+    resolveSpacingValue(theme.components.sidebar?.defaultPadding, theme) ??
+    theme.components.sidebar?.defaultPadding;
+  const resolvedGap =
+    resolveSpacingValue(gap, theme) ??
+    resolveSpacingValue(theme.components.sidebar?.defaultGap, theme) ??
+    theme.components.sidebar?.defaultGap;
+  const resolvedStickyOffset =
+    resolveSpacingValue(stickyOffset, theme) ??
+    resolveSpacingValue(theme.components.sidebar?.defaultStickyOffset, theme) ??
+    theme.components.sidebar?.defaultStickyOffset;
+
+  const resolvedStyle: LunaSidebarStyle = {
+    ...(resolvedWidth ? { ["--luna-sidebar-width" as const]: resolvedWidth } : {}),
+    ...(resolvedPadding ? { ["--luna-sidebar-padding" as const]: resolvedPadding } : {}),
+    ...(resolvedGap ? { ["--luna-sidebar-gap" as const]: resolvedGap } : {}),
+    ...(resolvedStickyOffset
+      ? { ["--luna-sidebar-sticky-offset" as const]: resolvedStickyOffset }
+      : {}),
+    ...style
+  };
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      className={toClassName(["luna-sidebar", className])}
+      data-sticky={sticky ? "true" : "false"}
+      style={resolvedStyle}
+    >
+      {header ? <div className="luna-sidebar__header">{header}</div> : null}
+      {children !== undefined && children !== null ? (
+        <div className="luna-sidebar__content">{children}</div>
+      ) : null}
+      {footer ? <div className="luna-sidebar__footer">{footer}</div> : null}
+    </Component>
+  );
+});

--- a/src/components/luna-sidebar/index.ts
+++ b/src/components/luna-sidebar/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaSidebar";
+export * from "./LunaSidebar.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -73,6 +73,15 @@ describe("theme size contract", () => {
     expect(drawer?.defaultSize).toBe("28rem");
   });
 
+  it("defines sidebar defaults for the persistent side surface", () => {
+    const sidebar = lunarTheme.components.sidebar;
+
+    expect(sidebar?.defaultWidth).toBe("18rem");
+    expect(sidebar?.defaultPadding).toBe("5");
+    expect(sidebar?.defaultGap).toBe("4");
+    expect(sidebar?.defaultStickyOffset).toBe("4");
+  });
+
   it("defines modal defaults and supported size tiers", () => {
     const modal = lunarTheme.components.modal;
 

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1287,6 +1287,28 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    sidebar: {
+      defaultWidth: "18rem",
+      defaultPadding: "5",
+      defaultGap: "4",
+      defaultStickyOffset: "4",
+      radius: "lg",
+      shadow: "sm",
+      modes: {
+        light: {
+          bg: "neutral.50",
+          fg: "neutral.900",
+          border: "neutral.200",
+          shadow: "0 10px 28px rgba(15, 23, 42, 0.08)"
+        },
+        dark: {
+          bg: "neutral.800",
+          fg: "neutral.50",
+          border: "neutral.700",
+          shadow: "0 14px 32px rgba(2, 6, 23, 0.28)"
+        }
+      }
+    },
     drawer: {
       defaultPadding: "5",
       defaultGap: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -294,6 +294,13 @@ export type ThemeAccordionModeTokens = {
   panelFg?: string;
 };
 
+export type ThemeSidebarModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  shadow?: string;
+};
+
 export type ThemeDrawerPlacement = "left" | "right" | "top" | "bottom";
 
 export type ThemeDrawerModeTokens = {
@@ -416,6 +423,15 @@ export type ThemeComponents = {
         >
       >
     >;
+  };
+  sidebar?: {
+    defaultWidth?: string;
+    defaultPadding?: string;
+    defaultGap?: string;
+    defaultStickyOffset?: string;
+    radius?: string;
+    shadow?: string;
+    modes?: Partial<Record<ThemeMode, ThemeSidebarModeTokens>>;
   };
   drawer?: {
     defaultPadding?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -201,6 +201,47 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
       resolveTokenValue(theme, cardMode.hoverShadow);
   }
 
+  const sidebar = theme.components.sidebar;
+  if (sidebar?.defaultWidth) {
+    vars["--luna-sidebar-width-default"] =
+      resolveScaleValue(theme.spacing, sidebar.defaultWidth) ?? sidebar.defaultWidth;
+  }
+  if (sidebar?.defaultPadding) {
+    vars["--luna-sidebar-padding-default"] =
+      resolveScaleValue(theme.spacing, sidebar.defaultPadding) ?? sidebar.defaultPadding;
+  }
+  if (sidebar?.defaultGap) {
+    vars["--luna-sidebar-gap-default"] =
+      resolveScaleValue(theme.spacing, sidebar.defaultGap) ?? sidebar.defaultGap;
+  }
+  if (sidebar?.defaultStickyOffset) {
+    vars["--luna-sidebar-sticky-offset-default"] =
+      resolveScaleValue(theme.spacing, sidebar.defaultStickyOffset) ?? sidebar.defaultStickyOffset;
+  }
+  if (sidebar?.radius) {
+    vars["--luna-sidebar-radius"] =
+      resolveScaleValue(theme.radii, sidebar.radius) ?? sidebar.radius;
+  }
+  if (sidebar?.shadow) {
+    vars["--luna-sidebar-shadow"] =
+      resolveScaleValue(theme.shadows, sidebar.shadow) ?? resolveTokenValue(theme, sidebar.shadow);
+  }
+  const sidebarMode = sidebar?.modes?.[mode];
+  if (sidebarMode?.bg) {
+    vars["--luna-sidebar-bg"] = resolveTokenValue(theme, sidebarMode.bg);
+  }
+  if (sidebarMode?.fg) {
+    vars["--luna-sidebar-fg"] = resolveTokenValue(theme, sidebarMode.fg);
+  }
+  if (sidebarMode?.border) {
+    vars["--luna-sidebar-border"] = resolveTokenValue(theme, sidebarMode.border);
+  }
+  if (sidebarMode?.shadow) {
+    vars["--luna-sidebar-shadow"] =
+      resolveScaleValue(theme.shadows, sidebarMode.shadow) ??
+      resolveTokenValue(theme, sidebarMode.shadow);
+  }
+
   const accordion = theme.components.accordion;
   if (accordion?.defaultGap) {
     vars["--luna-accordion-gap-default"] =


### PR DESCRIPTION
Closes #27

storybook-component: luna-sidebar

## Summary
Implemented `LunaSidebar` as a narrow persistent side-surface composite with optional header and footer regions, theme-driven width and spacing, and optional sticky behavior in [LunaSidebar.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-sidebar/LunaSidebar.tsx), with matching styles, stories, tests, export wiring, theme defaults, docs, screenshot metadata, and a changeset. The main contract and docs landed in [LunaSidebar.props.ts](/Users/jordanb/.codex/automations/react-luna/src/components/luna-sidebar/LunaSidebar.props.ts), [LunaSidebar.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-sidebar/LunaSidebar.stories.tsx), [LunaSidebar.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-sidebar/LunaSidebar.test.tsx), [LunaSidebar.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaSidebar.md), [LunaSidebar.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaSidebar.md), [luna-sidebar.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-sidebar.json), and [.changeset/luna-sidebar-composite.md](/Users/jordanb/.codex/automations/react-luna/.changeset/luna-sidebar-composite.md). Theme support was added in [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts), [types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts), and [vars.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/vars.ts).

Verification I ran:
- `npm run test -- src/components/luna-sidebar/LunaSidebar.test.tsx src/theme/base.test.ts` and it passed: 2 files, 11 tests.
- `npm run build` and it passed.
- `npm run storybook:build` and it passed.
- `STORYBOOK_COMPONENT=luna-sidebar npm run screenshots:storybook` and it ran but failed in this sandbox because Playwright could not bind `127.0.0.1:6106` (`EPERM`).
- `STORYBOOK_COMPONENT=luna-sidebar npm run screenshots:storybook:list` and it passed, resolving 3 sidebar captures: `components-lunasidebar--playground` in light and dark, and `components-lunasidebar--layout-preview` in light.

I could not create the required git commit because the sandbox denies writing `.git/index.lock`, so the work remains uncommitted in the current tree.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`