### PR TITLE
Resolve #63: Build LunaRadioGroup composite

### DIFF
--- a/.changeset/loud-pears-type.md
+++ b/.changeset/loud-pears-type.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaRadioGroup` composite for grouped single-choice selection on top of `LunaRadio`.

--- a/docs/v1/components/LunaRadioGroup.md
+++ b/docs/v1/components/LunaRadioGroup.md
@@ -1,0 +1,56 @@
+# LunaRadioGroup
+
+`LunaRadioGroup` is the grouped single-choice selection composite for `react-luna`.
+
+It owns:
+- one shared selection value across related `LunaRadio` options
+- controlled and uncontrolled selection state
+- group-level label, description, help, and error text
+- vertical and horizontal option layout
+
+It does not own:
+- nested field composition
+- async option loading
+- custom item rendering outside the built-in radio option shape
+
+## Props
+
+- `items: Array<{ value: string; label: React.ReactNode; description?: React.ReactNode; disabled?: boolean }>`
+- `name: string`
+- `label?: React.ReactNode`
+- `description?: React.ReactNode`
+- `helpText?: React.ReactNode`
+- `error?: React.ReactNode`
+- `value?: string`
+- `defaultValue?: string`
+- `onValueChange?: (value: string) => void`
+- `orientation?: "vertical" | "horizontal"`
+
+Native `FieldsetHTMLAttributes<HTMLFieldSetElement>` continue to pass through to the root group, except for `children`, `defaultValue`, and `onChange`.
+
+## Contract
+
+- uses a native `fieldset` and `legend` for group semantics
+- builds on `LunaRadio` for each option
+- `value` makes the group controlled
+- `defaultValue` seeds uncontrolled state
+- if neither `value` nor `defaultValue` resolves to an enabled item, the first enabled item is selected when available
+- disabled items stay visible but cannot be selected
+- `error` takes precedence over `helpText`
+- `orientation="horizontal"` changes layout only; selection semantics stay the same
+- group-level `disabled` disables every option
+
+## Accessibility Notes
+
+- the rendered group uses native fieldset semantics and exposes a grouped radio control through the browser accessibility tree
+- the legend provides the shared group label
+- group-level description and support text are attached through `aria-describedby`
+- radio exclusivity remains native through the shared `name`
+
+## Theme Integration
+
+`LunaRadioGroup` reuses the existing radio and form-adjacent token families for:
+- label and description color
+- help and error text treatment
+- disabled group text treatment
+- layout spacing between the group shell and individual options

--- a/docs/v1/design/LunaRadioGroup.md
+++ b/docs/v1/design/LunaRadioGroup.md
@@ -1,0 +1,24 @@
+# LunaRadioGroup Design Notes
+
+`LunaRadioGroup` exists to turn manual radio composition into a durable grouped contract without introducing a broader form container.
+
+## Intent
+
+- keep grouped single-choice selection on top of the existing `LunaRadio` primitive
+- centralize shared label and support text at the group level
+- preserve native semantics instead of recreating radio behavior in custom elements
+- stay themeable through the current radio and form token families
+
+## V1 Decisions
+
+- use an `items` array rather than freeform children so the first version stays compact and testable
+- support controlled and uncontrolled selection because both are common library consumer needs
+- keep layout to `vertical` or `horizontal` only
+- leave per-item help and error handling to `LunaRadio`; the group owns only shared support text
+- avoid adding validation orchestration, field registration, or form abstraction concerns in this issue
+
+## Follow-Up Space
+
+- custom item rendering if downstream needs exceed the V1 item shape
+- tighter form integration patterns if the library later adds grouped field primitives more broadly
+- richer responsive layout controls if a real consumer need appears

--- a/playwright/storybook/manifests/luna-radio-group.json
+++ b/playwright/storybook/manifests/luna-radio-group.json
@@ -1,0 +1,37 @@
+[
+  {
+    "storyId": "components-lunaradiogroup--basic",
+    "fileName": "luna-radio-group-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradiogroup--controlled",
+    "fileName": "luna-radio-group-controlled",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradiogroup--dark-mode",
+    "fileName": "luna-radio-group-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradiogroup--horizontal",
+    "fileName": "luna-radio-group-horizontal",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunaradiogroup--support-text",
+    "fileName": "luna-radio-group-support-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export * from "./luna-checkbox";
 export * from "./luna-date-input";
 export * from "./luna-date-picker";
 export * from "./luna-radio";
+export * from "./luna-radio-group";
 export * from "./luna-divider";
 export * from "./luna-drawer";
 export * from "./luna-empty-state";

--- a/src/components/luna-radio-group/LunaRadioGroup.css
+++ b/src/components/luna-radio-group/LunaRadioGroup.css
@@ -1,0 +1,41 @@
+.luna-radio-group {
+  display: grid;
+  gap: var(--luna-space-3, 0.75rem);
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.luna-radio-group__label {
+  margin: 0;
+  color: var(--luna-checkbox-label-fg, var(--luna-input-label-fg, var(--luna-foreground)));
+}
+
+.luna-radio-group__description {
+  color: var(--luna-checkbox-description-fg, var(--luna-input-help-fg, var(--luna-muted)));
+}
+
+.luna-radio-group__items {
+  display: grid;
+  gap: var(--luna-space-3, 0.75rem);
+}
+
+.luna-radio-group--horizontal .luna-radio-group__items {
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  align-items: start;
+}
+
+.luna-radio-group__message--help {
+  color: var(--luna-checkbox-help-fg, var(--luna-input-help-fg, var(--luna-muted)));
+}
+
+.luna-radio-group__message--error {
+  color: var(--luna-checkbox-error-fg, var(--luna-input-error-fg, var(--luna-color-danger-600)));
+}
+
+.luna-radio-group--disabled .luna-radio-group__label,
+.luna-radio-group--disabled .luna-radio-group__description,
+.luna-radio-group--disabled .luna-radio-group__message--help {
+  color: var(--luna-checkbox-disabled-label-fg, var(--luna-input-disabled-fg, var(--luna-muted)));
+}

--- a/src/components/luna-radio-group/LunaRadioGroup.props.ts
+++ b/src/components/luna-radio-group/LunaRadioGroup.props.ts
@@ -1,0 +1,27 @@
+import type React from "react";
+
+export type LunaRadioGroupOrientation = "vertical" | "horizontal";
+
+export type LunaRadioGroupItem = {
+  value: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+};
+
+export type LunaRadioGroupProps = Omit<
+  React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
+  "children" | "defaultValue" | "onChange"
+> & {
+  items: LunaRadioGroupItem[];
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  helpText?: React.ReactNode;
+  error?: React.ReactNode;
+  name: string;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  orientation?: LunaRadioGroupOrientation;
+  required?: boolean;
+};

--- a/src/components/luna-radio-group/LunaRadioGroup.stories.tsx
+++ b/src/components/luna-radio-group/LunaRadioGroup.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ThemeProvider } from "../../theme";
+import { LunaColumn } from "../luna-column";
+import { LunaRadioGroup } from "./LunaRadioGroup";
+
+const items = [
+  {
+    value: "standard",
+    label: "Standard window",
+    description: "Balanced launch profile for routine missions."
+  },
+  {
+    value: "priority",
+    label: "Priority window",
+    description: "Use when mission timing takes precedence."
+  },
+  {
+    value: "hold",
+    label: "Hold launch",
+    description: "Keep the vehicle grounded until the next review cycle."
+  },
+  {
+    value: "disabled",
+    label: "Disabled option",
+    description: "Unavailable for this mission.",
+    disabled: true
+  }
+];
+
+const meta = {
+  title: "Components/LunaRadioGroup",
+  component: LunaRadioGroup,
+  args: {
+    label: "Launch window",
+    name: "launch-window",
+    items
+  }
+} satisfies Meta<typeof LunaRadioGroup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    defaultValue: "standard"
+  }
+};
+
+export const Horizontal: Story = {
+  args: {
+    defaultValue: "priority",
+    orientation: "horizontal"
+  }
+};
+
+export const SupportText: Story = {
+  render: () => (
+    <LunaColumn gap="4">
+      <LunaRadioGroup
+        label="Launch window"
+        name="support-text-help"
+        items={items.slice(0, 3)}
+        helpText="Choose the launch profile for the upcoming review."
+      />
+      <LunaRadioGroup
+        label="Launch window"
+        name="support-text-error"
+        items={items.slice(0, 3)}
+        error="A launch profile must be selected."
+      />
+    </LunaColumn>
+  )
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledStory />
+};
+
+export const DarkMode: Story = {
+  render: () => (
+    <ThemeProvider mode="dark">
+      <div style={{ padding: "1rem", background: "var(--luna-background)" }}>
+        <LunaRadioGroup
+          label="Launch window"
+          name="launch-window-dark"
+          items={items}
+          defaultValue="standard"
+        />
+      </div>
+    </ThemeProvider>
+  )
+};
+
+function ControlledStory() {
+  const [value, setValue] = React.useState("standard");
+
+  return (
+    <LunaRadioGroup
+      label="Launch window"
+      description="Keep the mission review locked to a single active profile."
+      name="launch-window-controlled"
+      items={items.slice(0, 3)}
+      value={value}
+      onValueChange={setValue}
+      helpText={`Selected: ${value}`}
+    />
+  );
+}

--- a/src/components/luna-radio-group/LunaRadioGroup.test.tsx
+++ b/src/components/luna-radio-group/LunaRadioGroup.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaRadioGroup } from "./LunaRadioGroup";
+
+const items = [
+  {
+    value: "standard",
+    label: "Standard window",
+    description: "Balanced launch profile for routine missions."
+  },
+  {
+    value: "priority",
+    label: "Priority window",
+    description: "Use when mission timing takes precedence."
+  },
+  {
+    value: "hold",
+    label: "Hold launch",
+    description: "Keep the vehicle grounded until the next review cycle."
+  },
+  {
+    value: "disabled",
+    label: "Disabled option",
+    disabled: true
+  }
+];
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaRadioGroup", () => {
+  it("renders a grouped set of radio inputs with a legend", () => {
+    renderWithTheme(<LunaRadioGroup label="Launch window" name="launch-window" items={items} />);
+
+    expect(screen.getByText("Launch window", { selector: "legend" })).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+  });
+
+  it("supports uncontrolled selection with defaultValue", () => {
+    renderWithTheme(
+      <LunaRadioGroup
+        label="Launch window"
+        name="launch-window"
+        items={items}
+        defaultValue="standard"
+      />
+    );
+
+    const standard = screen.getByRole("radio", { name: /Standard window/i });
+    const priority = screen.getByRole("radio", { name: /Priority window/i });
+
+    expect(standard).toBeChecked();
+    expect(priority).not.toBeChecked();
+
+    fireEvent.click(screen.getByText("Priority window"));
+
+    expect(standard).not.toBeChecked();
+    expect(priority).toBeChecked();
+  });
+
+  it("supports controlled value updates through onValueChange", () => {
+    function ControlledGroupTest() {
+      const [value, setValue] = React.useState("standard");
+
+      return (
+        <LunaRadioGroup
+          label="Launch window"
+          name="launch-window"
+          items={items}
+          value={value}
+          onValueChange={setValue}
+        />
+      );
+    }
+
+    renderWithTheme(<ControlledGroupTest />);
+
+    const standard = screen.getByRole("radio", { name: /Standard window/i });
+    const hold = screen.getByRole("radio", { name: /Hold launch/i });
+
+    fireEvent.click(screen.getByText("Hold launch"));
+
+    expect(standard).not.toBeChecked();
+    expect(hold).toBeChecked();
+  });
+
+  it("calls onValueChange with the selected option value", () => {
+    const onValueChange = vi.fn();
+
+    renderWithTheme(
+      <LunaRadioGroup
+        label="Launch window"
+        name="launch-window"
+        items={items}
+        onValueChange={onValueChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Priority window"));
+
+    expect(onValueChange).toHaveBeenCalledWith("priority");
+  });
+
+  it("renders description and support text with error taking precedence", () => {
+    const { rerender } = renderWithTheme(
+      <LunaRadioGroup
+        label="Launch window"
+        description="Keep the mission review locked to a single active profile."
+        name="launch-window"
+        items={items}
+        helpText="Choose the launch profile for the upcoming review."
+      />
+    );
+
+    expect(
+      screen.getByText("Keep the mission review locked to a single active profile.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Choose the launch profile for the upcoming review.")
+    ).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider>
+        <LunaRadioGroup
+          label="Launch window"
+          name="launch-window"
+          items={items}
+          helpText="Choose the launch profile for the upcoming review."
+          error="A launch profile must be selected."
+        />
+      </ThemeProvider>
+    );
+
+    expect(
+      screen.queryByText("Choose the launch profile for the upcoming review.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("A launch profile must be selected.")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Launch window/i })).toHaveAttribute(
+      "aria-invalid",
+      "true"
+    );
+  });
+
+  it("applies disabled state to the whole group and to disabled items", () => {
+    const { rerender } = renderWithTheme(
+      <LunaRadioGroup label="Launch window" name="launch-window" items={items} />
+    );
+
+    expect(screen.getByRole("radio", { name: /Disabled option/i })).toBeDisabled();
+
+    rerender(
+      <ThemeProvider>
+        <LunaRadioGroup label="Launch window" name="launch-window" items={items} disabled />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByRole("radio", { name: /Standard window/i })).toBeDisabled();
+    expect(screen.getByRole("group", { name: /Launch window/i })).toBeDisabled();
+  });
+});

--- a/src/components/luna-radio-group/LunaRadioGroup.tsx
+++ b/src/components/luna-radio-group/LunaRadioGroup.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { LunaText } from "../luna-text";
+import { LunaRadio } from "../luna-radio";
+import type { LunaRadioGroupProps } from "./LunaRadioGroup.props";
+import "./LunaRadioGroup.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function getInitialValue(
+  items: LunaRadioGroupProps["items"],
+  value: string | undefined,
+  defaultValue: string | undefined
+) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof defaultValue === "string") {
+    return defaultValue;
+  }
+
+  return items.find((item) => !item.disabled)?.value ?? "";
+}
+
+function isSelectableValue(items: LunaRadioGroupProps["items"], candidate: string | undefined) {
+  if (!candidate) {
+    return false;
+  }
+
+  return items.some((item) => item.value === candidate && !item.disabled);
+}
+
+export const LunaRadioGroup = React.forwardRef<HTMLFieldSetElement, LunaRadioGroupProps>(
+  function LunaRadioGroup(
+    {
+      className,
+      defaultValue,
+      description,
+      disabled,
+      error,
+      helpText,
+      id,
+      items,
+      label,
+      name,
+      onValueChange,
+      orientation = "vertical",
+      required,
+      style,
+      value,
+      ...fieldsetProps
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const groupId = id ?? `luna-radio-group-${reactId.replace(/:/g, "")}`;
+    const descriptionId = description ? `${groupId}-description` : undefined;
+    const messageId = error || helpText ? `${groupId}-message` : undefined;
+    const isInvalid = error !== undefined && error !== null;
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = React.useState(() =>
+      getInitialValue(items, value, defaultValue)
+    );
+
+    React.useEffect(() => {
+      if (isControlled) {
+        return;
+      }
+
+      if (isSelectableValue(items, internalValue)) {
+        return;
+      }
+
+      setInternalValue(getInitialValue(items, undefined, defaultValue));
+    }, [defaultValue, internalValue, isControlled, items]);
+
+    const selectedValue = isControlled
+      ? isSelectableValue(items, value) ? value : ""
+      : isSelectableValue(items, internalValue) ? internalValue : "";
+
+    function commitValue(nextValue: string) {
+      if (!isSelectableValue(items, nextValue) || nextValue === selectedValue) {
+        return;
+      }
+
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+    }
+
+    return (
+      <fieldset
+        {...fieldsetProps}
+        ref={ref}
+        id={groupId}
+        className={toClassName([
+          "luna-radio-group",
+          orientation === "horizontal" && "luna-radio-group--horizontal",
+          disabled && "luna-radio-group--disabled",
+          isInvalid && "luna-radio-group--invalid",
+          className
+        ])}
+        style={style}
+        disabled={disabled}
+        aria-invalid={isInvalid ? true : fieldsetProps["aria-invalid"]}
+        aria-describedby={[descriptionId, messageId].filter(Boolean).join(" ") || undefined}
+      >
+        {label !== undefined && label !== null ? (
+          <LunaText as="legend" variant="label" className="luna-radio-group__label">
+            {label}
+          </LunaText>
+        ) : null}
+        {description !== undefined && description !== null ? (
+          <LunaText
+            id={descriptionId}
+            variant="body-small"
+            className="luna-radio-group__description"
+          >
+            {description}
+          </LunaText>
+        ) : null}
+        <div className="luna-radio-group__items">
+          {items.map((item) => (
+            <LunaRadio
+              key={item.value}
+              name={name}
+              value={item.value}
+              label={item.label}
+              description={item.description}
+              checked={selectedValue === item.value}
+              disabled={disabled || item.disabled}
+              required={required}
+              onChange={(event) => {
+                if (event.currentTarget.checked) {
+                  commitValue(item.value);
+                }
+              }}
+            />
+          ))}
+        </div>
+        {isInvalid ? (
+          <LunaText
+            id={messageId}
+            variant="caption"
+            className="luna-radio-group__message luna-radio-group__message--error"
+          >
+            {error}
+          </LunaText>
+        ) : helpText !== undefined && helpText !== null ? (
+          <LunaText
+            id={messageId}
+            variant="caption"
+            className="luna-radio-group__message luna-radio-group__message--help"
+          >
+            {helpText}
+          </LunaText>
+        ) : null}
+      </fieldset>
+    );
+  }
+);

--- a/src/components/luna-radio-group/index.ts
+++ b/src/components/luna-radio-group/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaRadioGroup";
+export type * from "./LunaRadioGroup.props";


### PR DESCRIPTION
Closes #63

storybook-component: luna-radio-group

## Summary
Implemented issue `#63` as a new `LunaRadioGroup` composite built on top of `LunaRadio`. The new component adds grouped single-choice state, shared label and support text, controlled and uncontrolled value handling, vertical or horizontal layout, exports, docs, Storybook stories, screenshot metadata for the `luna-radio-group` slug, and a release changeset. Main files: [LunaRadioGroup.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-radio-group/LunaRadioGroup.tsx), [LunaRadioGroup.props.ts](/Users/jordanb/.codex/automations/react-luna/src/components/luna-radio-group/LunaRadioGroup.props.ts), [LunaRadioGroup.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-radio-group/LunaRadioGroup.stories.tsx), [LunaRadioGroup.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-radio-group/LunaRadioGroup.test.tsx), [LunaRadioGroup component docs](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaRadioGroup.md), [LunaRadioGroup design notes](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaRadioGroup.md), [screenshot manifest](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-radio-group.json), and [component exports](/Users/jordanb/.codex/automations/react-luna/src/components/index.ts#L11).

Verification ran successfully:
- `npm test -- src/components/luna-radio-group/LunaRadioGroup.test.tsx`
- `npm test -- src/components/luna-radio/LunaRadio.test.tsx`
- `npm run build`
- `npm run storybook:build`
- `STORYBOOK_COMPONENT=luna-radio-group npm run screenshots:storybook:list`

The screenshot-path check resolved 5 capture targets for `components-lunaradiogroup`: `basic`, `controlled`, `dark-mode`, `horizontal`, and `support-text`.

One workflow gap remains: I could not create the requested commit because the sandbox denied writes inside `.git` (`.git/index.lock: Operation not permitted`). Also, I found repo-doc drift while checking guardrails: [WORKFLOW.md](/Users/jordanb/.codex/automations/react-luna/WORKFLOW.md) uses `Backlog -> Ready -> In Progress -> Verify -> Done`, while [CHANGE_MANAGEMENT.md](/Users/jordanb/.codex/automations/react-luna/CHANGE_MANAGEMENT.md) still says `Todo -> In Progress -> Done`. I left that untouched to keep this work scoped to issue `#63`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`