### PR TITLE
Resolve #144: Add LunaPieChart baseline chart surface

### DIFF
--- a/.changeset/luna-pie-chart-baseline.md
+++ b/.changeset/luna-pie-chart-baseline.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add `LunaPieChart` as a baseline categorical proportion chart with theme-aware styling, legend-first rendering, defined loading and empty states, Storybook coverage, documentation, and tests.

--- a/docs/v1/components/LunaPieChart.md
+++ b/docs/v1/components/LunaPieChart.md
@@ -1,0 +1,118 @@
+# LunaPieChart
+
+`LunaPieChart` is a first-pass categorical proportion chart for `react-luna`.
+
+It is responsible for:
+- showing how ordered categories contribute to a whole
+- keeping the readable breakdown in a required legend
+- exposing a narrow, themeable chart surface that fits dashboard and panel layouts
+- defining loading, empty, and error states
+
+It is not responsible for:
+- donut presentation
+- multi-series charting
+- generic chart-builder configuration
+- advanced label placement systems
+
+## Contract
+
+`LunaPieChart` intentionally stays narrow.
+
+Core rules:
+- `data` is ordered categorical input for one series only
+- `ariaLabel` is required so the chart always has an accessible name
+- the visible breakdown is legend-first by design
+- empty state is inferred when there are no positive values to plot
+- `loading` and `error` switch the surface into defined non-data states
+
+Intentional choice:
+- this first pass keeps labels in the legend instead of on the slices so the chart remains readable at panel size and narrow widths
+
+## Props
+
+- `ariaLabel: string`
+- `data: Array<{ id?: string; label: string; value: number; color?: string }>`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `loading?: boolean`
+- `error?: React.ReactNode`
+- `empty?: React.ReactNode`
+- `showLegend?: boolean`
+- `size?: string`
+
+### Data
+
+Rules:
+- `data` order is preserved in both the slices and the legend
+- non-positive and non-finite values are treated as zero
+- the chart uses positive values only when calculating the whole
+- zero-value categories still stay visible in the legend so the ordered key remains stable
+
+### Accessibility
+
+Rules:
+- `ariaLabel` names the chart graphic directly
+- visible `description` is linked into the chart accessibility description when present
+- the component also emits a hidden textual summary of the total and category breakdown
+
+This keeps the chart understandable even when the visual pie alone would not be enough.
+
+### Legend
+
+Rules:
+- the default presentation is legend-forward
+- `showLegend` defaults to `true`
+- when `showLegend` is set to `false`, the legend remains in the DOM but becomes visually hidden
+
+The baseline recommendation is still to leave the visible legend on.
+
+### Size
+
+- `size?: string`
+
+Built-in size keys:
+- `small`
+- `medium`
+- `large`
+
+Theme size profiles control:
+- chart diameter
+- content gap
+- legend gap
+- legend swatch size
+- minimum surface height
+
+## States
+
+`LunaPieChart` defines these states:
+- ready
+- loading
+- empty
+- error
+
+Priority:
+1. `loading`
+2. `error`
+3. empty inferred from data
+4. ready
+
+## Theme Expectations
+
+`LunaPieChart` depends on the theme for:
+- default size key
+- size profiles
+- slice palette
+- surface background, border, and shadow
+- chart track and slice separators
+- title, description, legend, and state text colors
+
+Downstream themes should be able to reshape the chart’s palette and chrome without changing the component contract.
+
+## Testing Focus
+
+The chart contract should stay covered in unit tests for:
+- normal data rendering
+- empty state behavior
+- legend presence
+- accessibility naming and description wiring
+- theme-driven sizing and surface token resolution

