### PR TITLE
Resolve #145: Add LunaBarChart baseline chart surface

### DIFF
--- a/.changeset/luna-bar-chart-baseline.md
+++ b/.changeset/luna-bar-chart-baseline.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the new `LunaBarChart` baseline chart surface with theme support, Storybook coverage, docs, tests, and visual review metadata.

--- a/docs/v1/components/LunaBarChart.md
+++ b/docs/v1/components/LunaBarChart.md
@@ -1,0 +1,86 @@
+# LunaBarChart
+
+`LunaBarChart` is the baseline categorical comparison chart for `react-luna`.
+
+It is responsible for:
+- single-series categorical comparison
+- finished chart presentation for panels and dashboards
+- accessible naming and descriptive support
+- theme-driven bar, axis, legend, and surface styling
+- defined empty, loading, and error states
+
+It is not responsible for:
+- stacked or grouped data
+- multi-series comparison
+- free-form chart configuration
+- interaction-heavy chart behavior
+
+## Contract
+
+`LunaBarChart` keeps a narrow first-pass contract on purpose.
+
+Core rules:
+- orientation is vertical only
+- `data` stays ordered and single-series
+- legend is optional and represents the one visible series
+- the chart keeps a framed surface even in empty, loading, and error states
+- labels wrap to preserve readability and expose the full value through native title text
+
+## Props
+
+- `data: Array<{ label: string; value: number }>`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `ariaLabel: string`
+- `showLegend?: boolean`
+- `loading?: boolean`
+- `error?: React.ReactNode`
+- `emptyState?: React.ReactNode`
+
+Rules:
+- `ariaLabel` is required for the chart graphic
+- negative and non-finite values are normalized to zero for this baseline surface
+- `error` wins over `loading`
+- `loading` wins over empty-data rendering
+- `showLegend` is off by default because this is a single-series chart
+
+Legend strategy:
+- when `showLegend` is enabled, the chart shows one legend item
+- the legend label uses the string `title` when available
+- otherwise the legend falls back to `Values`
+
+Axis behavior:
+- the numeric axis starts at zero
+- the top tick rounds to a readable maximum
+- the chart uses five horizontal tick lines to keep the baseline consistent across datasets
+
+## Theme Expectations
+
+`LunaBarChart` depends on `theme.components.barChart` for:
+- surface background and border
+- axis label and grid color
+- legend text color
+- value label color
+- state text color
+- bar palette
+- chart padding, height, and density
+
+The base theme ships a rotating palette and a panel-ready surface. Downstream themes can replace both without changing the component API.
+
+## State Model
+
+Defined states:
+- ready: bars and axis render
+- empty: a message explains that no categorical values are available
+- loading: skeleton columns preserve the chart footprint
+- error: the chart surface shows failure copy without collapsing layout
+
+## Testing Focus
+
+The bar chart should remain covered for:
+- normal bar rendering
+- empty, loading, and error behavior
+- legend fallback behavior
+- long-label handling
+- accessibility naming and descriptive wiring
+- theme token resolution

--- a/docs/v1/design/LunaBarChart.md
+++ b/docs/v1/design/LunaBarChart.md
@@ -1,0 +1,18 @@
+# LunaBarChart
+
+`LunaBarChart` is intended to feel like a finished chart surface, not a starter chart primitive waiting for application code to rescue it.
+
+The design direction is:
+- vertical bars only
+- quiet axis chrome
+- strong value readability
+- stable framed surface for panels and dashboards
+- enough density control through theme tokens instead of prop sprawl
+
+The component should stay visually disciplined:
+- bars carry most of the emphasis
+- grid lines stay supportive and low contrast
+- labels are allowed to wrap before the chart turns into a cramped abbreviation puzzle
+- horizontal overflow is preferred over unreadable compression in narrow containers
+
+This baseline is meant to prove the contract quality for future chart work. If chart needs start pushing toward engines, builders, or multi-series configuration, that should be a separate issue rather than growth inside this component.

