### PR TITLE
Resolve #57: Build LunaForm composite

### DIFF
--- a/docs/v1/components/LunaForm.md
+++ b/docs/v1/components/LunaForm.md
@@ -1,0 +1,56 @@
+# LunaForm
+
+`LunaForm` is the first form composition layer for `react-luna`.
+
+It owns:
+- semantic form rendering by default
+- optional header region
+- stacked body layout for existing field primitives
+- optional actions region
+- theme-aware region spacing
+- native form prop passthrough
+
+Default element:
+- `form`
+
+## Props
+
+- `as?: React.ElementType`
+- `header?: React.ReactNode`
+- `actions?: React.ReactNode`
+- `actionsAlign?: "left" | "center" | "right"`
+- `actionsGap?: string`
+- `gap?: string`
+
+Important native form props are also supported through passthrough, especially:
+- `onSubmit`
+- `onReset`
+- `action`
+- `method`
+- `noValidate`
+- `autoComplete`
+
+## Contract
+
+- `children` are rendered as the body region
+- `header` renders above the body region
+- `actions` renders below the body region
+- `actionsAlign` controls the horizontal alignment of action content
+- `actionsGap` controls spacing between action children
+- `gap` controls spacing between the top-level regions
+- body content is stacked so existing fields compose without extra wrapper markup
+- `className`, `style`, `data-*`, and `aria-*` pass through to the root
+
+## Theme Integration
+
+`LunaForm` consumes the existing `ThemeProvider` for:
+- spacing token resolution
+- text and field colors through its child components
+
+`gap` and `actionsGap` resolve through theme spacing first, then raw CSS values.
+
+## Accessibility
+
+- use the default `form` element unless you have a strong semantic reason to override it
+- submit and reset controls should keep their native button semantics
+- fields inside `LunaForm` still own their own labels, messages, and error semantics

--- a/docs/v1/design/LunaForm.md
+++ b/docs/v1/design/LunaForm.md
@@ -1,0 +1,55 @@
+# LunaForm
+
+`LunaForm` should be the first composite layer above the field primitives in `react-luna`.
+
+It is intentionally narrow in V1.
+
+It should not become:
+- a validation framework
+- a field registry
+- a schema-driven renderer
+- a replacement for native form semantics
+
+## Design Goals
+
+- give downstream consumers a durable form shell without forcing a specific data model
+- let existing field primitives line up as a coherent stack
+- provide a predictable place for introductory content and form actions
+- stay themeable through spacing and child component theming instead of one-off visual props
+
+## Region Model
+
+`LunaForm` has three optional regions:
+
+- header
+- body
+- actions
+
+The body is always the direct composition area for form fields and helper content.
+
+The actions region should stay simple:
+- align the group
+- control spacing between actions
+- preserve native button behavior
+
+## Visual Rules
+
+- the form shell itself should stay visually quiet
+- spacing should carry most of the composition work
+- stronger surface treatments should belong to parent containers such as `LunaCard` when needed
+- a form should be able to live inside cards, drawers, modals, or plain page layouts without fighting them
+
+## Contract Boundaries
+
+`LunaForm` should own:
+- semantic root rendering
+- vertical region spacing
+- action alignment
+
+`LunaForm` should not own:
+- field-specific error rendering
+- validation state orchestration
+- async submission state
+- responsive multi-column layout logic
+
+Those can land in later issue-scoped work if needed.

