### PR TITLE
Clarify icon provider strategy

### DIFF
--- a/docs/ICON_STRATEGY.md
+++ b/docs/ICON_STRATEGY.md
@@ -4,42 +4,90 @@ This document records the current recommended direction for icon support in `rea
 
 ## Why This Exists
 
-Icons are a real library concern for primitives and composites, but the project should not block on building a full icon system before the contract is clear.
+Icons are a real library concern for primitives and composites. `react-luna` should not treat them as an afterthought or push the entire experience onto consumers.
 
-The immediate need is to define the path, not to overbuild the implementation.
+The immediate need is to define a durable icon contract and provider model so the library can ship a strong default experience without blocking future extensibility.
 
 ## North Star
 
 The library should support three icon paths:
 
+- first-party `react-luna` icons as the default experience
 - custom icons supplied by the consumer
-- user-installed icon packs or adapters
-- optional first-party `react-luna` icons
+- user-installed icon packs through adapters/providers
 
-The contract should be designed so these paths can coexist instead of forcing the project into one early implementation.
+The contract should be designed so these paths coexist instead of forcing the project into one closed implementation.
 
-## Recommended V1 Path
+## Recommended Direction
 
-- Prefer explicit user-supplied icon content as `React.ReactNode` in component APIs.
-- Keep the public contract open enough that user-installed icon packs can plug in cleanly later.
-- Treat library-managed icon naming as provisional until there is a deliberate first-party icon package or icon asset strategy.
-- Avoid spreading placeholder icon-name semantics across more components before the icon contract is settled.
+- Ship a first-party icon experience for `react-luna`.
+- Back that experience with a provider model instead of hard-coding one icon source into every component.
+- Keep direct user-supplied icon content supported everywhere a component reasonably allows iconography.
+- Support user-installed icon packs through adapters instead of teaching components about specific third-party libraries.
 
-## Practical Guidance
+## Provider Model
 
-- For V1, `icon`, `startIcon`, and `endIcon`-style inputs are safer than committing to a large built-in icon surface too early.
-- If `iconName` exists in a component, it should be treated as provisional unless the library ships a real internal icon map.
-- New components should not assume a mature internal icon registry exists.
+The preferred architecture is:
+
+- `react-luna`
+  - defines the shared icon contract used by components
+  - resolves named icons through a provider
+- `@react-luna/icons`
+  - ships the default first-party icon set and provider
+- optional adapter packages
+  - `@react-luna/icons-fa`
+  - `@react-luna/icons-lucide`
+  - other user-installed packs later
+
+Components should not know about Font Awesome classes, Lucide imports, or third-party icon naming schemes directly.
+
+## Contract Guidance
+
+- Components should continue to support explicit icon nodes such as `icon?: React.ReactNode`.
+- Where named icons are supported, they should resolve through the icon provider instead of a component-local registry.
+- If both a direct icon node and a named icon are provided, the direct icon node should win.
+- New components should follow one shared contract instead of inventing one-off icon props.
+
+## First-Party Experience
+
+`react-luna` should feel complete out of the box.
+
+That means:
+
+- consumers should not need to install a third-party icon pack just to use the library normally
+- the default icon set should be visually consistent with the design system
+- first-party icons should still live behind the same provider contract used for adapters
+
+Whether the implementation ships as a transitive dependency or an internal package is a packaging detail. The consumer experience should still feel first-class.
+
+## Authoring Guidance
+
+The project should maintain a deliberate icon asset pipeline instead of hand-managing random SVG files over time.
+
+At minimum:
+
+- raw SVG sources
+- generated React exports
+- generated icon-name/types metadata
+- preview stories for review
+- consistency checks for grid, stroke, and sizing
+
+AI can help draft icons and automation can scaffold one icon issue at a time, but icon quality should still be curated by human review.
 
 ## Suggested Next Decisions
 
-1. Define the shared icon contract for custom icons, user-installed icon packs, and eventual first-party icons.
-2. Decide whether first-party `react-luna` icons ship in V1 or later.
-3. Keep V1 components compatible with user-supplied icon nodes even if first-party icons are deferred.
-4. Align button, notification, menu, and future composite APIs to the same icon rules.
+1. Define the shared provider interface and component-level icon contract.
+2. Decide whether `react-luna` depends transitively on `@react-luna/icons` or bundles the default set another way.
+3. Define the first-party icon authoring spec:
+   - grid
+   - stroke
+   - optical rules
+   - naming
+4. Align button, notification, menu, and future composite APIs to the same provider-backed icon rules.
+5. Decide which external adapter package should be the first proof path after first-party icons.
 
 ## Current Status
 
 - `LunaButton` already exposes `icon` and `iconName`.
-- The repo docs currently defer icon-library decisions.
-- A dedicated tracked issue should remain open until the contract is settled.
+- The current docs and components still reflect a more provisional icon direction than the project now wants.
+- A dedicated tracked issue should remain open until the provider contract, first-party package plan, and authoring pipeline are settled.


### PR DESCRIPTION
## Summary\n- update the icon strategy doc to reflect a first-class default icon experience\n- require a provider model so external icon packs can plug in without leaking into component contracts\n- document first-party package, adapter-package, and icon authoring pipeline expectations\n\n## Testing\n- docs only\n