--- a/playwright/storybook/manifests/luna-bar-chart.json
+++ b/playwright/storybook/manifests/luna-bar-chart.json
@@ -1,0 +1,52 @@
+[
+  {
+    "storyId": "components-lunabarchart--basic",
+    "fileName": "luna-bar-chart-basic",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--small-dataset",
+    "fileName": "luna-bar-chart-small-dataset",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--longer-labels",
+    "fileName": "luna-bar-chart-longer-labels",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--narrow-width",
+    "fileName": "luna-bar-chart-narrow-width",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--empty",
+    "fileName": "luna-bar-chart-empty",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--loading",
+    "fileName": "luna-bar-chart-loading",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunabarchart--panel-embedding",
+    "fileName": "luna-bar-chart-panel-embedding",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./luna-avatar";
 export * from "./luna-alert";
 export * from "./luna-accordion";
 export * from "./luna-badge";
+export * from "./luna-bar-chart";
 export * from "./luna-button";
 export * from "./luna-breadcrumb";
 export * from "./luna-card";

--- a/src/components/luna-bar-chart/LunaBarChart.css
+++ b/src/components/luna-bar-chart/LunaBarChart.css
@@ -1,0 +1,245 @@
+.luna-bar-chart {
+  --luna-bar-chart-radius: 0.75rem;
+  --luna-bar-chart-padding: 1.25rem;
+  --luna-bar-chart-header-gap: 1rem;
+  --luna-bar-chart-legend-gap: 0.5rem;
+  --luna-bar-chart-height: 14rem;
+  --luna-bar-chart-bar-gap: 0.75rem;
+  --luna-bar-chart-bar-min-width: 5.25rem;
+  --luna-bar-chart-bg: var(--luna-surface);
+  --luna-bar-chart-border: var(--luna-border);
+  --luna-bar-chart-axis-text: var(--luna-muted);
+  --luna-bar-chart-axis-grid: var(--luna-border);
+  --luna-bar-chart-legend-text: var(--luna-foreground);
+  --luna-bar-chart-value-text: var(--luna-foreground);
+  --luna-bar-chart-state-text: var(--luna-muted);
+  display: grid;
+  gap: 1rem;
+  padding: var(--luna-bar-chart-padding);
+  border: 1px solid var(--luna-bar-chart-border);
+  border-radius: var(--luna-bar-chart-radius);
+  background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--luna-bar-chart-bg) 94%, white),
+      var(--luna-bar-chart-bg)
+    );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.luna-bar-chart__header {
+  display: grid;
+  gap: calc(var(--luna-bar-chart-header-gap) * 0.25);
+}
+
+.luna-bar-chart__title {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--luna-foreground);
+}
+
+.luna-bar-chart__description {
+  max-width: 60ch;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--luna-muted);
+}
+
+.luna-bar-chart__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--luna-bar-chart-legend-gap);
+  color: var(--luna-bar-chart-legend-text);
+}
+
+.luna-bar-chart__legend-swatch {
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--luna-color-primary-400), var(--luna-color-primary-600));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--luna-color-primary-600) 38%, transparent);
+}
+
+.luna-bar-chart__legend-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.luna-bar-chart__visual {
+  min-width: 0;
+}
+
+.luna-bar-chart__plot {
+  display: grid;
+  grid-template-columns: minmax(2.75rem, auto) minmax(0, 1fr);
+  gap: 0.875rem;
+  align-items: start;
+}
+
+.luna-bar-chart__axis,
+.luna-bar-chart__grid {
+  display: grid;
+  grid-template-rows: repeat(5, 1fr);
+  height: var(--luna-bar-chart-height);
+}
+
+.luna-bar-chart__axis {
+  color: var(--luna-bar-chart-axis-text);
+}
+
+.luna-bar-chart__axis-row {
+  position: relative;
+}
+
+.luna-bar-chart__axis-label {
+  position: absolute;
+  top: -0.65em;
+  right: 0;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.luna-bar-chart__plot-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.25rem;
+}
+
+.luna-bar-chart__plot-surface {
+  position: relative;
+  min-width: 100%;
+}
+
+.luna-bar-chart__grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.luna-bar-chart__grid-line {
+  border-top: 1px solid var(--luna-bar-chart-axis-grid);
+}
+
+.luna-bar-chart__grid-line:last-child {
+  border-bottom: 1px solid var(--luna-bar-chart-axis-grid);
+}
+
+.luna-bar-chart__bars {
+  position: relative;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(var(--luna-bar-chart-bar-min-width), 1fr);
+  gap: var(--luna-bar-chart-bar-gap);
+  align-items: end;
+  min-height: var(--luna-bar-chart-height);
+}
+
+.luna-bar-chart__column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 0.625rem;
+  min-height: var(--luna-bar-chart-height);
+  padding-top: 0.25rem;
+}
+
+.luna-bar-chart__value {
+  display: inline-flex;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--luna-bar-chart-value-text);
+}
+
+.luna-bar-chart__bar-track {
+  position: relative;
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  min-height: 0;
+}
+
+.luna-bar-chart__bar {
+  --luna-bar-chart-current-bar-color: var(--luna-color-primary-500);
+  --luna-bar-chart-current-bar-percent: 0%;
+  width: min(100%, 3.5rem);
+  height: var(--luna-bar-chart-current-bar-percent);
+  min-height: 0;
+  border-radius: 0.875rem 0.875rem 0.375rem 0.375rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--luna-bar-chart-current-bar-color) 82%, white),
+    var(--luna-bar-chart-current-bar-color)
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 10px 20px color-mix(in srgb, var(--luna-bar-chart-current-bar-color) 18%, transparent);
+}
+
+.luna-bar-chart__category {
+  display: -webkit-box;
+  min-height: 2.5rem;
+  overflow: hidden;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  text-align: center;
+  color: var(--luna-bar-chart-axis-text);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.luna-bar-chart__loading {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(var(--luna-bar-chart-bar-min-width), 1fr);
+  gap: var(--luna-bar-chart-bar-gap);
+  min-height: var(--luna-bar-chart-height);
+  align-items: end;
+}
+
+.luna-bar-chart__loading-column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 0.625rem;
+  min-height: var(--luna-bar-chart-height);
+}
+
+.luna-bar-chart__loading-value,
+.luna-bar-chart__loading-label {
+  justify-self: center;
+}
+
+.luna-bar-chart__loading-bar {
+  align-self: end;
+  width: min(100%, 3.5rem);
+  justify-self: center;
+}
+
+.luna-bar-chart__state {
+  min-height: var(--luna-bar-chart-height);
+  color: var(--luna-bar-chart-state-text);
+}
+
+.luna-bar-chart__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .luna-bar-chart {
+    gap: 0.875rem;
+    padding: 1rem;
+  }
+
+  .luna-bar-chart__plot {
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+    gap: 0.625rem;
+  }
+}

