### PR TITLE
Resolve #64: Build LunaCheckboxGroup composite

### DIFF
--- a/.changeset/luna-checkbox-group.md
+++ b/.changeset/luna-checkbox-group.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaCheckboxGroup` composite for grouped checkbox selection on top of `LunaCheckbox`.

--- a/docs/v1/components/LunaCheckboxGroup.md
+++ b/docs/v1/components/LunaCheckboxGroup.md
@@ -1,0 +1,49 @@
+# LunaCheckboxGroup
+
+`LunaCheckboxGroup` is the grouped multi-selection composite built on top of `LunaCheckbox`.
+
+It owns:
+- group legend rendering
+- optional group description, help text, and error text rendering
+- controlled or uncontrolled selected values
+- option mapping into native checkbox inputs
+
+## Props
+
+- `label?: React.ReactNode`
+- `description?: React.ReactNode`
+- `helpText?: React.ReactNode`
+- `error?: React.ReactNode`
+- `name?: string`
+- `options: Array<{ value: string; label: React.ReactNode; description?: React.ReactNode; disabled?: boolean }>`
+- `value?: string[]`
+- `defaultValue?: string[]`
+- `onChange?: (value: string[]) => void`
+
+Important native fieldset props are also supported through passthrough, especially:
+- `id`
+- `className`
+- `style`
+- `disabled`
+- `aria-*`
+- `data-*`
+
+## Contract
+
+- renders a native `fieldset` and `legend` for group semantics
+- each option is rendered through `LunaCheckbox`
+- each checkbox receives the shared `name` when provided for form submission
+- `value` and `defaultValue` represent the selected option values
+- `error` takes precedence over `helpText`
+- group-level support text sits below the option list
+- option-level `description` stays attached to its own checkbox row
+- group `disabled` disables every checkbox in the set
+
+## Theme Integration
+
+`LunaCheckboxGroup` reuses the existing checkbox and field supporting-text token families for:
+- group label color
+- group description color
+- help text color
+- error text color
+- disabled text treatment

--- a/docs/v1/design/LunaCheckboxGroup.md
+++ b/docs/v1/design/LunaCheckboxGroup.md
@@ -1,0 +1,131 @@
+# Checkbox Group Design
+
+This document defines the design direction for `LunaCheckboxGroup` before implementation.
+
+`LunaCheckboxGroup` should be the grouped multi-selection composite for the library. It should build directly on top of `LunaCheckbox` and stay narrow enough that downstream applications can still compose more specialized selection flows themselves.
+
+## Design Stance
+
+- Keep the composite narrow.
+- Reuse `LunaCheckbox` for option rendering instead of creating a second checkbox presentation path.
+- Use native `fieldset` and `legend` semantics for the group shell.
+- Keep the public API focused on values and options, not per-row render callbacks in V1.
+- Keep theme behavior aligned with the existing checkbox and supporting-text token families.
+
+## Role In The System
+
+`LunaCheckboxGroup` should own:
+- group legend rendering
+- optional group description, help text, and error text rendering
+- controlled or uncontrolled selected values
+- option mapping into `LunaCheckbox`
+- shared disabled and invalid state wiring
+
+`LunaCheckboxGroup` should not own:
+- parent-child tree selection logic
+- indeterminate group aggregation
+- custom option templates
+- column layout controls in V1
+
+## Base Element Strategy
+
+Visible structure:
+- native `fieldset`
+- native `legend`
+- stacked checkbox rows rendered by `LunaCheckbox`
+
+Rules:
+- the fieldset should carry group-level support text wiring
+- the legend should be the visible group label when one is present
+- option semantics should remain native checkbox inputs via `LunaCheckbox`
+
+## Core Contract
+
+Option shape:
+
+```ts
+type LunaCheckboxGroupOption = {
+  value: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+};
+```
+
+Recommended props:
+- `label?: React.ReactNode`
+- `description?: React.ReactNode`
+- `helpText?: React.ReactNode`
+- `error?: React.ReactNode`
+- `name?: string`
+- `options: LunaCheckboxGroupOption[]`
+- `value?: string[]`
+- `defaultValue?: string[]`
+- `onChange?: (value: string[]) => void`
+
+Important passthrough should remain available for the fieldset root:
+- `id`
+- `className`
+- `style`
+- `disabled`
+- `aria-*`
+- `data-*`
+
+## State Model
+
+V1 states:
+- empty group
+- one or many selected values
+- disabled group
+- invalid group
+
+Rules:
+- option selection stays independent because the composite is multi-select
+- group `disabled` should disable every option
+- option-level `disabled` should still work when the group is otherwise enabled
+- invalid should affect group-level support text wiring and visuals without rewriting the checkbox option contract
+
+## Theme Provider Integration
+
+`LunaCheckboxGroup` should not introduce a dedicated theme slice in V1.
+
+Direction:
+- reuse checkbox label and description tokens for group heading and copy
+- reuse checkbox help and error tokens for group-level support text
+- keep spacing on the existing space scale
+
+## Accessibility
+
+V1 accessibility expectations:
+- use native `fieldset` and `legend`
+- keep native checkbox inputs through `LunaCheckbox`
+- connect group description and support text through `aria-describedby`
+- set invalid state through `aria-invalid`
+
+## Storybook Expectations
+
+Stories should explicitly show:
+- basic unchecked state
+- preselected state
+- controlled selection
+- disabled state
+- help and error states
+- dark mode
+
+## Testing Focus
+
+When implemented, tests should cover:
+- fieldset group semantics
+- uncontrolled multi-selection
+- controlled multi-selection
+- `onChange` value updates
+- help and error precedence
+- disabled behavior
+
+## Implementation Order
+
+1. Lock this design
+2. Build the component
+3. Add Storybook coverage
+4. Add unit tests
+5. Add the component reference doc under `docs/v1/components`

--- a/playwright/storybook/manifests/luna-checkbox-group.json
+++ b/playwright/storybook/manifests/luna-checkbox-group.json
@@ -1,0 +1,30 @@
+[
+  {
+    "storyId": "components-lunacheckboxgroup--basic",
+    "fileName": "luna-checkbox-group-basic",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckboxgroup--dark-mode",
+    "fileName": "luna-checkbox-group-dark-mode",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckboxgroup--states",
+    "fileName": "luna-checkbox-group-states",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunacheckboxgroup--support-text",
+    "fileName": "luna-checkbox-group-support-text",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export * from "./luna-badge";
 export * from "./luna-button";
 export * from "./luna-card";
 export * from "./luna-checkbox";
+export * from "./luna-checkbox-group";
 export * from "./luna-date-input";
 export * from "./luna-date-picker";
 export * from "./luna-radio";

--- a/src/components/luna-checkbox-group/LunaCheckboxGroup.css
+++ b/src/components/luna-checkbox-group/LunaCheckboxGroup.css
@@ -1,0 +1,41 @@
+.luna-checkbox-group {
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+  border: 0;
+  display: grid;
+  gap: var(--luna-space-3, 0.75rem);
+}
+
+.luna-checkbox-group__legend {
+  margin: 0;
+  padding: 0;
+  color: var(--luna-checkbox-label-fg, var(--luna-input-label-fg, var(--luna-foreground)));
+}
+
+.luna-checkbox-group__description {
+  margin: 0;
+  color: var(--luna-checkbox-description-fg, var(--luna-input-help-fg, var(--luna-muted)));
+}
+
+.luna-checkbox-group__options {
+  display: grid;
+  gap: var(--luna-space-3, 0.75rem);
+}
+
+.luna-checkbox-group--disabled .luna-checkbox-group__legend,
+.luna-checkbox-group--disabled .luna-checkbox-group__description {
+  color: var(--luna-checkbox-disabled-label-fg, var(--luna-input-disabled-fg, var(--luna-muted)));
+}
+
+.luna-checkbox-group__message {
+  margin: 0;
+}
+
+.luna-checkbox-group__message--help {
+  color: var(--luna-checkbox-help-fg, var(--luna-input-help-fg, var(--luna-muted)));
+}
+
+.luna-checkbox-group__message--error {
+  color: var(--luna-checkbox-error-fg, var(--luna-input-error-fg, var(--luna-color-danger-600)));
+}

--- a/src/components/luna-checkbox-group/LunaCheckboxGroup.props.ts
+++ b/src/components/luna-checkbox-group/LunaCheckboxGroup.props.ts
@@ -1,0 +1,23 @@
+import type React from "react";
+
+export type LunaCheckboxGroupOption = {
+  value: string;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  disabled?: boolean;
+};
+
+export type LunaCheckboxGroupProps = Omit<
+  React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
+  "children" | "defaultValue" | "onChange"
+> & {
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  helpText?: React.ReactNode;
+  error?: React.ReactNode;
+  name?: string;
+  options: LunaCheckboxGroupOption[];
+  value?: string[];
+  defaultValue?: string[];
+  onChange?: (value: string[]) => void;
+};

--- a/src/components/luna-checkbox-group/LunaCheckboxGroup.stories.tsx
+++ b/src/components/luna-checkbox-group/LunaCheckboxGroup.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ThemeProvider } from "../../theme";
+import { LunaCheckboxGroup } from "./LunaCheckboxGroup";
+
+const options = [
+  {
+    value: "telemetry",
+    label: "Telemetry review",
+    description: "Keep mission telemetry checks enabled during the release window."
+  },
+  {
+    value: "readiness",
+    label: "Launch readiness",
+    description: "Confirm launch approvals and payload sequencing before handoff."
+  },
+  {
+    value: "documentation",
+    label: "Documentation handoff",
+    description: "Include updated runbooks and change notes for downstream teams.",
+    disabled: true
+  }
+];
+
+const meta = {
+  title: "Components/LunaCheckboxGroup",
+  component: LunaCheckboxGroup,
+  args: {
+    label: "Mission review checklist",
+    options
+  }
+} satisfies Meta<typeof LunaCheckboxGroup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1.5rem" }}>
+      <LunaCheckboxGroup label="Unchecked group" options={options} />
+      <LunaCheckboxGroup
+        label="Preselected group"
+        options={options}
+        defaultValue={["telemetry", "readiness"]}
+      />
+      <LunaCheckboxGroup
+        label="Disabled group"
+        options={options}
+        defaultValue={["telemetry"]}
+        disabled
+      />
+      <ControlledStory />
+    </div>
+  )
+};
+
+export const SupportText: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: "1.5rem" }}>
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        description="Select every review gate that must be completed before the mission closes."
+        options={options}
+        helpText="Choose at least one gate for every release review."
+      />
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        description="Select every review gate that must be completed before the mission closes."
+        options={options}
+        error="At least one checklist item must be selected."
+      />
+    </div>
+  )
+};
+
+export const DarkMode: Story = {
+  render: () => (
+    <ThemeProvider mode="dark">
+      <div
+        style={{
+          padding: "1rem",
+          background: "var(--luna-background)",
+          display: "grid",
+          gap: "1.5rem"
+        }}
+      >
+        <LunaCheckboxGroup
+          label="Mission review checklist"
+          options={options}
+          defaultValue={["telemetry"]}
+        />
+        <LunaCheckboxGroup label="Disabled group" options={options} disabled />
+      </div>
+    </ThemeProvider>
+  )
+};
+
+function ControlledStory() {
+  const [value, setValue] = React.useState<string[]>(["telemetry"]);
+
+  return (
+    <LunaCheckboxGroup
+      label="Controlled group"
+      description="Selection stays driven by the parent component."
+      options={options}
+      value={value}
+      onChange={setValue}
+      helpText={`Selected: ${value.join(", ") || "none"}`}
+    />
+  );
+}

--- a/src/components/luna-checkbox-group/LunaCheckboxGroup.test.tsx
+++ b/src/components/luna-checkbox-group/LunaCheckboxGroup.test.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaCheckboxGroup } from "./LunaCheckboxGroup";
+
+const options = [
+  {
+    value: "telemetry",
+    label: "Telemetry review",
+    description: "Keep mission telemetry checks enabled during the release window."
+  },
+  {
+    value: "readiness",
+    label: "Launch readiness"
+  },
+  {
+    value: "documentation",
+    label: "Documentation handoff",
+    disabled: true
+  }
+];
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaCheckboxGroup", () => {
+  it("renders a checkbox group with a legend and native checkboxes", () => {
+    renderWithTheme(<LunaCheckboxGroup label="Mission review checklist" options={options} />);
+
+    expect(screen.getByText("Mission review checklist").tagName).toBe("SPAN");
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+    expect(screen.getByRole("group", { name: /Mission review checklist/i })).toBeInTheDocument();
+  });
+
+  it("supports uncontrolled multi-selection", () => {
+    renderWithTheme(<LunaCheckboxGroup label="Mission review checklist" options={options} />);
+
+    const telemetry = screen.getByRole("checkbox", { name: /Telemetry review/i });
+    const readiness = screen.getByRole("checkbox", { name: /Launch readiness/i });
+
+    fireEvent.click(screen.getByText("Telemetry review"));
+    fireEvent.click(screen.getByText("Launch readiness"));
+
+    expect(telemetry).toBeChecked();
+    expect(readiness).toBeChecked();
+  });
+
+  it("supports controlled multi-selection through value and onChange", () => {
+    function ControlledGroupTest() {
+      const [value, setValue] = React.useState<string[]>(["telemetry"]);
+
+      return (
+        <LunaCheckboxGroup
+          label="Mission review checklist"
+          options={options}
+          value={value}
+          onChange={setValue}
+        />
+      );
+    }
+
+    renderWithTheme(<ControlledGroupTest />);
+
+    const telemetry = screen.getByRole("checkbox", { name: /Telemetry review/i });
+    const readiness = screen.getByRole("checkbox", { name: /Launch readiness/i });
+
+    expect(telemetry).toBeChecked();
+    expect(readiness).not.toBeChecked();
+
+    fireEvent.click(screen.getByText("Launch readiness"));
+
+    expect(telemetry).toBeChecked();
+    expect(readiness).toBeChecked();
+  });
+
+  it("calls onChange with the next selected values", () => {
+    const handleChange = vi.fn();
+
+    renderWithTheme(
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        options={options}
+        onChange={handleChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Telemetry review"));
+    fireEvent.click(screen.getByText("Launch readiness"));
+    fireEvent.click(screen.getByText("Telemetry review"));
+
+    expect(handleChange).toHaveBeenLastCalledWith(["readiness"]);
+  });
+
+  it("renders group description and help text", () => {
+    renderWithTheme(
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        description="Select every review gate that must be completed."
+        options={options}
+        helpText="Choose at least one gate."
+      />
+    );
+
+    expect(screen.getByText("Select every review gate that must be completed.")).toBeInTheDocument();
+    expect(screen.getByText("Choose at least one gate.")).toBeInTheDocument();
+  });
+
+  it("renders error text instead of help text when both are present", () => {
+    renderWithTheme(
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        options={options}
+        helpText="Choose at least one gate."
+        error="At least one checklist item must be selected."
+      />
+    );
+
+    expect(screen.queryByText("Choose at least one gate.")).not.toBeInTheDocument();
+    expect(screen.getByText("At least one checklist item must be selected.")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Mission review checklist/i })).toHaveAttribute(
+      "aria-invalid",
+      "true"
+    );
+  });
+
+  it("respects group and option disabled states", () => {
+    renderWithTheme(
+      <LunaCheckboxGroup
+        label="Mission review checklist"
+        options={options}
+        defaultValue={["telemetry"]}
+        disabled
+      />
+    );
+
+    expect(screen.getByRole("checkbox", { name: /Telemetry review/i })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: /Launch readiness/i })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: /Documentation handoff/i })).toBeDisabled();
+  });
+});

--- a/src/components/luna-checkbox-group/LunaCheckboxGroup.tsx
+++ b/src/components/luna-checkbox-group/LunaCheckboxGroup.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { LunaCheckbox } from "../luna-checkbox";
+import { LunaText } from "../luna-text";
+import type { LunaCheckboxGroupOption, LunaCheckboxGroupProps } from "./LunaCheckboxGroup.props";
+import "./LunaCheckboxGroup.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function normalizeValues(values: readonly string[] | undefined) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return values.map(String);
+}
+
+function sanitizeIdPart(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+export const LunaCheckboxGroup = React.forwardRef<HTMLFieldSetElement, LunaCheckboxGroupProps>(
+  function LunaCheckboxGroup(
+    {
+      className,
+      defaultValue,
+      description,
+      disabled,
+      error,
+      helpText,
+      id,
+      label,
+      name,
+      onChange,
+      options,
+      style,
+      value,
+      ...fieldsetProps
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const fieldsetId = id ?? `luna-checkbox-group-${reactId.replace(/:/g, "")}`;
+    const descriptionId = description ? `${fieldsetId}-description` : undefined;
+    const messageId = error || helpText ? `${fieldsetId}-message` : undefined;
+    const isInvalid = error !== undefined && error !== null;
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = React.useState(() => normalizeValues(defaultValue));
+    const selectedValues = isControlled ? normalizeValues(value) : internalValue;
+    const selectedValueSet = new Set(selectedValues);
+
+    function updateValue(nextValue: string[]) {
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+
+      onChange?.(nextValue);
+    }
+
+    function handleOptionChange(option: LunaCheckboxGroupOption, checked: boolean) {
+      if (option.disabled || disabled) {
+        return;
+      }
+
+      const nextValue = checked
+        ? [...selectedValues.filter((entry) => entry !== option.value), option.value]
+        : selectedValues.filter((entry) => entry !== option.value);
+
+      updateValue(nextValue);
+    }
+
+    return (
+      <fieldset
+        {...fieldsetProps}
+        ref={ref}
+        id={fieldsetId}
+        className={toClassName([
+          "luna-checkbox-group",
+          disabled && "luna-checkbox-group--disabled",
+          isInvalid && "luna-checkbox-group--invalid",
+          className
+        ])}
+        style={style}
+        disabled={disabled}
+        aria-invalid={isInvalid ? true : fieldsetProps["aria-invalid"]}
+        aria-describedby={[descriptionId, messageId].filter(Boolean).join(" ") || undefined}
+      >
+        {label !== undefined && label !== null ? (
+          <legend className="luna-checkbox-group__legend">
+            <LunaText as="span" variant="label">
+              {label}
+            </LunaText>
+          </legend>
+        ) : null}
+        {description !== undefined && description !== null ? (
+          <LunaText
+            id={descriptionId}
+            as="p"
+            variant="body-small"
+            className="luna-checkbox-group__description"
+          >
+            {description}
+          </LunaText>
+        ) : null}
+        <div className="luna-checkbox-group__options">
+          {options.map((option, index) => {
+            const optionId = `${fieldsetId}-option-${sanitizeIdPart(option.value || String(index))}`;
+
+            return (
+              <LunaCheckbox
+                key={`${option.value}-${index}`}
+                id={optionId}
+                name={name}
+                value={option.value}
+                label={option.label}
+                description={option.description}
+                disabled={disabled || option.disabled}
+                checked={selectedValueSet.has(option.value)}
+                onChange={(event) => {
+                  handleOptionChange(option, event.currentTarget.checked);
+                }}
+              />
+            );
+          })}
+        </div>
+        {isInvalid ? (
+          <LunaText
+            id={messageId}
+            variant="caption"
+            className="luna-checkbox-group__message luna-checkbox-group__message--error"
+          >
+            {error}
+          </LunaText>
+        ) : helpText !== undefined && helpText !== null ? (
+          <LunaText
+            id={messageId}
+            variant="caption"
+            className="luna-checkbox-group__message luna-checkbox-group__message--help"
+          >
+            {helpText}
+          </LunaText>
+        ) : null}
+      </fieldset>
+    );
+  }
+);

--- a/src/components/luna-checkbox-group/index.ts
+++ b/src/components/luna-checkbox-group/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaCheckboxGroup";
+export * from "./LunaCheckboxGroup.props";


### PR DESCRIPTION
Closes #64

storybook-component: luna-checkbox-group

## Summary
Implemented issue `#64` by adding `LunaCheckboxGroup` as a narrow composite on top of `LunaCheckbox`. The new component renders a native `fieldset` and `legend`, supports controlled and uncontrolled selected values, maps an `options` array into checkbox rows, and keeps group-level description/help/error messaging separate from option-level descriptions in [LunaCheckboxGroup.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-checkbox-group/LunaCheckboxGroup.tsx). Public exports were added in [index.ts](/Users/jordanb/.codex/automations/react-luna/src/components/index.ts), with Storybook coverage in [LunaCheckboxGroup.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-checkbox-group/LunaCheckboxGroup.stories.tsx), tests in [LunaCheckboxGroup.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-checkbox-group/LunaCheckboxGroup.test.tsx), docs in [LunaCheckboxGroup.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaCheckboxGroup.md) and [LunaCheckboxGroup.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaCheckboxGroup.md), screenshot metadata in [luna-checkbox-group.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-checkbox-group.json), and a release changeset in [luna-checkbox-group.md](/Users/jordanb/.codex/automations/react-luna/.changeset/luna-checkbox-group.md).

Verification ran successfully:
- `npx vitest run src/components/luna-checkbox-group/LunaCheckboxGroup.test.tsx`
- `npm run build`
- `npm run storybook:build`
- `STORYBOOK_COMPONENT=luna-checkbox-group npm run screenshots:storybook:list`

The screenshot path check listed the expected four stories for the `luna-checkbox-group` slug: `basic`, `dark-mode`, `states`, and `support-text`.

One repo-workflow step is still blocked: I could not create the requested commit because the sandbox denied `.git/index.lock` creation.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`