### PR TITLE
Resolve #135: Add LunaLineChart presentation primitive

### DIFF
--- a/.changeset/four-houses-train.md
+++ b/.changeset/four-houses-train.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaLineChart` presentation primitive with Storybook coverage, tests, and theme controls for chart styling.

--- a/docs/v1/components/LunaLineChart.md
+++ b/docs/v1/components/LunaLineChart.md
@@ -1,0 +1,74 @@
+# LunaLineChart
+
+`LunaLineChart` is a presentation primitive for single-series trend and time-series views.
+
+It is intended for:
+
+- dashboard trend panels
+- reporting surfaces
+- compact status overviews that still need axes
+- pairing with `LunaPanel` or future dashboard layouts
+
+It is not intended to be a general charting framework.
+
+## Props
+
+- `ariaLabel: string`
+- `ariaDescription?: string`
+- `data: Array<{ x: string | number | Date; y: number }>`
+- `emptyTitle?: React.ReactNode`
+- `emptyDescription?: React.ReactNode`
+- `error?: React.ReactNode`
+- `errorTitle?: React.ReactNode`
+- `errorDescription?: React.ReactNode`
+- `formatXAxisLabel?: (value, context) => string`
+- `formatYAxisLabel?: (value) => string`
+- `height?: React.CSSProperties["height"]`
+- `loading?: boolean`
+- `loadingLabel?: string`
+- `showGridLines?: boolean`
+- `showMarkers?: boolean`
+
+It also accepts normal `div` HTML attributes.
+
+## Behavior
+
+- only one ordered series is supported in the first pass
+- the component does not include an internal title or header
+- loading, empty, and error states are handled inside the chart surface
+- invalid `y` values are ignored before plotting
+- x-axis labels are sampled automatically for dense series
+- markers are optional and should be used selectively on denser data
+
+## Accessibility
+
+- `ariaLabel` is required so the chart always exposes a readable name
+- `ariaDescription` is the place for a short trend summary or contextual explanation
+- the component exposes itself as a grouped line chart surface instead of relying on raw SVG semantics
+- loading state sets `aria-busy`
+
+## Theme
+
+`LunaLineChart` exposes component theme variables for:
+
+- `--luna-line-chart-bg`
+- `--luna-line-chart-border`
+- `--luna-line-chart-axis-text`
+- `--luna-line-chart-axis-line`
+- `--luna-line-chart-grid`
+- `--luna-line-chart-line`
+- `--luna-line-chart-marker-fill`
+- `--luna-line-chart-marker-stroke`
+- `--luna-line-chart-empty-bg`
+
+The default theme also provides sizing controls for height, padding, label spacing, stroke width, and marker size.
+
+## First-Pass Limits
+
+- single-series only
+- no mixed chart modes
+- no chart header API
+- no chart builder or plugin abstraction
+- no zooming, panning, or tooltip system
+
+This keeps the primitive aligned with the issue scope and leaves broader chart-system work for later phases.

--- a/playwright/storybook/manifests/luna-line-chart.json
+++ b/playwright/storybook/manifests/luna-line-chart.json
@@ -1,0 +1,32 @@
+[
+  {
+    "storyId": "components-lunalinechart--basic",
+    "fileName": "luna-line-chart-basic",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunalinechart--sparse-data",
+    "fileName": "luna-line-chart-sparse-data",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunalinechart--dense-data",
+    "fileName": "luna-line-chart-dense-data",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunalinechart--empty-state",
+    "fileName": "luna-line-chart-empty-state",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunalinechart--loading-state",
+    "fileName": "luna-line-chart-loading-state",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunalinechart--dashboard-embed",
+    "fileName": "luna-line-chart-dashboard-embed",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export * from "./luna-form";
 export * from "./luna-header";
 export * from "./luna-hover-text";
 export * from "./luna-input";
+export * from "./luna-line-chart";
 export * from "./luna-menu";
 export * from "./luna-progress";
 export * from "./luna-slider";

--- a/src/components/luna-line-chart/LunaLineChart.css
+++ b/src/components/luna-line-chart/LunaLineChart.css
@@ -1,0 +1,154 @@
+.luna-line-chart {
+  --luna-line-chart-current-height: var(--luna-line-chart-height, 16rem);
+  display: grid;
+  gap: var(--luna-line-chart-label-gap, 0.75rem);
+  min-width: 0;
+  padding: var(--luna-line-chart-padding, 1rem);
+  border: 1px solid var(--luna-line-chart-border, rgba(108, 122, 171, 0.2));
+  border-radius: var(--luna-line-chart-radius, 0.75rem);
+  background: var(--luna-line-chart-bg, var(--luna-surface));
+  color: var(--luna-line-chart-axis-text, var(--luna-muted));
+  box-sizing: border-box;
+}
+
+.luna-line-chart[data-state="loading"],
+.luna-line-chart[data-state="empty"],
+.luna-line-chart[data-state="error"] {
+  align-items: stretch;
+}
+
+.luna-line-chart__frame {
+  display: grid;
+  grid-template-columns: minmax(2.75rem, auto) minmax(0, 1fr);
+  grid-template-rows: minmax(0, var(--luna-line-chart-current-height)) auto;
+  gap: var(--luna-line-chart-label-gap, 0.75rem);
+  min-width: 0;
+}
+
+.luna-line-chart__y-axis,
+.luna-line-chart__x-axis {
+  position: relative;
+  font-size: var(--luna-line-chart-axis-font-size, 0.75rem);
+  line-height: 1;
+  color: var(--luna-line-chart-axis-text, var(--luna-muted));
+}
+
+.luna-line-chart__y-axis {
+  min-height: var(--luna-line-chart-current-height);
+}
+
+.luna-line-chart__y-axis-label,
+.luna-line-chart__x-axis-label {
+  position: absolute;
+  white-space: nowrap;
+}
+
+.luna-line-chart__y-axis-label {
+  right: 0;
+  transform: translateY(50%);
+}
+
+.luna-line-chart__plot {
+  position: relative;
+  min-width: 0;
+  min-height: var(--luna-line-chart-current-height);
+  overflow: hidden;
+  border-radius: calc(var(--luna-line-chart-radius, 0.75rem) - 0.25rem);
+  background: var(--luna-line-chart-empty-bg, rgba(247, 249, 255, 0.8));
+}
+
+.luna-line-chart__plot svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.luna-line-chart__grid-line,
+.luna-line-chart__axis-line {
+  fill: none;
+  stroke-linecap: round;
+}
+
+.luna-line-chart__grid-line {
+  stroke: var(--luna-line-chart-grid, rgba(120, 133, 181, 0.18));
+  stroke-width: var(--luna-line-chart-grid-stroke-width, 1);
+}
+
+.luna-line-chart__axis-line {
+  stroke: var(--luna-line-chart-axis-line, rgba(108, 122, 171, 0.35));
+  stroke-width: max(var(--luna-line-chart-grid-stroke-width, 1), 1);
+}
+
+.luna-line-chart__series {
+  fill: none;
+  stroke: var(--luna-line-chart-line, #5b63f6);
+  stroke-width: var(--luna-line-chart-stroke-width, 3);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.luna-line-chart__marker {
+  fill: var(--luna-line-chart-marker-fill, #ffffff);
+  stroke: var(--luna-line-chart-marker-stroke, var(--luna-line-chart-line, #5b63f6));
+  stroke-width: max(calc(var(--luna-line-chart-stroke-width, 3) / 2), 1);
+}
+
+.luna-line-chart__x-axis {
+  grid-column: 2;
+  min-height: 1rem;
+}
+
+.luna-line-chart__x-axis-label {
+  top: 0;
+  transform: translateX(-50%);
+}
+
+.luna-line-chart__state {
+  min-height: var(--luna-line-chart-current-height);
+}
+
+.luna-line-chart__loading {
+  display: grid;
+  gap: 1rem;
+  min-height: var(--luna-line-chart-current-height);
+}
+
+.luna-line-chart__loading-bars {
+  display: grid;
+  grid-template-columns: minmax(2.75rem, auto) minmax(0, 1fr);
+  align-items: end;
+  gap: var(--luna-line-chart-label-gap, 0.75rem);
+  min-height: var(--luna-line-chart-current-height);
+}
+
+.luna-line-chart__loading-y-axis {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: end;
+}
+
+.luna-line-chart__loading-plot {
+  display: grid;
+  align-items: stretch;
+  padding: 0.75rem;
+  border-radius: calc(var(--luna-line-chart-radius, 0.75rem) - 0.25rem);
+  background: var(--luna-line-chart-empty-bg, rgba(247, 249, 255, 0.8));
+}
+
+.luna-line-chart__loading-x-axis {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.luna-line-chart__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/luna-line-chart/LunaLineChart.props.ts
+++ b/src/components/luna-line-chart/LunaLineChart.props.ts
@@ -1,0 +1,35 @@
+import type React from "react";
+
+export type LunaLineChartDatum = {
+  x: string | number | Date;
+  y: number;
+};
+
+export type LunaLineChartLabelFormatterContext = {
+  index: number;
+  points: LunaLineChartDatum[];
+};
+
+export type LunaLineChartProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children" | "color" | "title"
+> & {
+  ariaLabel: string;
+  ariaDescription?: string;
+  data: LunaLineChartDatum[];
+  emptyDescription?: React.ReactNode;
+  emptyTitle?: React.ReactNode;
+  error?: React.ReactNode;
+  errorDescription?: React.ReactNode;
+  errorTitle?: React.ReactNode;
+  formatXAxisLabel?: (
+    value: LunaLineChartDatum["x"],
+    context: LunaLineChartLabelFormatterContext
+  ) => string;
+  formatYAxisLabel?: (value: number) => string;
+  height?: React.CSSProperties["height"];
+  loading?: boolean;
+  loadingLabel?: string;
+  showGridLines?: boolean;
+  showMarkers?: boolean;
+};

--- a/src/components/luna-line-chart/LunaLineChart.stories.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ThemeProvider } from "../../theme";
+import { LunaPanel } from "../luna-panel";
+import { LunaLineChart } from "./LunaLineChart";
+
+const basicSeries = [
+  { x: "Mon", y: 14 },
+  { x: "Tue", y: 18 },
+  { x: "Wed", y: 16 },
+  { x: "Thu", y: 22 },
+  { x: "Fri", y: 25 },
+  { x: "Sat", y: 21 },
+  { x: "Sun", y: 29 }
+];
+
+const sparseSeries = [
+  { x: "Jan", y: 1200 },
+  { x: "Mar", y: 1800 },
+  { x: "Jun", y: 1500 },
+  { x: "Sep", y: 2400 }
+];
+
+const denseSeries = Array.from({ length: 36 }, (_, index) => ({
+  x: `Day ${index + 1}`,
+  y: 48 + Math.round(Math.sin(index / 4) * 18 + Math.cos(index / 7) * 9 + index * 0.8)
+}));
+
+const meta = {
+  title: "Components/LunaLineChart",
+  component: LunaLineChart,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    ariaLabel: "Weekly trend",
+    ariaDescription: "Trend line showing the week climbing toward the weekend.",
+    data: basicSeries,
+    showGridLines: true,
+    showMarkers: true
+  }
+} satisfies Meta<typeof LunaLineChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const SparseData: Story = {
+  args: {
+    ariaLabel: "Sparse quarterly signals",
+    ariaDescription: "Four reported values distributed across the year.",
+    data: sparseSeries,
+    formatYAxisLabel: (value) =>
+      new Intl.NumberFormat("en-US", {
+        notation: "compact",
+        maximumFractionDigits: 1
+      }).format(value)
+  }
+};
+
+export const DenseData: Story = {
+  args: {
+    ariaLabel: "Dense thirty-six day trend",
+    ariaDescription: "A dense rolling signal with labels sampled for readability.",
+    data: denseSeries,
+    showMarkers: false
+  }
+};
+
+export const EmptyState: Story = {
+  args: {
+    ariaLabel: "Empty usage trend",
+    ariaDescription: "No datapoints are available for the current filter.",
+    data: [],
+    emptyTitle: "No reporting trend yet",
+    emptyDescription: "This view will chart activity as soon as the source stream starts sending values."
+  }
+};
+
+export const LoadingState: Story = {
+  args: {
+    ariaLabel: "Loading usage trend",
+    ariaDescription: "The chart is preparing the current reporting range.",
+    data: [],
+    loading: true
+  }
+};
+
+export const DashboardEmbed: Story = {
+  render: () => (
+    <div style={{ width: "min(100%, 54rem)" }}>
+      <LunaPanel
+        title="Mission throughput"
+        description="Thirty day output trend inside a reporting panel."
+        tone="chrome"
+      >
+        <LunaLineChart
+          ariaLabel="Mission throughput for the last thirty days"
+          ariaDescription="Output climbs through the second half of the month and settles into a higher range."
+          data={denseSeries}
+          showMarkers={false}
+          formatXAxisLabel={(value, context) =>
+            context.index === 0 || context.index === denseSeries.length - 1
+              ? String(value)
+              : String(value).replace("Day ", "")
+          }
+        />
+      </LunaPanel>
+    </div>
+  )
+};
+
+export const ThemeOverride: Story = {
+  render: () => (
+    <ThemeProvider
+      theme={{
+        components: {
+          lineChart: {
+            modes: {
+              light: {
+                line: "#14b8a6",
+                grid: "rgba(20, 184, 166, 0.18)",
+                axisText: "#0f766e",
+                bg: "linear-gradient(180deg, rgba(240, 253, 250, 0.94), rgba(236, 253, 245, 0.9))"
+              }
+            }
+          }
+        }
+      }}
+    >
+      <LunaLineChart
+        ariaLabel="Theme override trend"
+        ariaDescription="A theme override story proving the chart surface can be recolored through the theme."
+        data={basicSeries}
+        showMarkers
+      />
+    </ThemeProvider>
+  )
+};

--- a/src/components/luna-line-chart/LunaLineChart.test.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import { LunaLineChart } from "./LunaLineChart";
+
+const basicSeries = [
+  { x: "Mon", y: 12 },
+  { x: "Tue", y: 18 },
+  { x: "Wed", y: 14 },
+  { x: "Thu", y: 23 },
+  { x: "Fri", y: 19 }
+];
+
+const denseSeries = Array.from({ length: 18 }, (_, index) => ({
+  x: `Day ${index + 1}`,
+  y: 40 + index
+}));
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  options?: {
+    theme?: React.ComponentProps<typeof ThemeProvider>["theme"];
+  }
+) {
+  return render(<ThemeProvider theme={options?.theme}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaLineChart", () => {
+  it("renders a line path and sampled axes for normal data", () => {
+    const { container } = renderWithTheme(
+      <LunaLineChart
+        ariaLabel="Weekly trend"
+        ariaDescription="Trend over five days."
+        data={basicSeries}
+        showMarkers
+      />
+    );
+
+    const chart = screen.getByRole("group", { name: "Weekly trend" });
+    expect(chart).toHaveAttribute("aria-roledescription", "line chart");
+    expect(screen.getByText("Trend over five days.")).toBeInTheDocument();
+    expect(container.querySelector(".luna-line-chart__series")).toHaveAttribute("d");
+    expect(container.querySelectorAll(".luna-line-chart__marker")).toHaveLength(basicSeries.length);
+    expect(screen.getByText("Mon")).toBeInTheDocument();
+    expect(screen.getByText("Fri")).toBeInTheDocument();
+  });
+
+  it("samples dense x-axis labels instead of rendering every point label", () => {
+    const { container } = renderWithTheme(
+      <LunaLineChart ariaLabel="Dense trend" data={denseSeries} />
+    );
+
+    expect(container.querySelectorAll(".luna-line-chart__x-axis-label").length).toBeLessThan(
+      denseSeries.length
+    );
+  });
+
+  it("renders the empty state when no valid datapoints exist", () => {
+    renderWithTheme(
+      <LunaLineChart
+        ariaLabel="Empty trend"
+        data={[]}
+        emptyTitle="No events yet"
+        emptyDescription="Waiting for the first event."
+      />
+    );
+
+    expect(screen.getByText("No events yet")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for the first event.")).toBeInTheDocument();
+  });
+
+  it("renders the loading state with busy semantics", () => {
+    renderWithTheme(<LunaLineChart ariaLabel="Loading trend" data={[]} loading />);
+
+    expect(screen.getByRole("group", { name: "Loading trend" })).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("surfaces theme overrides through the provider variables", () => {
+    const { container } = renderWithTheme(
+      <LunaLineChart ariaLabel="Theme trend" data={basicSeries} />,
+      {
+        theme: {
+          components: {
+            lineChart: {
+              modes: {
+                light: {
+                  line: "#123456",
+                  grid: "#abcdef"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const provider = container.querySelector("[data-luna-theme]");
+    expect(provider).toHaveStyle({
+      "--luna-line-chart-line": "#123456",
+      "--luna-line-chart-grid": "#abcdef"
+    });
+  });
+});

--- a/src/components/luna-line-chart/LunaLineChart.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.tsx
@@ -1,0 +1,406 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue } from "../../theme/resolve";
+import { LunaEmptyState } from "../luna-empty-state";
+import { LunaSkeleton } from "../luna-skeleton";
+import type { LunaLineChartDatum, LunaLineChartProps } from "./LunaLineChart.props";
+import "./LunaLineChart.css";
+
+type ChartCssVariable = "--luna-line-chart-current-height";
+
+type LunaLineChartStyle = React.CSSProperties &
+  Partial<Record<ChartCssVariable, string | number | undefined>>;
+
+type PlotPoint = {
+  x: number;
+  y: number;
+  datum: LunaLineChartDatum;
+  index: number;
+};
+
+type AxisTick = {
+  value: number;
+  offset: number;
+  label: string;
+};
+
+const VIEWBOX_WIDTH = 100;
+const VIEWBOX_HEIGHT = 100;
+const PLOT_LEFT = 8;
+const PLOT_RIGHT = 98;
+const PLOT_TOP = 6;
+const PLOT_BOTTOM = 90;
+const DEFAULT_Y_TICK_COUNT = 4;
+const MAX_X_TICKS = 6;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveDimensionValue(
+  value: React.CSSProperties["height"] | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveNumericValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  const resolved = resolveScaleValue(theme.spacing, value) ?? value;
+  const numeric = Number.parseFloat(String(resolved));
+
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function normalizeData(data: LunaLineChartDatum[]) {
+  return data.filter((point) => Number.isFinite(point.y));
+}
+
+function buildYDomain(values: number[]) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.1, 1);
+    return { min: min - padding, max: max + padding };
+  }
+
+  const span = max - min;
+  const padding = span * 0.12;
+  return { min: min - padding, max: max + padding };
+}
+
+function formatAxisValue(value: LunaLineChartDatum["x"]) {
+  if (value instanceof Date) {
+    return value.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric"
+    });
+  }
+
+  return String(value);
+}
+
+function formatNumericAxisValue(value: number) {
+  if (Math.abs(value) >= 1000) {
+    return new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      maximumFractionDigits: 1
+    }).format(value);
+  }
+
+  if (Number.isInteger(value)) {
+    return String(value);
+  }
+
+  return value.toFixed(1);
+}
+
+function buildPlotPoints(data: LunaLineChartDatum[]) {
+  const domain = buildYDomain(data.map((point) => point.y));
+  const xSpan = data.length > 1 ? data.length - 1 : 1;
+  const ySpan = domain.max - domain.min || 1;
+
+  const points = data.map((datum, index) => {
+    const x =
+      data.length === 1
+        ? (PLOT_LEFT + PLOT_RIGHT) / 2
+        : PLOT_LEFT + ((PLOT_RIGHT - PLOT_LEFT) * index) / xSpan;
+    const y =
+      PLOT_BOTTOM - ((datum.y - domain.min) / ySpan) * (PLOT_BOTTOM - PLOT_TOP);
+
+    return {
+      x,
+      y,
+      datum,
+      index
+    } satisfies PlotPoint;
+  });
+
+  return { points, domain };
+}
+
+function buildLinePath(points: PlotPoint[]) {
+  if (points.length === 0) {
+    return "";
+  }
+
+  if (points.length === 1) {
+    const point = points[0];
+    return `M ${point.x} ${point.y}`;
+  }
+
+  return points
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+}
+
+function buildYAxisTicks(
+  min: number,
+  max: number,
+  formatYAxisLabel: LunaLineChartProps["formatYAxisLabel"]
+) {
+  return Array.from({ length: DEFAULT_Y_TICK_COUNT + 1 }, (_, index) => {
+    const ratio = index / DEFAULT_Y_TICK_COUNT;
+    const value = max - (max - min) * ratio;
+    return {
+      value,
+      offset: ratio * 100,
+      label: formatYAxisLabel ? formatYAxisLabel(value) : formatNumericAxisValue(value)
+    } satisfies AxisTick;
+  });
+}
+
+function buildXAxisTicks(
+  data: LunaLineChartDatum[],
+  formatXAxisLabel: LunaLineChartProps["formatXAxisLabel"]
+) {
+  if (data.length === 0) {
+    return [];
+  }
+
+  const desiredCount = Math.min(MAX_X_TICKS, data.length);
+  const indices = new Set<number>();
+
+  if (data.length === 1) {
+    indices.add(0);
+  } else {
+    for (let step = 0; step < desiredCount; step += 1) {
+      const ratio = desiredCount === 1 ? 0 : step / (desiredCount - 1);
+      const index = Math.round(ratio * (data.length - 1));
+      indices.add(index);
+    }
+  }
+
+  return Array.from(indices)
+    .sort((left, right) => left - right)
+    .map((index) => {
+      const datum = data[index];
+      const label = formatXAxisLabel
+        ? formatXAxisLabel(datum.x, { index, points: data })
+        : formatAxisValue(datum.x);
+
+      return {
+        value: index,
+        offset: data.length === 1 ? 50 : (index / (data.length - 1)) * 100,
+        label
+      };
+    });
+}
+
+export const LunaLineChart = React.forwardRef<HTMLDivElement, LunaLineChartProps>(
+  function LunaLineChart(
+    {
+      ariaDescription,
+      ariaLabel,
+      className,
+      data,
+      emptyDescription = "Add data points to show a trend line.",
+      emptyTitle = "No chart data",
+      error,
+      errorDescription,
+      errorTitle = "Chart unavailable",
+      formatXAxisLabel,
+      formatYAxisLabel,
+      height,
+      loading = false,
+      loadingLabel = "Loading chart",
+      showGridLines = true,
+      showMarkers = false,
+      style,
+      ...props
+    },
+    ref
+  ) {
+    const { theme } = useTheme();
+    const descriptionId = React.useId();
+    const normalizedData = normalizeData(data);
+    const resolvedState = error
+      ? "error"
+      : loading
+        ? "loading"
+        : normalizedData.length === 0
+          ? "empty"
+          : "ready";
+
+    const resolvedHeight =
+      resolveDimensionValue(height, theme) ??
+      resolveDimensionValue(theme.components.lineChart?.height, theme);
+    const markerRadius = (resolveNumericValue(theme.components.lineChart?.markerSize, theme) ?? 4.5) / 2.5;
+    const resolvedStyle: LunaLineChartStyle = {
+      ["--luna-line-chart-current-height" as const]: resolvedHeight,
+      ...style
+    };
+
+    const ariaDescriptionText =
+      typeof ariaDescription === "string" && ariaDescription.trim().length > 0
+        ? ariaDescription
+        : undefined;
+
+    if (resolvedState !== "ready") {
+      return (
+        <div
+          {...props}
+          ref={ref}
+          className={toClassName(["luna-line-chart", className])}
+          data-state={resolvedState}
+          role="group"
+          aria-label={ariaLabel}
+          aria-roledescription="line chart"
+          aria-describedby={ariaDescriptionText ? descriptionId : undefined}
+          aria-busy={resolvedState === "loading" ? true : undefined}
+          style={resolvedStyle}
+        >
+          {ariaDescriptionText ? (
+            <div className="luna-line-chart__sr-only" id={descriptionId}>
+              {ariaDescriptionText}
+            </div>
+          ) : null}
+          <div className="luna-line-chart__state">
+            {resolvedState === "loading" ? (
+              <div className="luna-line-chart__loading">
+                <div className="luna-line-chart__loading-bars" aria-label={loadingLabel}>
+                  <div className="luna-line-chart__loading-y-axis" aria-hidden="true">
+                    <LunaSkeleton width="2" />
+                    <LunaSkeleton width="2.5" />
+                    <LunaSkeleton width="2" />
+                    <LunaSkeleton width="2.25" />
+                    <LunaSkeleton width="1.75" />
+                  </div>
+                  <div className="luna-line-chart__loading-plot">
+                    <LunaSkeleton shape="block" height="100%" />
+                  </div>
+                </div>
+                <div className="luna-line-chart__loading-x-axis" aria-hidden="true">
+                  <LunaSkeleton width="2.5" />
+                  <LunaSkeleton width="2.25" />
+                  <LunaSkeleton width="2.75" />
+                  <LunaSkeleton width="2.25" />
+                </div>
+              </div>
+            ) : (
+              <LunaEmptyState
+                framed={false}
+                title={resolvedState === "error" ? errorTitle : emptyTitle}
+                description={
+                  resolvedState === "error"
+                    ? (errorDescription ?? error)
+                    : emptyDescription
+                }
+              />
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    const { points, domain } = buildPlotPoints(normalizedData);
+    const yTicks = buildYAxisTicks(domain.min, domain.max, formatYAxisLabel);
+    const xTicks = buildXAxisTicks(normalizedData, formatXAxisLabel);
+    const linePath = buildLinePath(points);
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-line-chart", className])}
+        data-state="ready"
+        role="group"
+        aria-label={ariaLabel}
+        aria-roledescription="line chart"
+        aria-describedby={ariaDescriptionText ? descriptionId : undefined}
+        style={resolvedStyle}
+      >
+        {ariaDescriptionText ? (
+          <div className="luna-line-chart__sr-only" id={descriptionId}>
+            {ariaDescriptionText}
+          </div>
+        ) : null}
+        <div className="luna-line-chart__frame">
+          <div className="luna-line-chart__y-axis" aria-hidden="true">
+            {yTicks.map((tick) => (
+              <span
+                className="luna-line-chart__y-axis-label"
+                key={tick.offset}
+                style={{ bottom: `${tick.offset}%` }}
+              >
+                {tick.label}
+              </span>
+            ))}
+          </div>
+          <div className="luna-line-chart__plot">
+            <svg aria-hidden="true" viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}>
+              {showGridLines
+                ? yTicks.map((tick) => (
+                    <line
+                      className="luna-line-chart__grid-line"
+                      key={`y-${tick.offset}`}
+                      x1={PLOT_LEFT}
+                      x2={PLOT_RIGHT}
+                      y1={PLOT_BOTTOM - (tick.offset / 100) * (PLOT_BOTTOM - PLOT_TOP)}
+                      y2={PLOT_BOTTOM - (tick.offset / 100) * (PLOT_BOTTOM - PLOT_TOP)}
+                    />
+                  ))
+                : null}
+              {showGridLines
+                ? xTicks.map((tick) => (
+                    <line
+                      className="luna-line-chart__grid-line"
+                      key={`x-${tick.value}`}
+                      x1={
+                        normalizedData.length === 1
+                          ? (PLOT_LEFT + PLOT_RIGHT) / 2
+                          : PLOT_LEFT + (tick.offset / 100) * (PLOT_RIGHT - PLOT_LEFT)
+                      }
+                      x2={
+                        normalizedData.length === 1
+                          ? (PLOT_LEFT + PLOT_RIGHT) / 2
+                          : PLOT_LEFT + (tick.offset / 100) * (PLOT_RIGHT - PLOT_LEFT)
+                      }
+                      y1={PLOT_TOP}
+                      y2={PLOT_BOTTOM}
+                    />
+                  ))
+                : null}
+              <line className="luna-line-chart__axis-line" x1={PLOT_LEFT} x2={PLOT_RIGHT} y1={PLOT_BOTTOM} y2={PLOT_BOTTOM} />
+              <line className="luna-line-chart__axis-line" x1={PLOT_LEFT} x2={PLOT_LEFT} y1={PLOT_TOP} y2={PLOT_BOTTOM} />
+              <path className="luna-line-chart__series" d={linePath} />
+              {showMarkers
+                ? points.map((point) => (
+                    <circle
+                      className="luna-line-chart__marker"
+                      cx={point.x}
+                      cy={point.y}
+                      key={`${point.index}-${point.datum.y}`}
+                      r={markerRadius}
+                    />
+                  ))
+                : null}
+            </svg>
+          </div>
+          <div className="luna-line-chart__x-axis" aria-hidden="true">
+            {xTicks.map((tick) => (
+              <span
+                className="luna-line-chart__x-axis-label"
+                key={`${tick.value}-${tick.label}`}
+                style={{ left: `${tick.offset}%` }}
+              >
+                {tick.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+);

--- a/src/components/luna-line-chart/index.ts
+++ b/src/components/luna-line-chart/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaLineChart";
+export * from "./LunaLineChart.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1488,6 +1488,40 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    lineChart: {
+      height: "16rem",
+      radius: "lg",
+      padding: "4",
+      axisFontSize: "0.75rem",
+      labelGap: "3",
+      strokeWidth: "3",
+      markerSize: "4.5",
+      gridStrokeWidth: "1",
+      modes: {
+        light: {
+          bg: "linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(244, 247, 255, 0.94))",
+          border: "rgba(108, 122, 171, 0.2)",
+          axisText: "#5f6b91",
+          axisLine: "rgba(108, 122, 171, 0.35)",
+          grid: "rgba(120, 133, 181, 0.18)",
+          line: "#5b63f6",
+          markerFill: "#ffffff",
+          markerStroke: "#5b63f6",
+          emptyBg: "rgba(247, 249, 255, 0.8)"
+        },
+        dark: {
+          bg: "linear-gradient(180deg, rgba(22, 29, 48, 0.9), rgba(14, 20, 36, 0.96))",
+          border: "rgba(120, 138, 194, 0.28)",
+          axisText: "#cbd6ff",
+          axisLine: "rgba(150, 166, 220, 0.45)",
+          grid: "rgba(129, 145, 198, 0.24)",
+          line: "#8da2ff",
+          markerFill: "#161d30",
+          markerStroke: "#8da2ff",
+          emptyBg: "rgba(22, 29, 48, 0.76)"
+        }
+      }
+    },
     progress: {
       defaultSize: "medium",
       defaultTone: "primary",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -192,6 +192,18 @@ export type ThemeSpinnerModeTokens = {
   track?: string;
 };
 
+export type ThemeLineChartModeTokens = {
+  bg?: string;
+  border?: string;
+  axisText?: string;
+  axisLine?: string;
+  grid?: string;
+  line?: string;
+  markerFill?: string;
+  markerStroke?: string;
+  emptyBg?: string;
+};
+
 export type ThemeProgressSizeProfile = {
   height?: string;
 };
@@ -521,6 +533,17 @@ export type ThemeComponents = {
     defaultLabel?: string;
     sizes?: Record<string, ThemeSpinnerSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeSpinnerModeTokens>>;
+  };
+  lineChart?: {
+    height?: string;
+    radius?: string;
+    padding?: string;
+    axisFontSize?: string;
+    labelGap?: string;
+    strokeWidth?: string;
+    markerSize?: string;
+    gridStrokeWidth?: string;
+    modes?: Partial<Record<ThemeMode, ThemeLineChartModeTokens>>;
   };
   progress?: {
     defaultSize?: string;

--- a/src/theme/vars.ts
+++ b/src/theme/vars.ts
@@ -735,6 +735,68 @@ export function buildThemeVars(theme: Theme, mode: "light" | "dark"): Record<str
     }
   }
 
+  const lineChart = theme.components.lineChart;
+  if (lineChart?.height) {
+    vars["--luna-line-chart-height"] =
+      resolveScaleValue(theme.spacing, lineChart.height) ?? lineChart.height;
+  }
+  if (lineChart?.radius) {
+    vars["--luna-line-chart-radius"] =
+      resolveScaleValue(theme.radii, lineChart.radius) ?? lineChart.radius;
+  }
+  if (lineChart?.padding) {
+    vars["--luna-line-chart-padding"] =
+      resolveScaleValue(theme.spacing, lineChart.padding) ?? lineChart.padding;
+  }
+  if (lineChart?.axisFontSize) {
+    vars["--luna-line-chart-axis-font-size"] =
+      resolveScaleValue(theme.typography.sizes, lineChart.axisFontSize) ?? lineChart.axisFontSize;
+  }
+  if (lineChart?.labelGap) {
+    vars["--luna-line-chart-label-gap"] =
+      resolveScaleValue(theme.spacing, lineChart.labelGap) ?? lineChart.labelGap;
+  }
+  if (lineChart?.strokeWidth) {
+    vars["--luna-line-chart-stroke-width"] =
+      resolveScaleValue(theme.spacing, lineChart.strokeWidth) ?? lineChart.strokeWidth;
+  }
+  if (lineChart?.markerSize) {
+    vars["--luna-line-chart-marker-size"] =
+      resolveScaleValue(theme.spacing, lineChart.markerSize) ?? lineChart.markerSize;
+  }
+  if (lineChart?.gridStrokeWidth) {
+    vars["--luna-line-chart-grid-stroke-width"] =
+      resolveScaleValue(theme.spacing, lineChart.gridStrokeWidth) ?? lineChart.gridStrokeWidth;
+  }
+  const lineChartMode = lineChart?.modes?.[mode];
+  if (lineChartMode?.bg) {
+    vars["--luna-line-chart-bg"] = resolveTokenValue(theme, lineChartMode.bg);
+  }
+  if (lineChartMode?.border) {
+    vars["--luna-line-chart-border"] = resolveTokenValue(theme, lineChartMode.border);
+  }
+  if (lineChartMode?.axisText) {
+    vars["--luna-line-chart-axis-text"] = resolveTokenValue(theme, lineChartMode.axisText);
+  }
+  if (lineChartMode?.axisLine) {
+    vars["--luna-line-chart-axis-line"] = resolveTokenValue(theme, lineChartMode.axisLine);
+  }
+  if (lineChartMode?.grid) {
+    vars["--luna-line-chart-grid"] = resolveTokenValue(theme, lineChartMode.grid);
+  }
+  if (lineChartMode?.line) {
+    vars["--luna-line-chart-line"] = resolveTokenValue(theme, lineChartMode.line);
+  }
+  if (lineChartMode?.markerFill) {
+    vars["--luna-line-chart-marker-fill"] = resolveTokenValue(theme, lineChartMode.markerFill);
+  }
+  if (lineChartMode?.markerStroke) {
+    vars["--luna-line-chart-marker-stroke"] = resolveTokenValue(theme, lineChartMode.markerStroke);
+  }
+  if (lineChartMode?.emptyBg) {
+    vars["--luna-line-chart-empty-bg"] = resolveTokenValue(theme, lineChartMode.emptyBg);
+  }
+
   const tooltip = theme.components.tooltip;
   if (tooltip?.radius) {
     vars["--luna-tooltip-radius"] =


### PR DESCRIPTION
Closes #135

storybook-component: luna-line-chart

## Summary
Implemented `LunaLineChart` as a new presentation primitive with a narrow first-pass contract: single-series SVG rendering, sampled axes, optional gridlines and markers, and built-in loading, empty, and error states with an explicit accessibility contract in [LunaLineChart.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.tsx#L201). Storybook coverage for basic, sparse, dense, empty, loading, dashboard embedding, and theme override lives in [LunaLineChart.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.stories.tsx#L29), tests are in [LunaLineChart.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.test.tsx#L33), the public docs are in [LunaLineChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaLineChart.md#L1), and the screenshot manifest for the required slug is in [luna-line-chart.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-line-chart.json#L1). Theme support was added through the repo’s typed theme system in [types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts#L192), [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts#L1488), and [vars.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/vars.ts#L738), and the component is exported from [src/components/index.ts](/Users/jordanb/.codex/automations/react-luna/src/components/index.ts#L21). A release changeset was added in [four-houses-train.md](/Users/jordanb/.codex/automations/react-luna/.changeset/four-houses-train.md#L1).

Verification ran as follows:
- `npm run test -- src/components/luna-line-chart/LunaLineChart.test.tsx` passed
- `npm run build` passed
- `npm run storybook:build` passed
- `STORYBOOK_COMPONENT=luna-line-chart npm run screenshots:storybook:list` ran and resolved 7 captures for the `luna-line-chart` manifest
- `STORYBOOK_COMPONENT=luna-line-chart npm run screenshots:storybook` failed in this sandbox because Playwright could not bind `127.0.0.1:6106` (`EPERM`)

I could not create the required git commit because the sandbox would not allow `.git/index.lock` creation, so the work is left uncommitted in the branch.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`