--- a/playwright/storybook/manifests/luna-form.json
+++ b/playwright/storybook/manifests/luna-form.json
@@ -1,0 +1,23 @@
+[
+  {
+    "storyId": "components-lunaform--playground",
+    "fileName": "luna-form-playground",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaform--action-alignment",
+    "fileName": "luna-form-action-alignment",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaform--compact-spacing",
+    "fileName": "luna-form-compact-spacing",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export * from "./luna-radio";
 export * from "./luna-divider";
 export * from "./luna-drawer";
 export * from "./luna-empty-state";
+export * from "./luna-form";
 export * from "./luna-header";
 export * from "./luna-hover-text";
 export * from "./luna-input";

--- a/src/components/luna-form/LunaForm.css
+++ b/src/components/luna-form/LunaForm.css
@@ -1,0 +1,16 @@
+.luna-form {
+  display: grid;
+  gap: var(--luna-form-gap, var(--luna-space-5, 1.25rem));
+  width: 100%;
+  min-width: 0;
+}
+
+.luna-form__header,
+.luna-form__body,
+.luna-form__actions {
+  min-width: 0;
+}
+
+.luna-form__actions {
+  width: 100%;
+}

--- a/src/components/luna-form/LunaForm.props.ts
+++ b/src/components/luna-form/LunaForm.props.ts
@@ -1,0 +1,12 @@
+import type React from "react";
+
+export type LunaFormAlign = "left" | "center" | "right";
+
+export type LunaFormProps = Omit<React.FormHTMLAttributes<HTMLFormElement>, "title"> & {
+  as?: React.ElementType;
+  header?: React.ReactNode;
+  actions?: React.ReactNode;
+  actionsAlign?: LunaFormAlign;
+  actionsGap?: string;
+  gap?: string;
+};

--- a/src/components/luna-form/LunaForm.stories.tsx
+++ b/src/components/luna-form/LunaForm.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaButton } from "../luna-button";
+import { LunaCheckbox } from "../luna-checkbox";
+import { LunaHeader } from "../luna-header";
+import { LunaInput } from "../luna-input";
+import { LunaSelect } from "../luna-select";
+import { LunaTextarea } from "../luna-textarea";
+import { LunaForm } from "./LunaForm";
+
+const selectOptions = [
+  { value: "low", label: "Low orbit" },
+  { value: "mid", label: "Mid orbit" },
+  { value: "high", label: "High orbit" }
+];
+
+const meta = {
+  title: "Components/LunaForm",
+  component: LunaForm
+} satisfies Meta<typeof LunaForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <LunaForm
+      {...args}
+      header={<LunaHeader title="Mission intake" subtitle="Confirm the launch request details." />}
+      actions={
+        <>
+          <LunaButton flat type="reset">
+            Reset
+          </LunaButton>
+          <LunaButton type="submit">Submit request</LunaButton>
+        </>
+      }
+    >
+      <LunaInput label="Mission name" name="missionName" placeholder="Aurora relay" externalLabel />
+      <LunaSelect
+        label="Orbit band"
+        name="orbitBand"
+        options={selectOptions}
+        placeholder="Choose orbit"
+        externalLabel
+      />
+      <LunaTextarea
+        label="Launch note"
+        name="launchNote"
+        minRows={3}
+        placeholder="Add final crew notes"
+        externalLabel
+      />
+    </LunaForm>
+  )
+};
+
+export const ActionAlignment: Story = {
+  render: () => (
+    <LunaForm
+      header={<LunaHeader title="Final review" subtitle="Action alignment stays configurable." />}
+      actionsAlign="right"
+      actions={
+        <>
+          <LunaButton flat type="button">
+            Save draft
+          </LunaButton>
+          <LunaButton type="submit">Approve flight plan</LunaButton>
+        </>
+      }
+    >
+      <LunaInput
+        label="Call sign"
+        name="callSign"
+        defaultValue="Moonline Seven"
+        externalLabel
+      />
+      <LunaCheckbox
+        label="Ready for launch window"
+        name="launchReady"
+        defaultChecked
+        description="This confirms the crew accepts the current weather corridor."
+      />
+    </LunaForm>
+  )
+};
+
+export const CompactSpacing: Story = {
+  render: () => (
+    <LunaForm
+      gap="3"
+      actionsGap="2"
+      header={<LunaHeader title="Quick confirmation" subtitle="Tighter spacing for short workflows." />}
+      actions={<LunaButton type="submit">Confirm</LunaButton>}
+    >
+      <LunaInput label="Code" name="code" defaultValue="L-42" externalLabel />
+      <LunaInput label="Verifier" name="verifier" defaultValue="Control deck" externalLabel />
+    </LunaForm>
+  )
+};