--- a/playwright/storybook/manifests/luna-pie-chart.json
+++ b/playwright/storybook/manifests/luna-pie-chart.json
@@ -1,0 +1,52 @@
+[
+  {
+    "storyId": "components-lunapiechart--basic",
+    "fileName": "luna-pie-chart-basic",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--many-categories",
+    "fileName": "luna-pie-chart-many-categories",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--legend-forward",
+    "fileName": "luna-pie-chart-legend-forward",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--narrow-width",
+    "fileName": "luna-pie-chart-narrow-width",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--empty-state",
+    "fileName": "luna-pie-chart-empty-state",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--loading-state",
+    "fileName": "luna-pie-chart-loading-state",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunapiechart--dashboard-panel",
+    "fileName": "luna-pie-chart-dashboard-panel",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -46,3 +46,4 @@ export * from "./luna-app";
 export * from "./luna-app-shell-wireframe";
 export * from "./luna-pane";
 export * from "./luna-panel";
+export * from "./luna-pie-chart";

--- a/src/components/luna-pie-chart/LunaPieChart.css
+++ b/src/components/luna-pie-chart/LunaPieChart.css
@@ -1,0 +1,199 @@
+.luna-pie-chart {
+  --luna-pie-chart-current-radius: var(--luna-radius-lg);
+  --luna-pie-chart-current-chart-size: 12rem;
+  --luna-pie-chart-current-gap: var(--luna-space-5, 1.25rem);
+  --luna-pie-chart-current-legend-gap: var(--luna-space-3, 0.75rem);
+  --luna-pie-chart-current-legend-swatch-size: 0.75rem;
+  --luna-pie-chart-current-min-height: 16rem;
+  position: relative;
+  display: grid;
+  gap: var(--luna-space-4, 1rem);
+  min-height: var(--luna-pie-chart-current-min-height);
+  padding: var(--luna-space-5, 1.25rem);
+  border: 1px solid var(--luna-pie-chart-current-border, var(--luna-border));
+  border-radius: var(--luna-pie-chart-current-radius);
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.18), transparent 58%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 45%),
+    var(--luna-pie-chart-current-bg, var(--luna-surface));
+  box-shadow: var(--luna-pie-chart-current-shadow, none);
+}
+
+.luna-pie-chart__header {
+  display: grid;
+  gap: var(--luna-space-2, 0.5rem);
+}
+
+.luna-pie-chart__title {
+  color: var(--luna-pie-chart-title-fg, var(--luna-foreground));
+}
+
+.luna-pie-chart__description {
+  color: var(--luna-pie-chart-description-fg, var(--luna-muted));
+}
+
+.luna-pie-chart__content {
+  display: grid;
+  grid-template-columns: minmax(0, var(--luna-pie-chart-current-chart-size)) minmax(0, 1fr);
+  gap: var(--luna-pie-chart-current-gap);
+  align-items: center;
+}
+
+.luna-pie-chart__visual-shell {
+  display: grid;
+  place-items: center;
+  min-height: var(--luna-pie-chart-current-chart-size);
+}
+
+.luna-pie-chart__svg {
+  width: var(--luna-pie-chart-current-chart-size);
+  height: var(--luna-pie-chart-current-chart-size);
+  overflow: visible;
+  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.14));
+}
+
+.luna-pie-chart__track {
+  fill: var(--luna-pie-chart-current-chart-bg, color-mix(in srgb, var(--luna-surface) 80%, transparent));
+}
+
+.luna-pie-chart__slice {
+  stroke: var(--luna-pie-chart-current-separator, var(--luna-surface));
+  stroke-width: 3;
+  stroke-linejoin: round;
+}
+
+.luna-pie-chart__legend {
+  display: grid;
+  gap: var(--luna-pie-chart-current-legend-gap);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.luna-pie-chart__legend--hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.luna-pie-chart__legend-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--luna-space-3, 0.75rem);
+  align-items: start;
+}
+
+.luna-pie-chart__legend-swatch {
+  width: var(--luna-pie-chart-current-legend-swatch-size);
+  height: var(--luna-pie-chart-current-legend-swatch-size);
+  margin-top: 0.375rem;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--luna-pie-chart-current-bg, var(--luna-surface)) 82%, transparent);
+}
+
+.luna-pie-chart__legend-copy {
+  display: grid;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.luna-pie-chart__legend-label {
+  color: var(--luna-pie-chart-legend-fg, var(--luna-foreground));
+}
+
+.luna-pie-chart__legend-value {
+  color: var(--luna-pie-chart-legend-value-fg, var(--luna-muted));
+}
+
+.luna-pie-chart__placeholder,
+.luna-pie-chart__state {
+  display: grid;
+  gap: var(--luna-space-3, 0.75rem);
+  justify-items: center;
+  text-align: center;
+  width: min(100%, var(--luna-pie-chart-current-chart-size));
+}
+
+.luna-pie-chart__loading-chart {
+  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.08));
+}
+
+.luna-pie-chart__loading-copy {
+  display: grid;
+  gap: var(--luna-space-2, 0.5rem);
+  justify-items: center;
+}
+
+.luna-pie-chart__state {
+  color: var(--luna-pie-chart-empty-fg, var(--luna-muted));
+}
+
+.luna-pie-chart__state-title {
+  color: currentColor;
+}
+
+.luna-pie-chart__state-copy {
+  color: currentColor;
+}
+
+.luna-pie-chart__state-slot {
+  width: 100%;
+}
+
+.luna-pie-chart__empty-orbit {
+  width: calc(var(--luna-pie-chart-current-chart-size) * 0.72);
+  aspect-ratio: 1;
+  border: 2px dashed color-mix(in srgb, var(--luna-pie-chart-empty-fg, var(--luna-muted)) 52%, transparent);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 30% 30%, color-mix(in srgb, var(--luna-pie-chart-empty-fg, var(--luna-muted)) 18%, transparent), transparent 28%),
+    radial-gradient(circle at 70% 65%, color-mix(in srgb, var(--luna-pie-chart-empty-fg, var(--luna-muted)) 10%, transparent), transparent 22%);
+}
+
+.luna-pie-chart__error-badge {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--luna-pie-chart-error-fg, #b91c1c) 14%, transparent);
+  color: var(--luna-pie-chart-error-fg, #b91c1c);
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.luna-pie-chart[data-state="loading"] .luna-pie-chart__state {
+  color: var(--luna-pie-chart-loading-fg, var(--luna-muted));
+}
+
+.luna-pie-chart[data-state="error"] .luna-pie-chart__state {
+  color: var(--luna-pie-chart-error-fg, #b91c1c);
+}
+
+.luna-pie-chart__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 42rem) {
+  .luna-pie-chart__content {
+    grid-template-columns: 1fr;
+  }
+
+  .luna-pie-chart__legend-item {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+}

--- a/src/components/luna-pie-chart/LunaPieChart.props.ts
+++ b/src/components/luna-pie-chart/LunaPieChart.props.ts
@@ -1,0 +1,20 @@
+import type React from "react";
+
+export type LunaPieChartDatum = {
+  id?: string;
+  label: string;
+  value: number;
+  color?: string;
+};
+
+export type LunaPieChartProps = Omit<React.HTMLAttributes<HTMLDivElement>, "children" | "title"> & {
+  ariaLabel: string;
+  data: LunaPieChartDatum[];
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  empty?: React.ReactNode;
+  error?: React.ReactNode;
+  loading?: boolean;
+  showLegend?: boolean;
+  size?: string;
+};

--- a/src/components/luna-pie-chart/LunaPieChart.stories.tsx
+++ b/src/components/luna-pie-chart/LunaPieChart.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaPanel } from "../luna-panel";
+import { LunaPieChart } from "./LunaPieChart";
+
+const baseData = [
+  { label: "Returning", value: 48 },
+  { label: "New", value: 32 },
+  { label: "Partner", value: 20 }
+];
+
+const meta = {
+  title: "Components/LunaPieChart",
+  component: LunaPieChart,
+  args: {
+    ariaLabel: "Session share by visitor type",
+    title: "Session mix",
+    description: "Visitor type contribution across the current reporting window.",
+    data: baseData
+  }
+} satisfies Meta<typeof LunaPieChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const ManyCategories: Story = {
+  args: {
+    ariaLabel: "Revenue share by plan",
+    title: "Revenue share",
+    description: "Eight plan groups ordered by contribution to current monthly revenue.",
+    data: [
+      { label: "Enterprise", value: 36 },
+      { label: "Growth", value: 22 },
+      { label: "Starter", value: 14 },
+      { label: "Legacy", value: 9 },
+      { label: "Education", value: 7 },
+      { label: "Sandbox", value: 5 },
+      { label: "Internal", value: 4 },
+      { label: "Trial", value: 3 }
+    ]
+  }
+};
+
+export const LegendForward: Story = {
+  args: {
+    ariaLabel: "Ticket share by queue",
+    title: "Support queue load",
+    description: "The legend carries the readable breakdown while the chart stays clean at panel size.",
+    data: [
+      { label: "Billing", value: 51, color: "warning.500" },
+      { label: "Operations", value: 27, color: "primary.500" },
+      { label: "Product", value: 14, color: "accent.500" },
+      { label: "Security", value: 8, color: "danger.500" }
+    ]
+  }
+};
+
+export const NarrowWidth: Story = {
+  render: (args) => (
+    <div style={{ width: "16rem" }}>
+      <LunaPieChart {...args} />
+    </div>
+  )
+};
+
+export const EmptyState: Story = {
+  args: {
+    ariaLabel: "No channel share data",
+    title: "Channel mix",
+    description: "No tracked visits landed in this period.",
+    data: [],
+    empty: "Connect a source or widen the date range to populate the chart."
+  }
+};
+
+export const LoadingState: Story = {
+  args: {
+    ariaLabel: "Loading pipeline stage share",
+    title: "Pipeline stage mix",
+    description: "Waiting for the latest stage totals to arrive.",
+    data: baseData,
+    loading: true
+  }
+};
+
+export const DashboardPanel: Story = {
+  render: (args) => (
+    <LunaPanel
+      description="A compact panel composition with the chart embedded inside surrounding chrome."
+      title="Traffic overview"
+      width="min(32rem, 100%)"
+    >
+      <LunaPieChart {...args} title={undefined} description={undefined} />
+    </LunaPanel>
+  )
+};

--- a/src/components/luna-pie-chart/LunaPieChart.test.tsx
+++ b/src/components/luna-pie-chart/LunaPieChart.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaPieChart } from "./LunaPieChart";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaPieChart", () => {
+  const data = [
+    { label: "Returning", value: 60 },
+    { label: "New", value: 30 },
+    { label: "Partner", value: 10 }
+  ];
+
+  it("renders a chart image and legend entries for normal data", () => {
+    renderWithTheme(
+      <LunaPieChart
+        ariaLabel="Traffic share by source"
+        data={data}
+        title="Traffic share"
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Traffic share by source" })).toBeInTheDocument();
+    expect(screen.getByText("Returning")).toBeInTheDocument();
+    expect(screen.getByText("60% • 60")).toBeInTheDocument();
+    expect(screen.getByText("Partner")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no positive data is available", () => {
+    renderWithTheme(
+      <LunaPieChart
+        ariaLabel="No data"
+        data={[
+          { label: "Returning", value: 0 },
+          { label: "New", value: -4 }
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Nothing to plot yet");
+    expect(screen.queryByRole("img", { name: "No data" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the legend in the DOM even when it is visually hidden", () => {
+    renderWithTheme(<LunaPieChart ariaLabel="Quiet chart" data={data} showLegend={false} />);
+
+    const legendLabel = screen.getByText("Returning");
+    expect(legendLabel.closest(".luna-pie-chart__legend")).toHaveClass(
+      "luna-pie-chart__legend--hidden"
+    );
+  });
+
+  it("exposes the accessibility naming contract through the chart image", () => {
+    renderWithTheme(
+      <LunaPieChart
+        ariaLabel="Plan mix for current month"
+        data={data}
+        description="Share by active plan tier."
+      />
+    );
+
+    const chart = screen.getByRole("img", { name: "Plan mix for current month" });
+    expect(chart).toHaveAttribute("aria-describedby");
+    expect(screen.getByText("Share by active plan tier.")).toHaveAttribute("id");
+  });
+
+  it("resolves theme-driven sizing and color tokens", () => {
+    renderWithTheme(<LunaPieChart ariaLabel="Branded mix" data={data} data-testid="chart" size="roomy" />, {
+      theme: {
+        components: {
+          pieChart: {
+            radius: "md",
+            palette: ["accent.500"],
+            sizes: {
+              roomy: {
+                chartSize: "16",
+                gap: "6",
+                legendGap: "4",
+                legendSwatchSize: "5",
+                minHeight: "16"
+              }
+            },
+            modes: {
+              light: {
+                bg: "neutral.100",
+                border: "neutral.300",
+                separator: "neutral.100"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(screen.getByTestId("chart")).toHaveStyle({
+      "--luna-pie-chart-current-chart-size": "4rem",
+      "--luna-pie-chart-current-gap": "1.5rem",
+      "--luna-pie-chart-current-legend-gap": "1rem",
+      "--luna-pie-chart-current-legend-swatch-size": "1.25rem",
+      "--luna-pie-chart-current-min-height": "4rem",
+      "--luna-pie-chart-current-radius": "0.5rem",
+      "--luna-pie-chart-current-bg": "#f1f5f9"
+    });
+  });
+});

--- a/src/components/luna-pie-chart/LunaPieChart.tsx
+++ b/src/components/luna-pie-chart/LunaPieChart.tsx
@@ -1,0 +1,425 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import { LunaSkeleton } from "../luna-skeleton";
+import { LunaText } from "../luna-text";
+import type { LunaPieChartDatum, LunaPieChartProps } from "./LunaPieChart.props";
+import "./LunaPieChart.css";
+
+type PieChartCssVariable =
+  | "--luna-pie-chart-current-radius"
+  | "--luna-pie-chart-current-chart-size"
+  | "--luna-pie-chart-current-gap"
+  | "--luna-pie-chart-current-legend-gap"
+  | "--luna-pie-chart-current-legend-swatch-size"
+  | "--luna-pie-chart-current-min-height"
+  | "--luna-pie-chart-current-bg"
+  | "--luna-pie-chart-current-border"
+  | "--luna-pie-chart-current-shadow"
+  | "--luna-pie-chart-current-chart-bg"
+  | "--luna-pie-chart-current-separator"
+  | "--luna-pie-chart-title-fg"
+  | "--luna-pie-chart-description-fg"
+  | "--luna-pie-chart-legend-fg"
+  | "--luna-pie-chart-legend-value-fg"
+  | "--luna-pie-chart-empty-fg"
+  | "--luna-pie-chart-loading-fg"
+  | "--luna-pie-chart-error-fg";
+
+type LunaPieChartStyle = React.CSSProperties &
+  Partial<Record<PieChartCssVariable, string | number | undefined>>;
+
+type NormalizedDatum = LunaPieChartDatum & {
+  color: string;
+  percent: number;
+  ratio: number;
+  value: number;
+};
+
+const SVG_SIZE = 200;
+const SVG_CENTER = SVG_SIZE / 2;
+const SVG_RADIUS = 88;
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: Number.isInteger(value) ? 0 : 1
+  }).format(value);
+}
+
+function formatPercent(value: number) {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded.toFixed(0)}%` : `${rounded}%`;
+}
+
+function resolveSpace(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveRadius(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function resolveShadow(value: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.shadows, value) ?? value;
+}
+
+function resolveSizeProfile(size: string | undefined, theme: ReturnType<typeof useTheme>["theme"]) {
+  if (!size) {
+    return undefined;
+  }
+
+  return theme.components.pieChart?.sizes?.[size];
+}
+
+function polarToCartesian(angle: number) {
+  const radians = ((angle - 90) * Math.PI) / 180;
+
+  return {
+    x: SVG_CENTER + SVG_RADIUS * Math.cos(radians),
+    y: SVG_CENTER + SVG_RADIUS * Math.sin(radians)
+  };
+}
+
+function buildSlicePath(startAngle: number, endAngle: number) {
+  const start = polarToCartesian(startAngle);
+  const end = polarToCartesian(endAngle);
+  const largeArcFlag = endAngle - startAngle > 180 ? 1 : 0;
+
+  return [
+    `M ${SVG_CENTER} ${SVG_CENTER}`,
+    `L ${start.x} ${start.y}`,
+    `A ${SVG_RADIUS} ${SVG_RADIUS} 0 ${largeArcFlag} 1 ${end.x} ${end.y}`,
+    "Z"
+  ].join(" ");
+}
+
+function normalizeData(
+  data: LunaPieChartDatum[],
+  palette: string[],
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  const sanitizedValues = data.map((item) => ({
+    ...item,
+    value: Number.isFinite(item.value) && item.value > 0 ? item.value : 0
+  }));
+  const total = sanitizedValues.reduce((sum, item) => sum + item.value, 0);
+
+  const normalized = sanitizedValues.map((item, index) => {
+    const ratio = total > 0 ? item.value / total : 0;
+
+    return {
+      ...item,
+      color: resolveTokenValue(theme, item.color ?? palette[index % palette.length] ?? "primary.500"),
+      percent: ratio * 100,
+      ratio
+    } satisfies NormalizedDatum;
+  });
+
+  return {
+    data: normalized,
+    total,
+    slices: normalized.filter((item) => item.value > 0)
+  };
+}
+
+function createSummary(
+  state: "ready" | "empty" | "loading" | "error",
+  title: React.ReactNode | undefined,
+  total: number,
+  data: NormalizedDatum[]
+) {
+  const titleText = typeof title === "string" ? `${title}. ` : "";
+
+  if (state === "loading") {
+    return `${titleText}Loading chart data.`;
+  }
+
+  if (state === "error") {
+    return `${titleText}Chart data could not be shown because the component is in an error state.`;
+  }
+
+  if (state === "empty") {
+    return `${titleText}No chart data is available.`;
+  }
+
+  return `${titleText}Total ${formatNumber(total)} across ${data.length} categories. ${data
+    .map((item) => `${item.label}: ${formatPercent(item.percent)} (${formatNumber(item.value)})`)
+    .join(". ")}.`;
+}
+
+export const LunaPieChart = React.forwardRef<HTMLDivElement, LunaPieChartProps>(
+  function LunaPieChart(
+    {
+      ariaLabel,
+      className,
+      data,
+      description,
+      empty,
+      error,
+      id,
+      loading = false,
+      showLegend = true,
+      size,
+      style,
+      title,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const baseId = id ?? `luna-pie-chart-${reactId.replace(/:/g, "")}`;
+    const descriptionId = description !== undefined && description !== null ? `${baseId}-description` : undefined;
+    const summaryId = `${baseId}-summary`;
+    const { theme, mode } = useTheme();
+    const resolvedSize = size ?? theme.components.pieChart?.defaultSize ?? "medium";
+    const sizeProfile = resolveSizeProfile(resolvedSize, theme);
+    const modeTokens = theme.components.pieChart?.modes?.[mode];
+    const palette = theme.components.pieChart?.palette ?? [];
+    const normalized = normalizeData(data, palette, theme);
+    const state = loading ? "loading" : error ? "error" : normalized.total <= 0 ? "empty" : "ready";
+    const describedBy = [descriptionId, summaryId].filter(Boolean).join(" ") || undefined;
+
+    const rootStyle: LunaPieChartStyle = {
+      ["--luna-pie-chart-current-radius" as const]: resolveRadius(
+        theme.components.pieChart?.radius,
+        theme
+      ),
+      ["--luna-pie-chart-current-chart-size" as const]:
+        resolveSpace(sizeProfile?.chartSize, theme) ?? sizeProfile?.chartSize,
+      ["--luna-pie-chart-current-gap" as const]: resolveSpace(sizeProfile?.gap, theme),
+      ["--luna-pie-chart-current-legend-gap" as const]: resolveSpace(sizeProfile?.legendGap, theme),
+      ["--luna-pie-chart-current-legend-swatch-size" as const]: resolveSpace(
+        sizeProfile?.legendSwatchSize,
+        theme
+      ),
+      ["--luna-pie-chart-current-min-height" as const]:
+        resolveSpace(sizeProfile?.minHeight, theme) ?? sizeProfile?.minHeight,
+      ["--luna-pie-chart-current-bg" as const]: modeTokens?.bg
+        ? resolveTokenValue(theme, modeTokens.bg)
+        : undefined,
+      ["--luna-pie-chart-current-border" as const]: modeTokens?.border
+        ? resolveTokenValue(theme, modeTokens.border)
+        : undefined,
+      ["--luna-pie-chart-current-shadow" as const]: resolveShadow(modeTokens?.shadow, theme),
+      ["--luna-pie-chart-current-chart-bg" as const]: modeTokens?.chartBg
+        ? resolveTokenValue(theme, modeTokens.chartBg)
+        : undefined,
+      ["--luna-pie-chart-current-separator" as const]: modeTokens?.separator
+        ? resolveTokenValue(theme, modeTokens.separator)
+        : undefined,
+      ["--luna-pie-chart-title-fg" as const]: modeTokens?.titleFg
+        ? resolveTokenValue(theme, modeTokens.titleFg)
+        : undefined,
+      ["--luna-pie-chart-description-fg" as const]: modeTokens?.descriptionFg
+        ? resolveTokenValue(theme, modeTokens.descriptionFg)
+        : undefined,
+      ["--luna-pie-chart-legend-fg" as const]: modeTokens?.legendFg
+        ? resolveTokenValue(theme, modeTokens.legendFg)
+        : undefined,
+      ["--luna-pie-chart-legend-value-fg" as const]: modeTokens?.legendValueFg
+        ? resolveTokenValue(theme, modeTokens.legendValueFg)
+        : undefined,
+      ["--luna-pie-chart-empty-fg" as const]: modeTokens?.emptyFg
+        ? resolveTokenValue(theme, modeTokens.emptyFg)
+        : undefined,
+      ["--luna-pie-chart-loading-fg" as const]: modeTokens?.loadingFg
+        ? resolveTokenValue(theme, modeTokens.loadingFg)
+        : undefined,
+      ["--luna-pie-chart-error-fg" as const]: modeTokens?.errorFg
+        ? resolveTokenValue(theme, modeTokens.errorFg)
+        : undefined,
+      ...style
+    };
+
+    let currentAngle = 0;
+    const summary = createSummary(state, title, normalized.total, normalized.data);
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-pie-chart", className])}
+        data-size={resolvedSize}
+        data-state={state}
+        style={rootStyle}
+      >
+        {title || description ? (
+          <header className="luna-pie-chart__header">
+            {title ? (
+              typeof title === "string" ? (
+                <LunaText as="h2" variant="title" className="luna-pie-chart__title">
+                  {title}
+                </LunaText>
+              ) : (
+                <div className="luna-pie-chart__title">{title}</div>
+              )
+            ) : null}
+            {description ? (
+              typeof description === "string" ? (
+                <LunaText
+                  as="p"
+                  id={descriptionId}
+                  variant="body-small"
+                  className="luna-pie-chart__description"
+                >
+                  {description}
+                </LunaText>
+              ) : (
+                <div className="luna-pie-chart__description" id={descriptionId}>
+                  {description}
+                </div>
+              )
+            ) : null}
+          </header>
+        ) : null}
+        <div className="luna-pie-chart__content">
+          <div className="luna-pie-chart__visual-shell">
+            {state === "ready" ? (
+              <svg
+                aria-describedby={describedBy}
+                aria-label={ariaLabel}
+                className="luna-pie-chart__svg"
+                role="img"
+                viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
+              >
+                <circle
+                  aria-hidden="true"
+                  className="luna-pie-chart__track"
+                  cx={SVG_CENTER}
+                  cy={SVG_CENTER}
+                  r={SVG_RADIUS}
+                />
+                {normalized.slices.length === 1 ? (
+                  <circle
+                    aria-hidden="true"
+                    className="luna-pie-chart__slice"
+                    cx={SVG_CENTER}
+                    cy={SVG_CENTER}
+                    fill={normalized.slices[0]?.color}
+                    r={SVG_RADIUS}
+                  />
+                ) : (
+                  normalized.slices.map((item) => {
+                    const startAngle = currentAngle;
+                    const endAngle = startAngle + item.ratio * 360;
+                    currentAngle = endAngle;
+
+                    return (
+                      <path
+                        aria-hidden="true"
+                        className="luna-pie-chart__slice"
+                        d={buildSlicePath(startAngle, endAngle)}
+                        fill={item.color}
+                        key={item.id ?? `${item.label}-${startAngle}`}
+                      />
+                    );
+                  })
+                )}
+              </svg>
+            ) : null}
+            {state === "loading" ? (
+              <div className="luna-pie-chart__placeholder" aria-hidden="true">
+                <LunaSkeleton
+                  className="luna-pie-chart__loading-chart"
+                  height="var(--luna-pie-chart-current-chart-size)"
+                  shape="circle"
+                  width="var(--luna-pie-chart-current-chart-size)"
+                />
+                <div className="luna-pie-chart__loading-copy">
+                  <LunaSkeleton height="1rem" width="8rem" />
+                  <LunaSkeleton height="0.875rem" width="10rem" />
+                </div>
+              </div>
+            ) : null}
+            {state === "empty" ? (
+              <div className="luna-pie-chart__state" role="status">
+                <div aria-hidden="true" className="luna-pie-chart__empty-orbit" />
+                <LunaText variant="label" className="luna-pie-chart__state-title">
+                  Nothing to plot yet
+                </LunaText>
+                <LunaText variant="body-small" className="luna-pie-chart__state-copy">
+                  {typeof empty === "string"
+                    ? empty
+                    : "Add at least one positive category value to render the chart."}
+                </LunaText>
+                {empty && typeof empty !== "string" ? (
+                  <div className="luna-pie-chart__state-slot">{empty}</div>
+                ) : null}
+              </div>
+            ) : null}
+            {state === "error" ? (
+              <div className="luna-pie-chart__state" role="alert">
+                <div aria-hidden="true" className="luna-pie-chart__error-badge">
+                  !
+                </div>
+                <LunaText variant="label" className="luna-pie-chart__state-title">
+                  Chart unavailable
+                </LunaText>
+                {typeof error === "string" ? (
+                  <LunaText variant="body-small" className="luna-pie-chart__state-copy">
+                    {error}
+                  </LunaText>
+                ) : (
+                  <div className="luna-pie-chart__state-slot">{error}</div>
+                )}
+              </div>
+            ) : null}
+          </div>
+          {state === "ready" ? (
+            <ul
+              className={toClassName([
+                "luna-pie-chart__legend",
+                !showLegend && "luna-pie-chart__legend--hidden"
+              ])}
+            >
+              {normalized.data.map((item, index) => (
+                <li
+                  className="luna-pie-chart__legend-item"
+                  data-index={String(index)}
+                  key={item.id ?? `${item.label}-${index}`}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="luna-pie-chart__legend-swatch"
+                    style={{ backgroundColor: item.color }}
+                  />
+                  <span className="luna-pie-chart__legend-copy">
+                    <LunaText as="span" variant="label" className="luna-pie-chart__legend-label">
+                      {item.label}
+                    </LunaText>
+                    <LunaText
+                      as="span"
+                      variant="caption"
+                      className="luna-pie-chart__legend-value"
+                    >
+                      {formatPercent(item.percent)} • {formatNumber(item.value)}
+                    </LunaText>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <span className="luna-pie-chart__sr-only" id={summaryId}>
+          {summary}
+        </span>
+      </div>
+    );
+  }
+);

--- a/src/components/luna-pie-chart/index.ts
+++ b/src/components/luna-pie-chart/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaPieChart";
+export * from "./LunaPieChart.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1547,6 +1547,73 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    pieChart: {
+      defaultSize: "medium",
+      radius: "lg",
+      palette: [
+        "primary.500",
+        "accent.500",
+        "success.500",
+        "warning.500",
+        "danger.500",
+        "neutral.500",
+        "primary.300",
+        "accent.300"
+      ],
+      sizes: {
+        small: {
+          chartSize: "10rem",
+          gap: "4",
+          legendGap: "2",
+          legendSwatchSize: "3",
+          minHeight: "14rem"
+        },
+        medium: {
+          chartSize: "12rem",
+          gap: "5",
+          legendGap: "3",
+          legendSwatchSize: "3",
+          minHeight: "16rem"
+        },
+        large: {
+          chartSize: "14rem",
+          gap: "6",
+          legendGap: "3",
+          legendSwatchSize: "4",
+          minHeight: "18rem"
+        }
+      },
+      modes: {
+        light: {
+          bg: "neutral.50",
+          border: "neutral.200",
+          shadow: "sm",
+          chartBg: "neutral.100",
+          separator: "neutral.50",
+          titleFg: "neutral.900",
+          descriptionFg: "neutral.600",
+          legendFg: "neutral.900",
+          legendValueFg: "neutral.600",
+          emptyFg: "neutral.500",
+          loadingFg: "neutral.600",
+          errorFg: "danger.700"
+        },
+        dark: {
+          bg: "neutral.800",
+          border: "neutral.700",
+          shadow: "md",
+          chartBg: "neutral.900",
+          separator: "neutral.800",
+          titleFg: "neutral.50",
+          descriptionFg: "neutral.300",
+          legendFg: "neutral.50",
+          legendValueFg: "neutral.300",
+          emptyFg: "neutral.400",
+          loadingFg: "neutral.300",
+          errorFg: "danger.300"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -208,6 +208,29 @@ export type ThemeProgressToneTokens = {
   glow?: string;
 };
 
+export type ThemePieChartSizeProfile = {
+  chartSize?: string;
+  gap?: string;
+  legendGap?: string;
+  legendSwatchSize?: string;
+  minHeight?: string;
+};
+
+export type ThemePieChartModeTokens = {
+  bg?: string;
+  border?: string;
+  shadow?: string;
+  chartBg?: string;
+  separator?: string;
+  titleFg?: string;
+  descriptionFg?: string;
+  legendFg?: string;
+  legendValueFg?: string;
+  emptyFg?: string;
+  loadingFg?: string;
+  errorFg?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -530,6 +553,13 @@ export type ThemeComponents = {
     sizes?: Record<string, ThemeProgressSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeProgressModeTokens>>;
     tones?: Record<string, ThemeProgressToneTokens>;
+  };
+  pieChart?: {
+    defaultSize?: string;
+    radius?: string;
+    palette?: string[];
+    sizes?: Record<string, ThemePieChartSizeProfile>;
+    modes?: Partial<Record<ThemeMode, ThemePieChartModeTokens>>;
   };
   input?: {
     defaultSize?: string;


### PR DESCRIPTION
Closes #144

storybook-component: luna-pie-chart

## Summary
Implemented `LunaPieChart` as an issue-scoped baseline chart surface with a narrow contract, theme-driven sizing and palette support, required accessibility naming, legend-first rendering, and defined loading, empty, and error states in [LunaPieChart.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-pie-chart/LunaPieChart.tsx#L1). Storybook coverage for the required scenarios is in [LunaPieChart.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-pie-chart/LunaPieChart.stories.tsx#L1), tests are in [LunaPieChart.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-pie-chart/LunaPieChart.test.tsx#L1), the public component doc is in [LunaPieChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaPieChart.md#L1), and the theme contract/defaults were extended in [types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts#L211) and [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts#L1550). I also added the export, changeset, and Storybook screenshot manifest for the `luna-pie-chart` slug.

Verification:
- `npm test -- src/components/luna-pie-chart/LunaPieChart.test.tsx` ✅
- `npm run build` ✅
- `npm run storybook:build` ✅
- `STORYBOOK_COMPONENT=luna-pie-chart npm run screenshots:storybook:list` ✅
- `STORYBOOK_COMPONENT=luna-pie-chart npm run screenshots:storybook` ❌ blocked by sandbox: `listen EPERM 127.0.0.1:6106`

I could not create the requested workflow commit because this sandbox cannot write `.git/index.lock`, so the branch remains uncommitted in the working tree.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`