--- a/src/components/luna-bar-chart/LunaBarChart.props.ts
+++ b/src/components/luna-bar-chart/LunaBarChart.props.ts
@@ -1,0 +1,20 @@
+import type React from "react";
+
+export type LunaBarChartDatum = {
+  label: string;
+  value: number;
+};
+
+export type LunaBarChartProps = Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "children" | "color" | "title"
+> & {
+  data: LunaBarChartDatum[];
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  ariaLabel: string;
+  showLegend?: boolean;
+  loading?: boolean;
+  error?: React.ReactNode;
+  emptyState?: React.ReactNode;
+};

--- a/src/components/luna-bar-chart/LunaBarChart.stories.css
+++ b/src/components/luna-bar-chart/LunaBarChart.stories.css
@@ -1,0 +1,12 @@
+.luna-bar-chart-story-narrow {
+  width: min(100%, 22rem);
+}
+
+.luna-bar-chart-story-panel {
+  width: min(100%, 44rem);
+}
+
+.luna-bar-chart-story-dashboard {
+  display: grid;
+  gap: 1rem;
+}

--- a/src/components/luna-bar-chart/LunaBarChart.stories.tsx
+++ b/src/components/luna-bar-chart/LunaBarChart.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaPanel } from "../luna-panel";
+import { LunaBarChart } from "./LunaBarChart";
+import "./LunaBarChart.stories.css";
+
+const quarterlyRevenue = [
+  { label: "North", value: 42 },
+  { label: "South", value: 31 },
+  { label: "East", value: 54 },
+  { label: "West", value: 26 },
+  { label: "Central", value: 38 }
+];
+
+const meta = {
+  title: "Components/LunaBarChart",
+  component: LunaBarChart,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    ariaLabel: "Quarterly performance by region",
+    title: "Quarterly performance",
+    description: "Single-series comparison for dashboard panels and summary surfaces.",
+    data: quarterlyRevenue
+  }
+} satisfies Meta<typeof LunaBarChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    showLegend: true
+  }
+};
+
+export const SmallDataset: Story = {
+  args: {
+    ariaLabel: "Issue status counts",
+    title: "Issue status",
+    description: "Compact category counts for a short status summary.",
+    data: [
+      { label: "Open", value: 8 },
+      { label: "Resolved", value: 21 },
+      { label: "Deferred", value: 5 }
+    ]
+  }
+};
+
+export const LongerLabels: Story = {
+  args: {
+    ariaLabel: "Operational work categories",
+    title: "Operational categories",
+    description: "Moderately long labels should remain readable without collapsing the chart.",
+    data: [
+      { label: "Release planning and handoff", value: 17 },
+      { label: "Customer account migration", value: 24 },
+      { label: "Quarterly instrumentation refresh", value: 13 },
+      { label: "Support backlog refinement", value: 19 }
+    ]
+  }
+};
+
+export const NarrowWidth: Story = {
+  render: (args) => (
+    <div className="luna-bar-chart-story-narrow">
+      <LunaBarChart {...args} />
+    </div>
+  ),
+  args: {
+    ariaLabel: "Quarterly performance by region in a narrow panel",
+    title: "Narrow panel",
+    description: "The plot scrolls horizontally before labels become unreadable.",
+    data: quarterlyRevenue
+  }
+};
+
+export const Empty: Story = {
+  args: {
+    ariaLabel: "Empty bar chart",
+    title: "Quarterly performance",
+    description: "The empty surface keeps the container stable and explanatory.",
+    data: []
+  }
+};
+
+export const Loading: Story = {
+  args: {
+    ariaLabel: "Loading quarterly performance chart",
+    title: "Quarterly performance",
+    description: "Loading keeps the chart footprint intact while data resolves.",
+    data: quarterlyRevenue,
+    loading: true
+  }
+};
+
+export const ErrorState: Story = {
+  args: {
+    ariaLabel: "Chart unavailable",
+    title: "Quarterly performance",
+    description: "Error state uses the same framed surface and leaves room for recovery messaging.",
+    data: quarterlyRevenue,
+    error: "We could not load the comparison data for this chart."
+  }
+};
+
+export const PanelEmbedding: Story = {
+  render: (args) => (
+    <div className="luna-bar-chart-story-panel">
+      <LunaPanel
+        title="Program dashboard"
+        description="Chart content should feel finished inside a composed panel surface."
+      >
+        <div className="luna-bar-chart-story-dashboard">
+          <LunaBarChart {...args} />
+        </div>
+      </LunaPanel>
+    </div>
+  ),
+  args: {
+    ariaLabel: "Delivery throughput by stream",
+    title: "Delivery throughput",
+    description: "Issue throughput for the current delivery streams.",
+    data: [
+      { label: "Foundation", value: 12 },
+      { label: "Primitives", value: 28 },
+      { label: "Composites", value: 16 },
+      { label: "Docs", value: 9 }
+    ],
+    showLegend: true
+  }
+};