--- a/src/components/luna-form/LunaForm.test.tsx
+++ b/src/components/luna-form/LunaForm.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaForm } from "./LunaForm";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("LunaForm", () => {
+  it("renders a form by default", () => {
+    renderWithTheme(<LunaForm header="Mission">Body</LunaForm>);
+
+    const form = screen.getByText("Mission").closest("form");
+
+    expect(form).toBeInTheDocument();
+  });
+
+  it("supports semantic overrides through as", () => {
+    renderWithTheme(
+      <LunaForm as="section" header="Mission">
+        Body
+      </LunaForm>
+    );
+
+    const form = screen.getByText("Mission").closest("section");
+
+    expect(form).toBeInTheDocument();
+  });
+
+  it("renders header, body, and actions regions", () => {
+    renderWithTheme(
+      <LunaForm header="Mission" actions={<button type="submit">Launch</button>}>
+        Body copy
+      </LunaForm>
+    );
+
+    expect(screen.getByText("Mission").closest(".luna-form__header")).toBeInTheDocument();
+    expect(screen.getByText("Body copy").closest(".luna-form__body")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Launch" }).closest(".luna-form__actions")).toBeInTheDocument();
+  });
+
+  it("applies alignment props to the actions region", () => {
+    renderWithTheme(
+      <LunaForm
+        header="Mission"
+        actionsAlign="right"
+        actions={<button type="submit">Launch</button>}
+      >
+        Body copy
+      </LunaForm>
+    );
+
+    expect(screen.getByRole("button", { name: "Launch" }).closest(".luna-form__actions")).toHaveStyle({
+      "--luna-layout-justify": "flex-end"
+    });
+  });
+
+  it("resolves spacing tokens onto the root style", () => {
+    renderWithTheme(
+      <LunaForm header="Mission" gap="6">
+        Body
+      </LunaForm>
+    );
+
+    const form = screen.getByText("Mission").closest(".luna-form");
+
+    expect(form).toHaveStyle({ "--luna-form-gap": "1.5rem" });
+  });
+
+  it("passes through native submit behavior", () => {
+    const handleSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    renderWithTheme(
+      <LunaForm onSubmit={handleSubmit} actions={<button type="submit">Launch</button>}>
+        <input name="mission" defaultValue="Aurora" />
+      </LunaForm>
+    );
+
+    fireEvent.submit(screen.getByRole("button", { name: "Launch" }).closest("form") as HTMLFormElement);
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/luna-form/LunaForm.tsx
+++ b/src/components/luna-form/LunaForm.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import { LunaColumn } from "../luna-column";
+import { LunaRow } from "../luna-row";
+import type { LunaFormProps } from "./LunaForm.props";
+import "./LunaForm.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpacingValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function flattenChildren(children: React.ReactNode): React.ReactNode[] {
+  return React.Children.toArray(children).flatMap((child) => {
+    if (React.isValidElement(child) && child.type === React.Fragment) {
+      return flattenChildren(child.props.children);
+    }
+
+    return [child];
+  });
+}
+
+export const LunaForm = React.forwardRef<HTMLElement, LunaFormProps>(function LunaForm(
+  { actions, actionsAlign = "left", actionsGap = "3", as, children, className, gap, header, style, ...props },
+  ref
+) {
+  const { theme } = useTheme();
+  const Component = (as ?? "form") as React.ElementType;
+  const resolvedGap = resolveSpacingValue(gap, theme);
+  const resolvedActionsGap = resolveSpacingValue(actionsGap, theme);
+  const resolvedStyle = {
+    ...(resolvedGap ? { ["--luna-form-gap" as const]: resolvedGap } : {}),
+    ...style
+  };
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      className={toClassName(["luna-form", className])}
+      style={resolvedStyle}
+    >
+      {header ? <div className="luna-form__header">{header}</div> : null}
+      {children ? <LunaColumn className="luna-form__body" gap="3">{children}</LunaColumn> : null}
+      {actions ? (
+        <LunaRow
+          className="luna-form__actions"
+          align="center"
+          gap={resolvedActionsGap}
+          justify={
+            actionsAlign === "center"
+              ? "center"
+              : actionsAlign === "right"
+                ? "end"
+                : "start"
+          }
+        >
+          {flattenChildren(actions).map((child, index) =>
+            child === null || child === undefined || typeof child === "boolean" ? child : (
+              <div data-col-span="auto" key={index}>
+                {child}
+              </div>
+            )
+          )}
+        </LunaRow>
+      ) : null}
+    </Component>
+  );
+});

--- a/src/components/luna-form/index.ts
+++ b/src/components/luna-form/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaForm";
+export type * from "./LunaForm.props";


### PR DESCRIPTION
Closes #57

storybook-component: luna-form

## Summary
Implemented issue `#57` as a narrow first-pass composite in [LunaForm.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-form/LunaForm.tsx), with props in [LunaForm.props.ts](/Users/jordanb/.codex/automations/react-luna/src/components/luna-form/LunaForm.props.ts) and export wiring in [index.ts](/Users/jordanb/.codex/automations/react-luna/src/components/index.ts). The contract stays issue-scoped: default semantic `form` root, optional `header`, stacked body content, optional `actions`, action alignment, and theme-backed spacing. I did not add validation orchestration or field registration because the issue body does not justify that larger surface.

Storybook, docs, and visual metadata were added in [LunaForm.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-form/LunaForm.stories.tsx), [LunaForm.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaForm.md), [LunaForm.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaForm.md), and [luna-form.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-form.json). Tests are in [LunaForm.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-form/LunaForm.test.tsx).

Verification:
- `npm test -- LunaForm` passed
- `npm run build` passed
- `npm run storybook:build` passed
- `STORYBOOK_COMPONENT=luna-form npm run screenshots:storybook:list` passed and found 3 stories
- `STORYBOOK_COMPONENT=luna-form npm run screenshots:storybook` ran but failed in this sandbox because Playwright could not bind `127.0.0.1:6106` (`EPERM`), so live capture could not complete here

I also attempted to commit the step, but git could not create `.git/index.lock` in this sandbox, so no commit was created.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`