### PR TITLE
Resolve #134: Add LunaMetricCard presentation surface

### DIFF
--- a/.changeset/soft-garlics-wink.md
+++ b/.changeset/soft-garlics-wink.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaMetricCard` KPI presentation surface with Storybook coverage, tests, docs, and visual review manifest entries.

--- a/docs/v1/components/LunaMetricCard.md
+++ b/docs/v1/components/LunaMetricCard.md
@@ -1,0 +1,82 @@
+# LunaMetricCard
+
+`LunaMetricCard` is the focused KPI presentation surface for `react-luna`.
+
+It is intended for:
+
+- primary metric summaries
+- dashboard KPI bands
+- app shell overview sections
+- compact metric callouts that may optionally pair with a small trend visual
+
+It is not intended for:
+
+- generic grouped content
+- arbitrary widget composition
+- replacing `LunaPanel` or `LunaCard`
+
+## Props
+
+- `as?: React.ElementType`
+- `label: React.ReactNode`
+- `value: React.ReactNode`
+- `delta?: React.ReactNode`
+- `trend?: "up" | "down" | "neutral"`
+- `meta?: React.ReactNode`
+- `tone?: "default" | "info" | "success" | "warning" | "danger"`
+- `visual?: React.ReactNode`
+
+It also accepts normal HTML attributes for the chosen element.
+
+## Behavior
+
+- `label` and `value` are required
+- the root is a named region by default, using both the label and value for its accessible name
+- `delta` is optional and can render with or without `meta`
+- `trend` controls the delta emphasis color and status text when delta is present
+- if no `delta` and no `meta` are provided, the footer region is omitted
+- `visual` is an optional compact slot for embedded trend content such as a sparkline or simple bars
+- the layout compresses by wrapping the visual slot beneath the metric content when width is constrained
+
+## When To Use It
+
+Use `LunaMetricCard` when the surface is primarily about one metric.
+
+Choose `LunaCard` when the surface needs broader grouped content, actions, or a reusable body shell.
+
+Choose `LunaPanel` when the surface is more about labeled content structure than KPI emphasis.
+
+## Theme
+
+`LunaMetricCard` exposes component-specific theme variables for:
+
+- `--luna-metric-card-padding`
+- `--luna-metric-card-gap`
+- `--luna-metric-card-radius`
+- `--luna-metric-card-header-gap`
+- `--luna-metric-card-footer-gap`
+- `--luna-metric-card-label-font-size`
+- `--luna-metric-card-label-letter-spacing`
+- `--luna-metric-card-value-font-size`
+- `--luna-metric-card-value-line-height`
+- `--luna-metric-card-delta-font-size`
+- `--luna-metric-card-meta-font-size`
+- `--luna-metric-card-visual-min-width`
+- `--luna-metric-card-bg`
+- `--luna-metric-card-border`
+- `--luna-metric-card-shadow`
+- `--luna-metric-card-label-fg`
+- `--luna-metric-card-value-fg`
+- `--luna-metric-card-meta-fg`
+- `--luna-metric-card-visual-bg`
+- `--luna-metric-card-trend-up-fg`
+- `--luna-metric-card-trend-down-fg`
+- `--luna-metric-card-trend-neutral-fg`
+
+Tone accents are also themeable through:
+
+- `--luna-metric-card-tone-default`
+- `--luna-metric-card-tone-info`
+- `--luna-metric-card-tone-success`
+- `--luna-metric-card-tone-warning`
+- `--luna-metric-card-tone-danger`

--- a/playwright/storybook/manifests/luna-metric-card.json
+++ b/playwright/storybook/manifests/luna-metric-card.json
@@ -1,0 +1,44 @@
+[
+  {
+    "storyId": "components-lunametriccard--basic-kpi-card",
+    "fileName": "luna-metric-card-basic-kpi-card",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunametriccard--positive-delta",
+    "fileName": "luna-metric-card-positive-delta",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunametriccard--negative-delta",
+    "fileName": "luna-metric-card-negative-delta",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunametriccard--neutral-no-delta",
+    "fileName": "luna-metric-card-neutral-no-delta",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunametriccard--with-compact-trend-content",
+    "fileName": "luna-metric-card-with-compact-trend-content",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunametriccard--narrow-width-dense-layout",
+    "fileName": "luna-metric-card-narrow-width-dense-layout",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export * from "./luna-header";
 export * from "./luna-hover-text";
 export * from "./luna-input";
 export * from "./luna-menu";
+export * from "./luna-metric-card";
 export * from "./luna-progress";
 export * from "./luna-slider";
 export * from "./luna-textarea";

--- a/src/components/luna-metric-card/LunaMetricCard.css
+++ b/src/components/luna-metric-card/LunaMetricCard.css
@@ -1,0 +1,150 @@
+.luna-metric-card {
+  position: relative;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--luna-metric-card-gap, 1rem);
+  align-items: stretch;
+  padding: var(--luna-metric-card-padding, 1rem);
+  box-sizing: border-box;
+  border: 1px solid var(--luna-metric-card-border, var(--luna-border));
+  border-radius: var(--luna-metric-card-radius, var(--luna-radius-lg, 0.75rem));
+  background: var(--luna-metric-card-bg, var(--luna-surface));
+  color: var(--luna-metric-card-fg, var(--luna-foreground));
+  box-shadow: var(--luna-metric-card-shadow, var(--luna-shadow-sm));
+  overflow: hidden;
+}
+
+.luna-metric-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: var(--luna-metric-card-accent-height, 0.25rem);
+  background: var(--luna-metric-card-accent, var(--luna-metric-card-tone-default, transparent));
+}
+
+.luna-metric-card[data-tone="default"][data-trend="up"] {
+  --luna-metric-card-accent: var(--luna-metric-card-trend-up-fg, #15803d);
+}
+
+.luna-metric-card[data-tone="default"][data-trend="down"] {
+  --luna-metric-card-accent: var(--luna-metric-card-trend-down-fg, #b91c1c);
+}
+
+.luna-metric-card[data-tone="default"][data-trend="neutral"] {
+  --luna-metric-card-accent: var(--luna-metric-card-trend-neutral-fg, #64748b);
+}
+
+.luna-metric-card[data-tone="info"] {
+  --luna-metric-card-accent: var(--luna-metric-card-tone-info, #4f46e5);
+}
+
+.luna-metric-card[data-tone="success"] {
+  --luna-metric-card-accent: var(--luna-metric-card-tone-success, #16a34a);
+}
+
+.luna-metric-card[data-tone="warning"] {
+  --luna-metric-card-accent: var(--luna-metric-card-tone-warning, #d97706);
+}
+
+.luna-metric-card[data-tone="danger"] {
+  --luna-metric-card-accent: var(--luna-metric-card-tone-danger, #dc2626);
+}
+
+.luna-metric-card__content {
+  min-width: 0;
+  flex: 1 1 12rem;
+  display: grid;
+  gap: var(--luna-metric-card-header-gap, 0.5rem);
+}
+
+.luna-metric-card__header {
+  min-width: 0;
+}
+
+.luna-metric-card__label {
+  min-width: 0;
+  font-size: var(--luna-metric-card-label-font-size, 0.75rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: var(--luna-metric-card-label-letter-spacing, 0.08em);
+  color: var(--luna-metric-card-label-fg, #64748b);
+}
+
+.luna-metric-card__value {
+  min-width: 0;
+  font-size: var(--luna-metric-card-value-font-size, 2rem);
+  font-weight: 700;
+  line-height: var(--luna-metric-card-value-line-height, 1.1);
+  letter-spacing: -0.03em;
+  color: var(--luna-metric-card-value-fg, inherit);
+  overflow-wrap: anywhere;
+}
+
+.luna-metric-card__footer {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--luna-metric-card-footer-gap, 0.5rem) 0.75rem;
+  align-items: center;
+}
+
+.luna-metric-card__delta {
+  min-width: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: var(--luna-metric-card-delta-font-size, 0.875rem);
+  font-weight: 600;
+}
+
+.luna-metric-card__trend-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: currentColor;
+  flex: 0 0 auto;
+}
+
+.luna-metric-card__trend-label,
+.luna-metric-card__delta-value,
+.luna-metric-card__meta {
+  min-width: 0;
+}
+
+.luna-metric-card__meta {
+  font-size: var(--luna-metric-card-meta-font-size, 0.875rem);
+  color: var(--luna-metric-card-meta-fg, #64748b);
+}
+
+.luna-metric-card__visual {
+  min-width: min(100%, var(--luna-metric-card-visual-min-width, 6rem));
+  flex: 0 1 var(--luna-metric-card-visual-min-width, 6rem);
+  align-self: stretch;
+  display: flex;
+  align-items: end;
+  justify-content: end;
+  padding: 0.25rem;
+  border-radius: calc(var(--luna-metric-card-radius, 0.75rem) - 0.25rem);
+  background: var(--luna-metric-card-visual-bg, rgba(148, 163, 184, 0.12));
+}
+
+.luna-metric-card[data-trend="up"] .luna-metric-card__delta {
+  color: var(--luna-metric-card-trend-up-fg, #15803d);
+}
+
+.luna-metric-card[data-trend="down"] .luna-metric-card__delta {
+  color: var(--luna-metric-card-trend-down-fg, #b91c1c);
+}
+
+.luna-metric-card[data-trend="neutral"] .luna-metric-card__delta {
+  color: var(--luna-metric-card-trend-neutral-fg, #64748b);
+}
+
+@media (max-width: 640px) {
+  .luna-metric-card__visual {
+    flex-basis: 100%;
+    justify-content: stretch;
+  }
+}

--- a/src/components/luna-metric-card/LunaMetricCard.props.ts
+++ b/src/components/luna-metric-card/LunaMetricCard.props.ts
@@ -1,0 +1,15 @@
+import type React from "react";
+
+export type LunaMetricCardTone = "default" | "info" | "success" | "warning" | "danger";
+export type LunaMetricCardTrend = "up" | "down" | "neutral";
+
+export type LunaMetricCardProps = Omit<React.HTMLAttributes<HTMLElement>, "children" | "title"> & {
+  as?: React.ElementType;
+  label: React.ReactNode;
+  value: React.ReactNode;
+  delta?: React.ReactNode;
+  trend?: LunaMetricCardTrend;
+  meta?: React.ReactNode;
+  tone?: LunaMetricCardTone;
+  visual?: React.ReactNode;
+};

--- a/src/components/luna-metric-card/LunaMetricCard.stories.tsx
+++ b/src/components/luna-metric-card/LunaMetricCard.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaMetricCard } from "./LunaMetricCard";
+
+function TrendBars() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+        alignItems: "end",
+        gap: "0.3rem",
+        width: "100%",
+        minHeight: "4.75rem"
+      }}
+    >
+      {[28, 34, 30, 42, 48, 56].map((height, index) => (
+        <span
+          key={index}
+          style={{
+            display: "block",
+            width: "100%",
+            height: `${height}px`,
+            borderRadius: "999px",
+            background:
+              "linear-gradient(180deg, rgba(79, 70, 229, 0.94), rgba(56, 189, 248, 0.88))"
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Components/LunaMetricCard",
+  component: LunaMetricCard,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    label: "Monthly recurring revenue",
+    value: "$128,400",
+    meta: "Compared with the previous 30 days"
+  }
+} satisfies Meta<typeof LunaMetricCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const BasicKpiCard: Story = {};
+
+export const PositiveDelta: Story = {
+  args: {
+    label: "Qualified pipeline",
+    value: "$2.4M",
+    delta: "12.4%",
+    trend: "up",
+    meta: "Compared with last month"
+  }
+};
+
+export const NegativeDelta: Story = {
+  args: {
+    label: "Net retention",
+    value: "92.1%",
+    delta: "3.7%",
+    trend: "down",
+    meta: "Compared with last quarter"
+  }
+};
+
+export const NeutralNoDelta: Story = {
+  args: {
+    label: "Activation rate",
+    value: "64%",
+    meta: "No material movement this week"
+  }
+};
+
+export const WithCompactTrendContent: Story = {
+  args: {
+    label: "Daily active users",
+    value: "18,240",
+    delta: "6.2%",
+    trend: "up",
+    meta: "Seven day rolling average",
+    visual: <TrendBars />
+  }
+};
+
+export const NarrowWidthDenseLayout: Story = {
+  render: () => (
+    <div style={{ width: "16.5rem" }}>
+      <LunaMetricCard
+        label="Conversion"
+        value="7.4%"
+        delta="0.3%"
+        trend="neutral"
+        meta="Week over week"
+        visual={<TrendBars />}
+      />
+    </div>
+  )
+};

--- a/src/components/luna-metric-card/LunaMetricCard.test.tsx
+++ b/src/components/luna-metric-card/LunaMetricCard.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaMetricCard } from "./LunaMetricCard";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaMetricCard", () => {
+  it("renders the primary label and value", () => {
+    renderWithTheme(<LunaMetricCard label="Monthly recurring revenue" value="$128,400" />);
+
+    expect(screen.getByText("Monthly recurring revenue")).toBeInTheDocument();
+    expect(screen.getByText("$128,400")).toBeInTheDocument();
+  });
+
+  it("renders delta and trend content for positive and negative states", () => {
+    const { rerender } = renderWithTheme(
+      <LunaMetricCard
+        label="Qualified pipeline"
+        value="$2.4M"
+        delta="12.4%"
+        trend="up"
+      />
+    );
+
+    expect(screen.getByText("Up")).toBeInTheDocument();
+    expect(screen.getByText("12.4%")).toBeInTheDocument();
+    expect(screen.getByText("$2.4M").closest(".luna-metric-card")).toHaveAttribute(
+      "data-trend",
+      "up"
+    );
+
+    rerender(
+      <ThemeProvider>
+        <LunaMetricCard
+          label="Qualified pipeline"
+          value="$2.1M"
+          delta="4.8%"
+          trend="down"
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText("Down")).toBeInTheDocument();
+    expect(screen.getByText("4.8%")).toBeInTheDocument();
+    expect(screen.getByText("$2.1M").closest(".luna-metric-card")).toHaveAttribute(
+      "data-trend",
+      "down"
+    );
+  });
+
+  it("omits optional regions when delta, meta, and visual are not provided", () => {
+    renderWithTheme(<LunaMetricCard label="Churn" value="1.8%" />);
+
+    const card = screen.getByText("Churn").closest(".luna-metric-card");
+
+    expect(card?.querySelector(".luna-metric-card__footer")).not.toBeInTheDocument();
+    expect(card?.querySelector(".luna-metric-card__visual")).not.toBeInTheDocument();
+  });
+
+  it("supports neutral trend and visual content", () => {
+    renderWithTheme(
+      <LunaMetricCard
+        label="Activation rate"
+        value="64%"
+        delta="0.0%"
+        trend="neutral"
+        meta="Compared with last week"
+        visual={<div>sparkline</div>}
+      />
+    );
+
+    expect(screen.getByText("Flat")).toBeInTheDocument();
+    expect(screen.getByText("Compared with last week")).toBeInTheDocument();
+    expect(screen.getByText("sparkline")).toBeInTheDocument();
+  });
+
+  it("exposes an accessible region name from the label and value", () => {
+    renderWithTheme(<LunaMetricCard label="Active seats" value="1,284" meta="Current billing period" />);
+
+    expect(
+      screen.getByRole("region", {
+        name: /Active seats 1,284/i,
+        description: /Current billing period/i
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/luna-metric-card/LunaMetricCard.tsx
+++ b/src/components/luna-metric-card/LunaMetricCard.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import type { LunaMetricCardProps, LunaMetricCardTrend } from "./LunaMetricCard.props";
+import "./LunaMetricCard.css";
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function getTrendLabel(trend: LunaMetricCardTrend | undefined) {
+  if (trend === undefined) {
+    return null;
+  }
+
+  if (trend === "up") {
+    return "Up";
+  }
+
+  if (trend === "down") {
+    return "Down";
+  }
+
+  return "Flat";
+}
+
+export const LunaMetricCard = React.forwardRef<HTMLElement, LunaMetricCardProps>(
+  function LunaMetricCard(
+    {
+      as,
+      className,
+      delta,
+      label,
+      meta,
+      style,
+      tone = "default",
+      trend,
+      value,
+      visual,
+      ...props
+    },
+    ref
+  ) {
+    const Component = (as ?? "section") as React.ElementType;
+    const labelId = React.useId();
+    const valueId = React.useId();
+    const deltaId = React.useId();
+    const metaId = React.useId();
+    const trendLabel = getTrendLabel(trend);
+    const hasFooter = delta !== undefined || delta === 0 || meta !== undefined || meta === 0;
+    const describedBy = [
+      delta !== undefined || delta === 0 ? deltaId : null,
+      meta !== undefined || meta === 0 ? metaId : null
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <Component
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-metric-card", className])}
+        data-tone={tone}
+        data-trend={trend}
+        data-has-visual={visual ? "true" : undefined}
+        aria-labelledby={`${labelId} ${valueId}`}
+        aria-describedby={describedBy || undefined}
+        style={style}
+      >
+        <div className="luna-metric-card__content">
+          <div className="luna-metric-card__header">
+            <div className="luna-metric-card__label" id={labelId}>
+              {label}
+            </div>
+          </div>
+          <div className="luna-metric-card__value" id={valueId}>
+            {value}
+          </div>
+          {hasFooter ? (
+            <div className="luna-metric-card__footer">
+              {delta !== undefined || delta === 0 ? (
+                <div className="luna-metric-card__delta" id={deltaId}>
+                  {trendLabel ? (
+                    <>
+                      <span aria-hidden="true" className="luna-metric-card__trend-dot" />
+                      <span className="luna-metric-card__trend-label">{trendLabel}</span>
+                    </>
+                  ) : null}
+                  <span className="luna-metric-card__delta-value">{delta}</span>
+                </div>
+              ) : null}
+              {meta !== undefined || meta === 0 ? (
+                <div className="luna-metric-card__meta" id={metaId}>
+                  {meta}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+        {visual ? <div className="luna-metric-card__visual">{visual}</div> : null}
+      </Component>
+    );
+  }
+);

--- a/src/components/luna-metric-card/index.ts
+++ b/src/components/luna-metric-card/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaMetricCard";
+export * from "./LunaMetricCard.props";

--- a/src/theme/base.test.ts
+++ b/src/theme/base.test.ts
@@ -99,4 +99,26 @@ describe("theme size contract", () => {
     expect(popover?.arrowSize).toBe("3");
     expect(popover?.arrowInset).toBe("4");
   });
+
+  it("defines metric card defaults and status colors", () => {
+    const metricCard = lunarTheme.components.metricCard;
+
+    expect(metricCard?.padding).toBe("4");
+    expect(metricCard?.valueFontSize).toBe("xxl");
+    expect(metricCard?.visualMinWidth).toBe("6rem");
+    expect(Object.keys(metricCard?.modes?.light?.tones ?? {})).toEqual([
+      "default",
+      "info",
+      "success",
+      "warning",
+      "danger"
+    ]);
+    expect(Object.keys(metricCard?.modes?.dark?.tones ?? {})).toEqual([
+      "default",
+      "info",
+      "success",
+      "warning",
+      "danger"
+    ]);
+  });
 });

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1756,6 +1756,63 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    metricCard: {
+      padding: "4",
+      gap: "4",
+      radius: "lg",
+      headerGap: "2",
+      footerGap: "2",
+      labelFontSize: "xs",
+      labelLetterSpacing: "0.08em",
+      valueFontSize: "xxl",
+      valueLineHeight: "tight",
+      deltaFontSize: "sm",
+      metaFontSize: "sm",
+      visualMinWidth: "6rem",
+      accentHeight: "0.25rem",
+      modes: {
+        light: {
+          bg: "neutral.50",
+          fg: "neutral.900",
+          border: "neutral.200",
+          shadow: "sm",
+          labelFg: "neutral.500",
+          valueFg: "neutral.950",
+          metaFg: "neutral.500",
+          visualBg: "neutral.100",
+          trendUpFg: "success.700",
+          trendDownFg: "danger.700",
+          trendNeutralFg: "neutral.500",
+          tones: {
+            default: "neutral.300",
+            info: "primary.500",
+            success: "success.500",
+            warning: "warning.500",
+            danger: "danger.500"
+          }
+        },
+        dark: {
+          bg: "neutral.800",
+          fg: "neutral.50",
+          border: "neutral.700",
+          shadow: "sm",
+          labelFg: "neutral.400",
+          valueFg: "neutral.50",
+          metaFg: "neutral.300",
+          visualBg: "neutral.900",
+          trendUpFg: "success.300",
+          trendDownFg: "danger.300",
+          trendNeutralFg: "neutral.300",
+          tones: {
+            default: "neutral.600",
+            info: "primary.300",
+            success: "success.300",
+            warning: "warning.300",
+            danger: "danger.300"
+          }
+        }
+      }
+    },
     wireframe: {
       gap: "4",
       padding: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -312,6 +312,24 @@ export type ThemePanelModeTokens = {
   descriptionFg?: string;
 };
 
+export type ThemeMetricCardTone = "default" | "info" | "success" | "warning" | "danger";
+export type ThemeMetricCardTrend = "up" | "down" | "neutral";
+
+export type ThemeMetricCardModeTokens = {
+  bg?: string;
+  fg?: string;
+  border?: string;
+  shadow?: string;
+  labelFg?: string;
+  valueFg?: string;
+  metaFg?: string;
+  visualBg?: string;
+  trendUpFg?: string;
+  trendDownFg?: string;
+  trendNeutralFg?: string;
+  tones?: Partial<Record<ThemeMetricCardTone, string>>;
+};
+
 export type ThemeWireframeModeTokens = {
   slotBorder?: string;
   slotBg?: string;
@@ -588,6 +606,22 @@ export type ThemeComponents = {
     descriptionFontSize?: string;
     descriptionLineHeight?: string;
     modes?: Partial<Record<ThemeMode, ThemePanelModeTokens>>;
+  };
+  metricCard?: {
+    padding?: string;
+    gap?: string;
+    radius?: string;
+    headerGap?: string;
+    footerGap?: string;
+    labelFontSize?: string;
+    labelLetterSpacing?: string;
+    valueFontSize?: string;
+    valueLineHeight?: string;
+    deltaFontSize?: string;
+    metaFontSize?: string;
+    visualMinWidth?: string;
+    accentHeight?: string;
+    modes?: Partial<Record<ThemeMode, ThemeMetricCardModeTokens>>;
   };
   wireframe?: {
     gap?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -902,6 +902,108 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     vars["--luna-panel-description-fg"] = resolveTokenValue(theme, panelMode.descriptionFg);
   }
 
+  const metricCard = theme.components.metricCard;
+  if (metricCard?.padding) {
+    vars["--luna-metric-card-padding"] =
+      resolveScaleValue(theme.spacing, metricCard.padding) ?? metricCard.padding;
+  }
+  if (metricCard?.gap) {
+    vars["--luna-metric-card-gap"] =
+      resolveScaleValue(theme.spacing, metricCard.gap) ?? metricCard.gap;
+  }
+  if (metricCard?.radius) {
+    vars["--luna-metric-card-radius"] =
+      resolveScaleValue(theme.radii, metricCard.radius) ?? metricCard.radius;
+  }
+  if (metricCard?.headerGap) {
+    vars["--luna-metric-card-header-gap"] =
+      resolveScaleValue(theme.spacing, metricCard.headerGap) ?? metricCard.headerGap;
+  }
+  if (metricCard?.footerGap) {
+    vars["--luna-metric-card-footer-gap"] =
+      resolveScaleValue(theme.spacing, metricCard.footerGap) ?? metricCard.footerGap;
+  }
+  if (metricCard?.labelFontSize) {
+    vars["--luna-metric-card-label-font-size"] =
+      resolveScaleValue(theme.typography.sizes, metricCard.labelFontSize) ??
+      metricCard.labelFontSize;
+  }
+  if (metricCard?.labelLetterSpacing) {
+    vars["--luna-metric-card-label-letter-spacing"] = metricCard.labelLetterSpacing;
+  }
+  if (metricCard?.valueFontSize) {
+    vars["--luna-metric-card-value-font-size"] =
+      resolveScaleValue(theme.typography.sizes, metricCard.valueFontSize) ??
+      metricCard.valueFontSize;
+  }
+  if (metricCard?.valueLineHeight) {
+    vars["--luna-metric-card-value-line-height"] =
+      resolveScaleValue(theme.typography.lineHeights, metricCard.valueLineHeight) ??
+      metricCard.valueLineHeight;
+  }
+  if (metricCard?.deltaFontSize) {
+    vars["--luna-metric-card-delta-font-size"] =
+      resolveScaleValue(theme.typography.sizes, metricCard.deltaFontSize) ??
+      metricCard.deltaFontSize;
+  }
+  if (metricCard?.metaFontSize) {
+    vars["--luna-metric-card-meta-font-size"] =
+      resolveScaleValue(theme.typography.sizes, metricCard.metaFontSize) ??
+      metricCard.metaFontSize;
+  }
+  if (metricCard?.visualMinWidth) {
+    vars["--luna-metric-card-visual-min-width"] =
+      resolveScaleValue(theme.spacing, metricCard.visualMinWidth) ?? metricCard.visualMinWidth;
+  }
+  if (metricCard?.accentHeight) {
+    vars["--luna-metric-card-accent-height"] =
+      resolveScaleValue(theme.spacing, metricCard.accentHeight) ?? metricCard.accentHeight;
+  }
+  const metricCardMode = metricCard?.modes?.[mode];
+  if (metricCardMode?.bg) {
+    vars["--luna-metric-card-bg"] = resolveTokenValue(theme, metricCardMode.bg);
+  }
+  if (metricCardMode?.fg) {
+    vars["--luna-metric-card-fg"] = resolveTokenValue(theme, metricCardMode.fg);
+  }
+  if (metricCardMode?.border) {
+    vars["--luna-metric-card-border"] = resolveTokenValue(theme, metricCardMode.border);
+  }
+  if (metricCardMode?.shadow) {
+    vars["--luna-metric-card-shadow"] =
+      resolveScaleValue(theme.shadows, metricCardMode.shadow) ??
+      resolveTokenValue(theme, metricCardMode.shadow);
+  }
+  if (metricCardMode?.labelFg) {
+    vars["--luna-metric-card-label-fg"] = resolveTokenValue(theme, metricCardMode.labelFg);
+  }
+  if (metricCardMode?.valueFg) {
+    vars["--luna-metric-card-value-fg"] = resolveTokenValue(theme, metricCardMode.valueFg);
+  }
+  if (metricCardMode?.metaFg) {
+    vars["--luna-metric-card-meta-fg"] = resolveTokenValue(theme, metricCardMode.metaFg);
+  }
+  if (metricCardMode?.visualBg) {
+    vars["--luna-metric-card-visual-bg"] = resolveTokenValue(theme, metricCardMode.visualBg);
+  }
+  if (metricCardMode?.trendUpFg) {
+    vars["--luna-metric-card-trend-up-fg"] = resolveTokenValue(theme, metricCardMode.trendUpFg);
+  }
+  if (metricCardMode?.trendDownFg) {
+    vars["--luna-metric-card-trend-down-fg"] =
+      resolveTokenValue(theme, metricCardMode.trendDownFg);
+  }
+  if (metricCardMode?.trendNeutralFg) {
+    vars["--luna-metric-card-trend-neutral-fg"] =
+      resolveTokenValue(theme, metricCardMode.trendNeutralFg);
+  }
+  for (const tone of ["default", "info", "success", "warning", "danger"] as const) {
+    const toneValue = metricCardMode?.tones?.[tone];
+    if (toneValue) {
+      vars[`--luna-metric-card-tone-${tone}`] = resolveTokenValue(theme, toneValue);
+    }
+  }
+
   const wireframe = theme.components.wireframe;
   if (wireframe?.gap) {
     vars["--luna-wireframe-gap"] =


### PR DESCRIPTION
Closes #134

storybook-component: luna-metric-card

## Summary
Implemented `LunaMetricCard` as a new KPI-specific presentation surface with required label/value, optional delta and trend, optional meta, optional compact visual slot, accessible region naming, and theme-driven tone and trend styling in [src/components/luna-metric-card/LunaMetricCard.tsx](/Users/jordanb/Documents/workspace/automations/react-luna/src/components/luna-metric-card/LunaMetricCard.tsx#L1). Storybook now covers the required states in [src/components/luna-metric-card/LunaMetricCard.stories.tsx](/Users/jordanb/Documents/workspace/automations/react-luna/src/components/luna-metric-card/LunaMetricCard.stories.tsx#L1), docs explain when to use it versus broader surfaces in [docs/v1/components/LunaMetricCard.md](/Users/jordanb/Documents/workspace/automations/react-luna/docs/v1/components/LunaMetricCard.md#L1), the visual review manifest targets the requested slug in [playwright/storybook/manifests/luna-metric-card.json](/Users/jordanb/Documents/workspace/automations/react-luna/playwright/storybook/manifests/luna-metric-card.json#L1), and theme tokens were added in [src/theme/base.ts](/Users/jordanb/Documents/workspace/automations/react-luna/src/theme/base.ts#L1759).

Verification:
- `npm run build` passed
- `npx vitest run src/components/luna-metric-card/LunaMetricCard.test.tsx src/theme/base.test.ts` passed
- `npm run storybook:build` passed
- `STORYBOOK_COMPONENT=luna-metric-card npm run screenshots:storybook` ran but failed in this sandbox because Playwright could not bind `127.0.0.1:6106` (`EPERM`), so screenshot capture could not complete here

I also added the release metadata in [.changeset/soft-garlics-wink.md](/Users/jordanb/Documents/workspace/automations/react-luna/.changeset/soft-garlics-wink.md#L1). I could not create the requested commit because this environment denied writing `.git/index.lock`, so the work remains uncommitted in the current tree.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`