--- a/src/components/luna-bar-chart/LunaBarChart.test.tsx
+++ b/src/components/luna-bar-chart/LunaBarChart.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaBarChart } from "./LunaBarChart";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaBarChart", () => {
+  const sampleData = [
+    { label: "North", value: 18 },
+    { label: "South", value: 24 },
+    { label: "West", value: 12 }
+  ];
+
+  it("renders the chart bars and values for normal data", () => {
+    const { container } = renderWithTheme(
+      <LunaBarChart ariaLabel="Regional counts" data={sampleData} title="Regional counts" />
+    );
+
+    expect(screen.getByRole("img", { name: "Regional counts" })).toBeInTheDocument();
+    expect(container.querySelectorAll(".luna-bar-chart__bar")).toHaveLength(3);
+    expect(screen.getByText("18")).toBeInTheDocument();
+    expect(screen.getByText("24")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no data is provided", () => {
+    const { container } = renderWithTheme(
+      <LunaBarChart ariaLabel="Empty chart" data={[]} title="Regional counts" />
+    );
+    const emptyState = container.querySelector(".luna-empty-state");
+
+    expect(screen.getByText("No chart data")).toBeInTheDocument();
+    expect(emptyState).not.toBeNull();
+    expect(
+      within(emptyState as HTMLElement).getByText(
+        "Add categorical values to render this comparison."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders a loading surface while keeping chart semantics", () => {
+    const { container } = renderWithTheme(
+      <LunaBarChart
+        ariaLabel="Loading regional counts"
+        data={sampleData}
+        loading
+        title="Regional counts"
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Loading regional counts" })).toBeInTheDocument();
+    expect(container.querySelectorAll(".luna-bar-chart__loading-column")).toHaveLength(5);
+  });
+
+  it("renders the error state when a failure message is provided", () => {
+    const { container } = renderWithTheme(
+      <LunaBarChart
+        ariaLabel="Regional counts unavailable"
+        data={sampleData}
+        error="We could not load the regional counts."
+        title="Regional counts"
+      />
+    );
+    const emptyState = container.querySelector(".luna-empty-state");
+
+    expect(screen.getByText("Unable to display chart")).toBeInTheDocument();
+    expect(emptyState).not.toBeNull();
+    expect(
+      within(emptyState as HTMLElement).getByText("We could not load the regional counts.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the legend when requested and falls back to a generic label", () => {
+    renderWithTheme(
+      <LunaBarChart ariaLabel="Regional counts" data={sampleData} showLegend />
+    );
+
+    expect(screen.getByText("Values")).toBeInTheDocument();
+  });
+
+  it("keeps long category labels available through the title attribute", () => {
+    renderWithTheme(
+      <LunaBarChart
+        ariaLabel="Operational work categories"
+        data={[
+          {
+            label: "Quarterly instrumentation refresh",
+            value: 11
+          }
+        ]}
+      />
+    );
+
+    expect(screen.getByTitle("Quarterly instrumentation refresh")).toBeInTheDocument();
+  });
+
+  it("uses the accessibility label and description on the chart graphic", () => {
+    renderWithTheme(
+      <LunaBarChart
+        ariaLabel="Regional counts bar chart"
+        data={sampleData}
+        description="Comparison of current regional issue counts."
+        title="Regional counts"
+      />
+    );
+
+    const chart = screen.getByRole("img", { name: "Regional counts bar chart" });
+    const description = screen.getByText("Comparison of current regional issue counts.");
+
+    expect(chart).toHaveAttribute("aria-describedby", expect.stringContaining(description.id));
+  });
+
+  it("resolves theme-driven bar chart tokens and palette colors", () => {
+    const { container } = renderWithTheme(
+      <LunaBarChart ariaLabel="Regional counts" data={sampleData} />,
+      {
+        theme: {
+          components: {
+            barChart: {
+              radius: "pill",
+              padding: "6",
+              chartHeight: "12rem",
+              palette: ["accent.500"],
+              modes: {
+                light: {
+                  bg: "neutral.50",
+                  border: "neutral.300",
+                  axisText: "neutral.500",
+                  axisGrid: "neutral.200",
+                  legendText: "neutral.700",
+                  valueText: "accent.700",
+                  stateText: "neutral.600"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const root = container.querySelector(".luna-bar-chart");
+    const firstBar = container.querySelector(".luna-bar-chart__bar");
+
+    expect(root).toHaveStyle({
+      "--luna-bar-chart-radius": "999px",
+      "--luna-bar-chart-padding": "1.5rem",
+      "--luna-bar-chart-height": "12rem",
+      "--luna-bar-chart-bg": "#f8fafc",
+      "--luna-bar-chart-border": "#cbd5e1"
+    });
+    expect(firstBar).toHaveStyle({
+      "--luna-bar-chart-current-bar-color": "#8b5cf6"
+    });
+  });
+});

--- a/src/components/luna-bar-chart/LunaBarChart.tsx
+++ b/src/components/luna-bar-chart/LunaBarChart.tsx
@@ -1,0 +1,349 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import { LunaEmptyState } from "../luna-empty-state";
+import { LunaSkeleton } from "../luna-skeleton";
+import type { LunaBarChartDatum, LunaBarChartProps } from "./LunaBarChart.props";
+import "./LunaBarChart.css";
+
+type BarChartCssVariable =
+  | "--luna-bar-chart-radius"
+  | "--luna-bar-chart-padding"
+  | "--luna-bar-chart-header-gap"
+  | "--luna-bar-chart-legend-gap"
+  | "--luna-bar-chart-height"
+  | "--luna-bar-chart-bar-gap"
+  | "--luna-bar-chart-bar-min-width"
+  | "--luna-bar-chart-bg"
+  | "--luna-bar-chart-border"
+  | "--luna-bar-chart-axis-text"
+  | "--luna-bar-chart-axis-grid"
+  | "--luna-bar-chart-legend-text"
+  | "--luna-bar-chart-value-text"
+  | "--luna-bar-chart-state-text";
+
+type LunaBarChartStyle = React.CSSProperties &
+  Partial<Record<BarChartCssVariable, string | number | undefined>>;
+
+type BarStyle = React.CSSProperties & {
+  "--luna-bar-chart-current-bar-color": string;
+  "--luna-bar-chart-current-bar-percent": string;
+};
+
+type NormalizedDatum = LunaBarChartDatum & {
+  safeLabel: string;
+  normalizedValue: number;
+  formattedValue: string;
+  percent: number;
+  color: string;
+};
+
+const DEFAULT_PALETTE = [
+  "primary.500",
+  "accent.500",
+  "success.500",
+  "warning.500",
+  "danger.500"
+];
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveDimensionValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveRadiusValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function normalizeValue(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, value);
+}
+
+function getNiceMaxValue(value: number) {
+  if (value <= 0) {
+    return 1;
+  }
+
+  const exponent = Math.pow(10, Math.floor(Math.log10(value)));
+  const fraction = value / exponent;
+
+  if (fraction <= 1) {
+    return exponent;
+  }
+
+  if (fraction <= 2) {
+    return 2 * exponent;
+  }
+
+  if (fraction <= 5) {
+    return 5 * exponent;
+  }
+
+  return 10 * exponent;
+}
+
+function buildNumberFormatter(maxValue: number) {
+  return new Intl.NumberFormat(undefined, {
+    notation: maxValue >= 1000 ? "compact" : "standard",
+    maximumFractionDigits: maxValue >= 10 ? 0 : 1
+  });
+}
+
+function buildTicks(maxValue: number) {
+  const tickCount = 5;
+  const step = maxValue / (tickCount - 1);
+
+  return Array.from({ length: tickCount }, (_, index) =>
+    Number((maxValue - step * index).toFixed(4))
+  );
+}
+
+function resolveLegendLabel(title: React.ReactNode) {
+  if (typeof title === "string" && title.trim().length > 0) {
+    return title;
+  }
+
+  return "Values";
+}
+
+export const LunaBarChart = React.forwardRef<HTMLElement, LunaBarChartProps>(
+  function LunaBarChart(
+    {
+      ariaLabel,
+      className,
+      data,
+      description,
+      emptyState = "Add categorical values to render this comparison.",
+      error,
+      loading = false,
+      showLegend = false,
+      style,
+      title,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const baseId = `luna-bar-chart-${reactId.replace(/:/g, "")}`;
+    const descriptionId =
+      description !== undefined && description !== null ? `${baseId}-description` : undefined;
+    const summaryId = `${baseId}-summary`;
+    const { theme, mode } = useTheme();
+    const chartTheme = theme.components.barChart;
+    const modeTokens = chartTheme?.modes?.[mode];
+    const resolvedRadius = resolveRadiusValue(chartTheme?.radius, theme);
+    const resolvedPadding = resolveDimensionValue(chartTheme?.padding, theme);
+    const resolvedHeaderGap = resolveDimensionValue(chartTheme?.headerGap, theme);
+    const resolvedLegendGap = resolveDimensionValue(chartTheme?.legendGap, theme);
+    const resolvedHeight = resolveDimensionValue(chartTheme?.chartHeight, theme);
+    const resolvedBarGap = resolveDimensionValue(chartTheme?.barGap, theme);
+    const resolvedBarMinWidth = resolveDimensionValue(chartTheme?.barMinWidth, theme);
+    const paletteTokens = chartTheme?.palette?.length ? chartTheme.palette : DEFAULT_PALETTE;
+    const resolvedPalette = paletteTokens.map((token) => resolveTokenValue(theme, token));
+    const resolvedMaxValue = getNiceMaxValue(
+      data.reduce((max, item) => Math.max(max, normalizeValue(item.value)), 0)
+    );
+    const numberFormatter = buildNumberFormatter(resolvedMaxValue);
+    const ticks = buildTicks(resolvedMaxValue);
+    const normalizedData: NormalizedDatum[] = data.map((item, index) => {
+      const normalizedValue = normalizeValue(item.value);
+      return {
+        ...item,
+        safeLabel: item.label.trim().length > 0 ? item.label : `Item ${index + 1}`,
+        normalizedValue,
+        formattedValue: numberFormatter.format(normalizedValue),
+        percent: (normalizedValue / resolvedMaxValue) * 100,
+        color:
+          resolvedPalette[index % resolvedPalette.length] ?? resolveTokenValue(theme, "primary.500")
+      };
+    });
+
+    const state = error ? "error" : loading ? "loading" : normalizedData.length === 0 ? "empty" : "ready";
+    const chartSummary =
+      state === "loading"
+        ? "Chart loading."
+        : state === "error"
+          ? typeof error === "string"
+            ? error
+            : "Chart data is unavailable."
+          : state === "empty"
+            ? typeof emptyState === "string"
+              ? emptyState
+              : "No chart data is available."
+            : normalizedData.map((item) => `${item.safeLabel}: ${item.formattedValue}`).join("; ");
+    const rootStyle: LunaBarChartStyle = {
+      ["--luna-bar-chart-radius" as const]: resolvedRadius,
+      ["--luna-bar-chart-padding" as const]: resolvedPadding,
+      ["--luna-bar-chart-header-gap" as const]: resolvedHeaderGap,
+      ["--luna-bar-chart-legend-gap" as const]: resolvedLegendGap,
+      ["--luna-bar-chart-height" as const]: resolvedHeight,
+      ["--luna-bar-chart-bar-gap" as const]: resolvedBarGap,
+      ["--luna-bar-chart-bar-min-width" as const]: resolvedBarMinWidth,
+      ["--luna-bar-chart-bg" as const]:
+        modeTokens?.bg ? resolveTokenValue(theme, modeTokens.bg) : undefined,
+      ["--luna-bar-chart-border" as const]:
+        modeTokens?.border ? resolveTokenValue(theme, modeTokens.border) : undefined,
+      ["--luna-bar-chart-axis-text" as const]:
+        modeTokens?.axisText ? resolveTokenValue(theme, modeTokens.axisText) : undefined,
+      ["--luna-bar-chart-axis-grid" as const]:
+        modeTokens?.axisGrid ? resolveTokenValue(theme, modeTokens.axisGrid) : undefined,
+      ["--luna-bar-chart-legend-text" as const]:
+        modeTokens?.legendText ? resolveTokenValue(theme, modeTokens.legendText) : undefined,
+      ["--luna-bar-chart-value-text" as const]:
+        modeTokens?.valueText ? resolveTokenValue(theme, modeTokens.valueText) : undefined,
+      ["--luna-bar-chart-state-text" as const]:
+        modeTokens?.stateText ? resolveTokenValue(theme, modeTokens.stateText) : undefined,
+      ...style
+    };
+
+    return (
+      <section
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-bar-chart", className])}
+        data-state={state}
+        aria-busy={loading ? "true" : undefined}
+        style={rootStyle}
+      >
+        {title || description ? (
+          <div className="luna-bar-chart__header">
+            {title ? <div className="luna-bar-chart__title">{title}</div> : null}
+            {description ? (
+              <div className="luna-bar-chart__description" id={descriptionId}>
+                {description}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {showLegend && state === "ready" ? (
+          <div className="luna-bar-chart__legend" aria-hidden="true">
+            <span className="luna-bar-chart__legend-swatch" />
+            <span className="luna-bar-chart__legend-label">{resolveLegendLabel(title)}</span>
+          </div>
+        ) : null}
+        <div
+          className="luna-bar-chart__visual"
+          role="img"
+          aria-label={ariaLabel}
+          aria-describedby={[descriptionId, summaryId].filter(Boolean).join(" ") || undefined}
+          aria-roledescription="bar chart"
+        >
+          {state === "loading" ? (
+            <div className="luna-bar-chart__loading" aria-hidden="true">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div className="luna-bar-chart__loading-column" key={index}>
+                  <LunaSkeleton
+                    className="luna-bar-chart__loading-value"
+                    inline
+                    shape="text"
+                    width={index % 2 === 0 ? "12" : "10"}
+                  />
+                  <LunaSkeleton
+                    className="luna-bar-chart__loading-bar"
+                    height={`${48 + index * 12}px`}
+                    shape="block"
+                    width="100%"
+                  />
+                  <LunaSkeleton
+                    className="luna-bar-chart__loading-label"
+                    inline
+                    shape="text"
+                    width={index % 2 === 0 ? "14" : "16"}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {state === "error" ? (
+            <LunaEmptyState
+              className="luna-bar-chart__state"
+              framed={false}
+              title="Unable to display chart"
+              description={error}
+            />
+          ) : null}
+          {state === "empty" ? (
+            <LunaEmptyState
+              className="luna-bar-chart__state"
+              framed={false}
+              title="No chart data"
+              description={emptyState}
+            />
+          ) : null}
+          {state === "ready" ? (
+            <div className="luna-bar-chart__plot">
+              <div className="luna-bar-chart__axis" aria-hidden="true">
+                {ticks.map((tick) => (
+                  <div className="luna-bar-chart__axis-row" key={tick}>
+                    <span className="luna-bar-chart__axis-label">
+                      {numberFormatter.format(tick)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="luna-bar-chart__plot-scroll">
+                <div className="luna-bar-chart__plot-surface">
+                  <div className="luna-bar-chart__grid" aria-hidden="true">
+                    {ticks.map((tick) => (
+                      <span className="luna-bar-chart__grid-line" key={tick} />
+                    ))}
+                  </div>
+                  <div className="luna-bar-chart__bars">
+                    {normalizedData.map((item) => {
+                      const barStyle: BarStyle = {
+                        "--luna-bar-chart-current-bar-color": item.color,
+                        "--luna-bar-chart-current-bar-percent": `${item.percent}%`
+                      };
+
+                      return (
+                        <div className="luna-bar-chart__column" key={item.safeLabel}>
+                          <span className="luna-bar-chart__value" title={item.formattedValue}>
+                            {item.formattedValue}
+                          </span>
+                          <div className="luna-bar-chart__bar-track">
+                            <span
+                              aria-hidden="true"
+                              className="luna-bar-chart__bar"
+                              style={barStyle}
+                            />
+                          </div>
+                          <span className="luna-bar-chart__category" title={item.safeLabel}>
+                            {item.safeLabel}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+        <p className="luna-bar-chart__sr-only" id={summaryId}>
+          {chartSummary}
+        </p>
+      </section>
+    );
+  }
+);

--- a/src/components/luna-bar-chart/index.ts
+++ b/src/components/luna-bar-chart/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaBarChart";
+export * from "./LunaBarChart.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1547,6 +1547,42 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    barChart: {
+      radius: "lg",
+      padding: "5",
+      headerGap: "4",
+      legendGap: "2",
+      chartHeight: "14rem",
+      barGap: "3",
+      barMinWidth: "5.25rem",
+      palette: [
+        "primary.500",
+        "accent.500",
+        "success.500",
+        "warning.500",
+        "danger.500"
+      ],
+      modes: {
+        light: {
+          bg: "neutral.100",
+          border: "neutral.200",
+          axisText: "neutral.600",
+          axisGrid: "neutral.300",
+          legendText: "neutral.700",
+          valueText: "neutral.900",
+          stateText: "neutral.600"
+        },
+        dark: {
+          bg: "neutral.800",
+          border: "neutral.700",
+          axisText: "neutral.400",
+          axisGrid: "neutral.600",
+          legendText: "neutral.200",
+          valueText: "neutral.50",
+          stateText: "neutral.300"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -208,6 +208,16 @@ export type ThemeProgressToneTokens = {
   glow?: string;
 };
 
+export type ThemeBarChartModeTokens = {
+  bg?: string;
+  border?: string;
+  axisText?: string;
+  axisGrid?: string;
+  legendText?: string;
+  valueText?: string;
+  stateText?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -530,6 +540,17 @@ export type ThemeComponents = {
     sizes?: Record<string, ThemeProgressSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeProgressModeTokens>>;
     tones?: Record<string, ThemeProgressToneTokens>;
+  };
+  barChart?: {
+    radius?: string;
+    padding?: string;
+    headerGap?: string;
+    legendGap?: string;
+    chartHeight?: string;
+    barGap?: string;
+    barMinWidth?: string;
+    palette?: string[];
+    modes?: Partial<Record<ThemeMode, ThemeBarChartModeTokens>>;
   };
   input?: {
     defaultSize?: string;


### PR DESCRIPTION
Closes #145

storybook-component: luna-bar-chart

## Summary
Implemented issue `#145` as a scoped `LunaBarChart` baseline surface. The new component lives in [src/components/luna-bar-chart/LunaBarChart.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-bar-chart/LunaBarChart.tsx), with theme tokens added in [src/theme/types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts) and [src/theme/base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts). It stays intentionally narrow: vertical single-series bars, optional legend with a defined fallback label, accessible chart naming via required `ariaLabel`, and explicit empty/loading/error states. Storybook, docs, screenshot metadata, and a changeset were added in [src/components/luna-bar-chart/LunaBarChart.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-bar-chart/LunaBarChart.stories.tsx), [docs/v1/components/LunaBarChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaBarChart.md), [docs/v1/design/LunaBarChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaBarChart.md), [playwright/storybook/manifests/luna-bar-chart.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-bar-chart.json), and [.changeset/luna-bar-chart-baseline.md](/Users/jordanb/.codex/automations/react-luna/.changeset/luna-bar-chart-baseline.md).

Verification ran cleanly:
- `npm run test -- src/components/luna-bar-chart/LunaBarChart.test.tsx`
- `npm run build`
- `STORYBOOK_COMPONENT=luna-bar-chart npm run screenshots:storybook:list`

The screenshot listing resolved 8 `luna-bar-chart` captures, so the visual review path is wired correctly. I could not create the required commit because the sandbox denies writes under `.git` and `git commit` failed with `Unable to create '.git/index.lock': Operation not permitted`.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`