### PR TITLE
Resolve #146: Add LunaScatterChart baseline chart surface

### DIFF
--- a/.changeset/luna-scatter-chart-baseline.md
+++ b/.changeset/luna-scatter-chart-baseline.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the `LunaScatterChart` baseline chart surface with Storybook coverage, tests, docs, and screenshot metadata.

--- a/docs/v1/components/LunaScatterChart.md
+++ b/docs/v1/components/LunaScatterChart.md
@@ -1,0 +1,53 @@
+# LunaScatterChart
+
+`LunaScatterChart` is the baseline single-series relationship chart for `react-luna`.
+
+It owns:
+- paired numeric x and y values only
+- a framed scatter chart surface for panels and dashboards
+- readable built-in numeric axes
+- an optional legend for the lone series
+- defined empty, loading, and error states
+
+Default root element:
+- `section`
+
+## Props
+
+- `data: LunaScatterChartDatum[]`
+- `ariaLabel: string`
+- `ariaDescription?: string`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `showLegend?: boolean`
+- `showGrid?: boolean`
+- `height?: React.CSSProperties["height"]`
+- `loading?: boolean`
+- `error?: React.ReactNode`
+- `emptyState?: React.ReactNode`
+
+`LunaScatterChartDatum` supports:
+- `id?: string`
+- `label?: string`
+- `x: number`
+- `y: number`
+
+## Contract
+
+- the chart stays single-series and does not expose multi-series configuration
+- `data` accepts only paired numeric values so the axis behavior stays disciplined
+- legend treatment is optional and resolves to a single keyed series label with point count
+- axis labels are derived from built-in numeric formatting instead of consumer formatting hooks
+- `description` is visible copy, while `ariaDescription` adds extra assistive context when needed
+- `loading`, `error`, and `emptyState` keep the chart container stable rather than collapsing the surface
+
+## Theme Integration
+
+`LunaScatterChart` uses theme tokens for:
+- surface background, border, and shadow
+- plot background treatment
+- axis text, axis line, and grid line color
+- legend text treatment
+- point palette
+- point size
+- padding, gaps, radius, and chart height

--- a/docs/v1/design/LunaScatterChart.md
+++ b/docs/v1/design/LunaScatterChart.md
@@ -1,0 +1,16 @@
+# LunaScatterChart
+
+`LunaScatterChart` should read as a finished chart surface rather than a thin wrapper over plotting math.
+
+The design direction is:
+- single-series only
+- numeric axes only
+- quiet axis chrome with enough contrast to orient the eye
+- dense points with a soft glow so clusters read quickly
+- a stable framed shell that can sit inside dashboards without extra rescue styling
+
+The component should stay visually disciplined:
+- the data points carry the emphasis
+- grid lines remain optional and supportive
+- legend treatment stays minimal because there is only one series
+- if future needs push toward multi-series or statistical overlays, that should be a separate issue

--- a/playwright/storybook/manifests/luna-scatter-chart.json
+++ b/playwright/storybook/manifests/luna-scatter-chart.json
@@ -1,0 +1,37 @@
+[
+  {
+    "storyId": "components-lunascatterchart--basic",
+    "fileName": "luna-scatter-chart-basic",
+    "backgrounds": ["light", "dark"]
+  },
+  {
+    "storyId": "components-lunascatterchart--clustered",
+    "fileName": "luna-scatter-chart-clustered",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunascatterchart--sparse",
+    "fileName": "luna-scatter-chart-sparse",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunascatterchart--narrow-width",
+    "fileName": "luna-scatter-chart-narrow-width",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunascatterchart--empty",
+    "fileName": "luna-scatter-chart-empty",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunascatterchart--loading",
+    "fileName": "luna-scatter-chart-loading",
+    "backgrounds": ["light"]
+  },
+  {
+    "storyId": "components-lunascatterchart--panel-embedding",
+    "fileName": "luna-scatter-chart-panel-embedding",
+    "backgrounds": ["light"]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,6 +23,7 @@ export * from "./luna-progress";
 export * from "./luna-slider";
 export * from "./luna-textarea";
 export * from "./luna-select";
+export * from "./luna-scatter-chart";
 export * from "./luna-multiselect";
 export * from "./luna-modal";
 export * from "./luna-notification";

--- a/src/components/luna-scatter-chart/LunaScatterChart.css
+++ b/src/components/luna-scatter-chart/LunaScatterChart.css
@@ -1,0 +1,275 @@
+.luna-scatter-chart {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--luna-scatter-chart-gap, 1rem);
+  padding: var(--luna-scatter-chart-padding, 1rem);
+  box-sizing: border-box;
+  border: 1px solid var(--luna-scatter-chart-border, rgba(108, 122, 171, 0.22));
+  border-radius: var(--luna-scatter-chart-radius, 1.25rem);
+  background: var(--luna-scatter-chart-bg, rgba(255, 255, 255, 0.92));
+  box-shadow: var(--luna-scatter-chart-shadow, inset 0 1px 0 rgba(255, 255, 255, 0.72));
+}
+
+.luna-scatter-chart__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--luna-scatter-chart-header-gap, 0.5rem);
+}
+
+.luna-scatter-chart__title {
+  margin: 0;
+  color: var(--luna-scatter-chart-title-fg, #46537e);
+}
+
+.luna-scatter-chart__description {
+  margin: 0;
+  color: var(--luna-scatter-chart-description-fg, #5b688f);
+}
+
+.luna-scatter-chart__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--luna-scatter-chart-legend-gap, 0.5rem);
+  min-width: 0;
+}
+
+.luna-scatter-chart__legend-swatch {
+  flex: none;
+  inline-size: calc(var(--luna-scatter-chart-point-size, 0.75rem) + 0.3rem);
+  block-size: calc(var(--luna-scatter-chart-point-size, 0.75rem) + 0.3rem);
+  border-radius: 999px;
+  background: var(--luna-scatter-chart-current-point-color, #6366f1);
+  box-shadow: 0 0 0 0.28rem color-mix(in srgb, var(--luna-scatter-chart-current-point-color, #6366f1) 18%, transparent);
+}
+
+.luna-scatter-chart__legend-copy {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.luna-scatter-chart__legend-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--luna-scatter-chart-legend-text, #46537e);
+}
+
+.luna-scatter-chart__legend-meta {
+  font-size: 0.75rem;
+  color: var(--luna-scatter-chart-legend-meta-text, #7380a2);
+}
+
+.luna-scatter-chart__visual {
+  min-width: 0;
+  min-height: var(--luna-scatter-chart-height, 15rem);
+}
+
+.luna-scatter-chart__frame {
+  display: grid;
+  grid-template-columns: minmax(2.75rem, 3.75rem) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
+  column-gap: 0.75rem;
+  row-gap: 0.6rem;
+  min-height: var(--luna-scatter-chart-height, 15rem);
+}
+
+.luna-scatter-chart__y-axis {
+  position: relative;
+  min-height: 0;
+  color: var(--luna-scatter-chart-axis-text, #5f6d93);
+}
+
+.luna-scatter-chart__y-axis-label {
+  position: absolute;
+  right: 0;
+  transform: translateY(50%);
+  font-size: 0.75rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.luna-scatter-chart__plot-shell {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  row-gap: 0.6rem;
+}
+
+.luna-scatter-chart__plot-surface {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  border-radius: calc(var(--luna-scatter-chart-radius, 1.25rem) - 0.35rem);
+  background: var(
+    --luna-scatter-chart-plot-bg,
+    linear-gradient(180deg, rgba(244, 247, 255, 0.94), rgba(255, 255, 255, 0.82))
+  );
+  overflow: hidden;
+}
+
+.luna-scatter-chart__grid-line,
+.luna-scatter-chart__axis-line {
+  position: absolute;
+  display: block;
+}
+
+.luna-scatter-chart__grid-line {
+  background: var(--luna-scatter-chart-grid, rgba(108, 122, 171, 0.16));
+}
+
+.luna-scatter-chart__grid-line--horizontal {
+  left: 0;
+  right: 0;
+  height: 1px;
+  transform: translateY(50%);
+}
+
+.luna-scatter-chart__grid-line--vertical {
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  transform: translateX(-50%);
+}
+
+.luna-scatter-chart__axis-line {
+  background: var(--luna-scatter-chart-axis-line, rgba(108, 122, 171, 0.42));
+}
+
+.luna-scatter-chart__axis-line--x {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+}
+
+.luna-scatter-chart__axis-line--y {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+}
+
+.luna-scatter-chart__point {
+  position: absolute;
+  z-index: 1;
+  inline-size: var(--luna-scatter-chart-point-size, 0.75rem);
+  block-size: var(--luna-scatter-chart-point-size, 0.75rem);
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  background: var(--luna-scatter-chart-current-point-color, #6366f1);
+  box-shadow:
+    0 0 0 0.3rem color-mix(in srgb, var(--luna-scatter-chart-current-point-color, #6366f1) 16%, transparent),
+    0 0.3rem 0.85rem color-mix(in srgb, var(--luna-scatter-chart-current-point-color, #6366f1) 22%, transparent);
+}
+
+.luna-scatter-chart__x-axis {
+  position: relative;
+  min-height: 2rem;
+  color: var(--luna-scatter-chart-axis-text, #5f6d93);
+}
+
+.luna-scatter-chart__x-axis-label {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  inline-size: 5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+.luna-scatter-chart__state,
+.luna-scatter-chart__loading {
+  min-height: var(--luna-scatter-chart-height, 15rem);
+}
+
+.luna-scatter-chart__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--luna-scatter-chart-state-text, #5b688f);
+}
+
+.luna-scatter-chart__loading {
+  display: grid;
+  grid-template-columns: minmax(2.75rem, 3.75rem) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
+  column-gap: 0.75rem;
+  row-gap: 0.6rem;
+}
+
+.luna-scatter-chart__loading-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-block: 0.25rem;
+}
+
+.luna-scatter-chart__loading-axis--x {
+  grid-column: 2;
+  grid-row: 2;
+  flex-direction: row;
+  padding-block: 0;
+}
+
+.luna-scatter-chart__loading-plot {
+  position: relative;
+  min-height: var(--luna-scatter-chart-height, 15rem);
+  overflow: hidden;
+  border-radius: calc(var(--luna-scatter-chart-radius, 1.25rem) - 0.35rem);
+}
+
+.luna-scatter-chart__loading-surface {
+  block-size: 100%;
+}
+
+.luna-scatter-chart__loading-dot {
+  position: absolute;
+  inline-size: var(--luna-scatter-chart-point-size, 0.75rem);
+  block-size: var(--luna-scatter-chart-point-size, 0.75rem);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--luna-scatter-chart-current-point-color, #6366f1) 44%, white);
+  box-shadow: 0 0 0 0.28rem color-mix(in srgb, var(--luna-scatter-chart-current-point-color, #6366f1) 14%, transparent);
+}
+
+.luna-scatter-chart__loading-dot--one {
+  left: 24%;
+  top: 62%;
+}
+
+.luna-scatter-chart__loading-dot--two {
+  left: 51%;
+  top: 38%;
+}
+
+.luna-scatter-chart__loading-dot--three {
+  left: 74%;
+  top: 52%;
+}
+
+.luna-scatter-chart__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .luna-scatter-chart__frame,
+  .luna-scatter-chart__loading {
+    grid-template-columns: minmax(2.35rem, 3rem) minmax(0, 1fr);
+    column-gap: 0.55rem;
+  }
+
+  .luna-scatter-chart__x-axis-label {
+    inline-size: 3.75rem;
+  }
+}

--- a/src/components/luna-scatter-chart/LunaScatterChart.props.ts
+++ b/src/components/luna-scatter-chart/LunaScatterChart.props.ts
@@ -1,0 +1,25 @@
+import type React from "react";
+
+export type LunaScatterChartDatum = {
+  id?: string;
+  label?: string;
+  x: number;
+  y: number;
+};
+
+export type LunaScatterChartProps = Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "children" | "color" | "title"
+> & {
+  ariaLabel: string;
+  ariaDescription?: string;
+  data: LunaScatterChartDatum[];
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  emptyState?: React.ReactNode;
+  error?: React.ReactNode;
+  height?: React.CSSProperties["height"];
+  loading?: boolean;
+  showGrid?: boolean;
+  showLegend?: boolean;
+};

--- a/src/components/luna-scatter-chart/LunaScatterChart.stories.css
+++ b/src/components/luna-scatter-chart/LunaScatterChart.stories.css
@@ -1,0 +1,12 @@
+.luna-scatter-chart-story-narrow {
+  width: 18rem;
+}
+
+.luna-scatter-chart-story-panel {
+  width: min(44rem, calc(100vw - 3rem));
+}
+
+.luna-scatter-chart-story-dashboard {
+  display: grid;
+  gap: 1rem;
+}

--- a/src/components/luna-scatter-chart/LunaScatterChart.stories.tsx
+++ b/src/components/luna-scatter-chart/LunaScatterChart.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { LunaPanel } from "../luna-panel";
+import { LunaScatterChart } from "./LunaScatterChart";
+import "./LunaScatterChart.stories.css";
+
+const basicData = [
+  { label: "North", x: 8, y: 22 },
+  { label: "South", x: 14, y: 38 },
+  { label: "East", x: 20, y: 35 },
+  { label: "West", x: 28, y: 51 },
+  { label: "Central", x: 34, y: 48 },
+  { label: "Coastal", x: 41, y: 62 }
+];
+
+const clusteredData = [
+  { label: "A1", x: 12, y: 44 },
+  { label: "A2", x: 13, y: 47 },
+  { label: "A3", x: 15, y: 45 },
+  { label: "A4", x: 16, y: 49 },
+  { label: "B1", x: 28, y: 24 },
+  { label: "B2", x: 29, y: 27 },
+  { label: "B3", x: 31, y: 25 },
+  { label: "Outlier", x: 44, y: 72 }
+];
+
+const sparseData = [
+  { label: "Low", x: 4, y: 12 },
+  { label: "Mid", x: 22, y: 41 },
+  { label: "High", x: 47, y: 18 }
+];
+
+const meta = {
+  title: "Components/LunaScatterChart",
+  component: LunaScatterChart,
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    ariaLabel: "Relationship between response time and completion score",
+    title: "Response relationship",
+    description: "Single-series paired values for relationship and spread in dashboard surfaces.",
+    data: basicData,
+    showGrid: true
+  }
+} satisfies Meta<typeof LunaScatterChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    showLegend: true
+  }
+};
+
+export const Clustered: Story = {
+  args: {
+    ariaLabel: "Clustered adoption observations",
+    title: "Clustered observations",
+    description: "Nearby points should stay readable without collapsing into a blur.",
+    data: clusteredData,
+    showLegend: true
+  }
+};
+
+export const Sparse: Story = {
+  args: {
+    ariaLabel: "Sparse distribution observations",
+    title: "Sparse distribution",
+    description: "A sparse set should still feel intentional and balanced.",
+    data: sparseData
+  }
+};
+
+export const NarrowWidth: Story = {
+  render: (args) => (
+    <div className="luna-scatter-chart-story-narrow">
+      <LunaScatterChart {...args} />
+    </div>
+  ),
+  args: {
+    ariaLabel: "Scatter chart in a narrow panel",
+    title: "Narrow panel",
+    description: "The axis chrome stays readable inside compact dashboard widths.",
+    data: basicData
+  }
+};
+
+export const Empty: Story = {
+  args: {
+    ariaLabel: "Empty scatter chart",
+    title: "Response relationship",
+    description: "The empty state keeps the same chart surface footprint.",
+    data: []
+  }
+};
+
+export const Loading: Story = {
+  args: {
+    ariaLabel: "Loading scatter chart",
+    title: "Response relationship",
+    description: "Loading preserves the chart frame while paired values resolve.",
+    data: basicData,
+    loading: true
+  }
+};
+
+export const PanelEmbedding: Story = {
+  render: (args) => (
+    <div className="luna-scatter-chart-story-panel">
+      <LunaPanel
+        title="Program dashboard"
+        description="Scatter chart surfaces should feel finished inside panel compositions."
+      >
+        <div className="luna-scatter-chart-story-dashboard">
+          <LunaScatterChart {...args} />
+        </div>
+      </LunaPanel>
+    </div>
+  ),
+  args: {
+    ariaLabel: "Relationship between throughput and quality score",
+    title: "Throughput versus quality",
+    description: "Paired delivery metrics for the current planning window.",
+    data: clusteredData,
+    showLegend: true
+  }
+};
+
+export const ErrorState: Story = {
+  args: {
+    ariaLabel: "Scatter chart unavailable",
+    title: "Response relationship",
+    description: "Error messaging uses the same framed chart shell.",
+    data: basicData,
+    error: "We could not load the paired relationship data for this chart."
+  }
+};

--- a/src/components/luna-scatter-chart/LunaScatterChart.test.tsx
+++ b/src/components/luna-scatter-chart/LunaScatterChart.test.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaScatterChart } from "./LunaScatterChart";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LunaScatterChart", () => {
+  const sampleData = [
+    { label: "North", x: 8, y: 22 },
+    { label: "South", x: 14, y: 38 },
+    { label: "West", x: 28, y: 51 }
+  ];
+
+  it("renders scatter points for normal data", () => {
+    const { container } = renderWithTheme(
+      <LunaScatterChart ariaLabel="Regional relationship" data={sampleData} title="Regional relationship" />
+    );
+
+    expect(screen.getByRole("img", { name: "Regional relationship" })).toBeInTheDocument();
+    expect(container.querySelectorAll(".luna-scatter-chart__point")).toHaveLength(3);
+    expect(screen.getByTitle("North: x 8, y 22")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no data is provided", () => {
+    renderWithTheme(
+      <LunaScatterChart ariaLabel="Empty scatter chart" data={[]} title="Regional relationship" />
+    );
+
+    expect(screen.getByText("No chart data")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add paired numeric values to render the relationship.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders clustered and sparse datasets without changing the single-series contract", () => {
+    const clusteredData = [
+      { label: "A1", x: 11, y: 42 },
+      { label: "A2", x: 12, y: 44 },
+      { label: "A3", x: 14, y: 43 },
+      { label: "Outlier", x: 30, y: 67 }
+    ];
+    const { container, rerender } = renderWithTheme(
+      <ThemeProvider>
+        <LunaScatterChart ariaLabel="Clustered points" data={clusteredData} />
+      </ThemeProvider>
+    );
+
+    expect(container.querySelectorAll(".luna-scatter-chart__point")).toHaveLength(4);
+    expect(screen.getByTitle("Outlier: x 30, y 67")).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider>
+        <LunaScatterChart
+          ariaLabel="Sparse points"
+          data={[
+            { label: "Low", x: 3, y: 12 },
+            { label: "High", x: 40, y: 44 }
+          ]}
+        />
+      </ThemeProvider>
+    );
+
+    expect(container.querySelectorAll(".luna-scatter-chart__point")).toHaveLength(2);
+    expect(screen.getByTitle("High: x 40, y 44")).toBeInTheDocument();
+  });
+
+  it("renders the legend when requested", () => {
+    renderWithTheme(
+      <LunaScatterChart ariaLabel="Regional relationship" data={sampleData} showLegend title="Regional relationship" />
+    );
+
+    expect(screen.getByRole("heading", { name: "Regional relationship" })).toBeInTheDocument();
+    expect(screen.getByText("3 points")).toBeInTheDocument();
+  });
+
+  it("uses the accessibility label and description on the chart graphic", () => {
+    renderWithTheme(
+      <LunaScatterChart
+        ariaLabel="Regional relationship scatter chart"
+        ariaDescription="Scatter chart describing the relationship between activity and completion."
+        data={sampleData}
+        description="Visible description"
+        title="Regional relationship"
+      />
+    );
+
+    const chart = screen.getByRole("img", { name: "Regional relationship scatter chart" });
+
+    expect(chart).toHaveAttribute("aria-describedby");
+    expect(screen.getByText("Scatter chart describing the relationship between activity and completion.")).toBeInTheDocument();
+  });
+
+  it("renders loading and error states with the same chart surface", () => {
+    const { container, rerender } = renderWithTheme(
+      <LunaScatterChart ariaLabel="Loading chart" data={sampleData} loading />
+    );
+
+    expect(container.querySelector(".luna-scatter-chart__loading")).not.toBeNull();
+
+    rerender(
+      <ThemeProvider>
+        <LunaScatterChart
+          ariaLabel="Chart unavailable"
+          data={sampleData}
+          error="We could not load the paired relationship data."
+        />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText("Unable to display chart")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("We could not load the paired relationship data.").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("resolves theme-driven scatter chart tokens and palette color", () => {
+    const { container } = renderWithTheme(
+      <LunaScatterChart ariaLabel="Regional relationship" data={sampleData} />,
+      {
+        theme: {
+          components: {
+            scatterChart: {
+              radius: "pill",
+              padding: "6",
+              chartHeight: "12rem",
+              pointSize: "4",
+              palette: ["accent.500"],
+              modes: {
+                light: {
+                  bg: "neutral.50",
+                  border: "neutral.300",
+                  plotBg: "neutral.100",
+                  axisText: "neutral.500",
+                  axisLine: "neutral.400",
+                  grid: "neutral.200",
+                  legendText: "neutral.700",
+                  legendMetaText: "neutral.500",
+                  stateText: "neutral.600"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    const root = container.querySelector(".luna-scatter-chart");
+
+    expect(root).toHaveStyle({
+      "--luna-scatter-chart-radius": "999px",
+      "--luna-scatter-chart-padding": "1.5rem",
+      "--luna-scatter-chart-height": "12rem",
+      "--luna-scatter-chart-point-size": "1rem",
+      "--luna-scatter-chart-bg": "#f8fafc",
+      "--luna-scatter-chart-border": "#cbd5e1",
+      "--luna-scatter-chart-current-point-color": "#8b5cf6"
+    });
+  });
+});

--- a/src/components/luna-scatter-chart/LunaScatterChart.tsx
+++ b/src/components/luna-scatter-chart/LunaScatterChart.tsx
@@ -1,0 +1,496 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import { LunaEmptyState } from "../luna-empty-state";
+import { LunaSkeleton } from "../luna-skeleton";
+import { LunaText } from "../luna-text";
+import type { LunaScatterChartDatum, LunaScatterChartProps } from "./LunaScatterChart.props";
+import "./LunaScatterChart.css";
+
+type ScatterChartCssVariable =
+  | "--luna-scatter-chart-radius"
+  | "--luna-scatter-chart-padding"
+  | "--luna-scatter-chart-gap"
+  | "--luna-scatter-chart-header-gap"
+  | "--luna-scatter-chart-legend-gap"
+  | "--luna-scatter-chart-height"
+  | "--luna-scatter-chart-point-size"
+  | "--luna-scatter-chart-bg"
+  | "--luna-scatter-chart-border"
+  | "--luna-scatter-chart-shadow"
+  | "--luna-scatter-chart-plot-bg"
+  | "--luna-scatter-chart-title-fg"
+  | "--luna-scatter-chart-description-fg"
+  | "--luna-scatter-chart-axis-text"
+  | "--luna-scatter-chart-axis-line"
+  | "--luna-scatter-chart-grid"
+  | "--luna-scatter-chart-legend-text"
+  | "--luna-scatter-chart-legend-meta-text"
+  | "--luna-scatter-chart-state-text"
+  | "--luna-scatter-chart-current-point-color";
+
+type LunaScatterChartStyle = React.CSSProperties &
+  Partial<Record<ScatterChartCssVariable, string | number | undefined>>;
+
+type AxisTick = {
+  value: number;
+  offset: number;
+  label: string;
+};
+
+type PlotPoint = LunaScatterChartDatum & {
+  safeLabel: string;
+  left: number;
+  top: number;
+};
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpace(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveRadius(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function resolveHeight(
+  value: React.CSSProperties["height"] | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function normalizeData(data: LunaScatterChartDatum[]) {
+  return data
+    .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y))
+    .map((point, index) => ({
+      ...point,
+      safeLabel:
+        typeof point.label === "string" && point.label.trim().length > 0
+          ? point.label.trim()
+          : `Point ${index + 1}`
+    }));
+}
+
+function buildDomain(values: number[]) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.12, 1);
+    return { min: min - padding, max: max + padding };
+  }
+
+  const span = max - min;
+  const padding = span * 0.12;
+
+  return {
+    min: min - padding,
+    max: max + padding
+  };
+}
+
+function getNiceStep(rawStep: number) {
+  if (rawStep <= 0 || !Number.isFinite(rawStep)) {
+    return 1;
+  }
+
+  const exponent = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const fraction = rawStep / exponent;
+
+  if (fraction <= 1) {
+    return exponent;
+  }
+
+  if (fraction <= 2) {
+    return 2 * exponent;
+  }
+
+  if (fraction <= 5) {
+    return 5 * exponent;
+  }
+
+  return 10 * exponent;
+}
+
+function formatAxisValue(value: number) {
+  if (Math.abs(value) >= 1000) {
+    return new Intl.NumberFormat(undefined, {
+      notation: "compact",
+      maximumFractionDigits: 1
+    }).format(value);
+  }
+
+  if (Number.isInteger(value)) {
+    return String(value);
+  }
+
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function buildTicks(domain: { min: number; max: number }, count = 5) {
+  const span = domain.max - domain.min || 1;
+  const step = getNiceStep(span / Math.max(1, count - 1));
+  const niceMin = Math.floor(domain.min / step) * step;
+  const niceMax = Math.ceil(domain.max / step) * step;
+  const range = niceMax - niceMin || step;
+  const tickCount = Math.round(range / step);
+
+  return Array.from({ length: tickCount + 1 }, (_, index) => {
+    const value = niceMin + index * step;
+    return {
+      value,
+      offset: ((value - niceMin) / range) * 100,
+      label: formatAxisValue(value)
+    } satisfies AxisTick;
+  });
+}
+
+function buildPlotPoints(
+  data: ReturnType<typeof normalizeData>,
+  xDomain: { min: number; max: number },
+  yDomain: { min: number; max: number }
+) {
+  const xSpan = xDomain.max - xDomain.min || 1;
+  const ySpan = yDomain.max - yDomain.min || 1;
+
+  return data.map((point) => ({
+    ...point,
+    left: ((point.x - xDomain.min) / xSpan) * 100,
+    top: 100 - ((point.y - yDomain.min) / ySpan) * 100
+  })) satisfies PlotPoint[];
+}
+
+function resolveLegendLabel(title: React.ReactNode) {
+  if (typeof title === "string" && title.trim().length > 0) {
+    return title;
+  }
+
+  return "Observations";
+}
+
+function createSummary(
+  state: "ready" | "empty" | "loading" | "error",
+  data: ReturnType<typeof normalizeData>,
+  xDomain: { min: number; max: number } | null,
+  yDomain: { min: number; max: number } | null,
+  title: React.ReactNode | undefined,
+  error: React.ReactNode | undefined
+) {
+  const titleText = typeof title === "string" && title.trim().length > 0 ? `${title}. ` : "";
+
+  if (state === "loading") {
+    return `${titleText}Loading scatter chart data.`;
+  }
+
+  if (state === "error") {
+    return `${titleText}${
+      typeof error === "string" && error.trim().length > 0
+        ? error
+        : "Scatter chart data is unavailable."
+    }`;
+  }
+
+  if (state === "empty") {
+    return `${titleText}No scatter chart data is available.`;
+  }
+
+  return `${titleText}${data.length} points. X values range from ${formatAxisValue(
+    xDomain?.min ?? 0
+  )} to ${formatAxisValue(xDomain?.max ?? 0)}. Y values range from ${formatAxisValue(
+    yDomain?.min ?? 0
+  )} to ${formatAxisValue(yDomain?.max ?? 0)}.`;
+}
+
+export const LunaScatterChart = React.forwardRef<HTMLElement, LunaScatterChartProps>(
+  function LunaScatterChart(
+    {
+      ariaDescription,
+      ariaLabel,
+      className,
+      data,
+      description,
+      emptyState = "Add paired numeric values to render the relationship.",
+      error,
+      height,
+      id,
+      loading = false,
+      showGrid = true,
+      showLegend = false,
+      style,
+      title,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const baseId = id ?? `luna-scatter-chart-${reactId.replace(/:/g, "")}`;
+    const visibleDescriptionId =
+      description !== undefined && description !== null ? `${baseId}-description` : undefined;
+    const assistiveDescriptionId =
+      ariaDescription && ariaDescription.trim().length > 0 ? `${baseId}-aria-description` : undefined;
+    const summaryId = `${baseId}-summary`;
+    const { theme, mode } = useTheme();
+    const chartTheme = theme.components.scatterChart;
+    const modeTokens = chartTheme?.modes?.[mode];
+    const normalizedData = normalizeData(data);
+    const state = error ? "error" : loading ? "loading" : normalizedData.length === 0 ? "empty" : "ready";
+    const xDomain = normalizedData.length > 0 ? buildDomain(normalizedData.map((point) => point.x)) : null;
+    const yDomain = normalizedData.length > 0 ? buildDomain(normalizedData.map((point) => point.y)) : null;
+    const xTicks = xDomain ? buildTicks(xDomain) : [];
+    const yTicks = yDomain ? buildTicks(yDomain) : [];
+    const plotPoints =
+      xDomain && yDomain ? buildPlotPoints(normalizedData, xDomain, yDomain) : [];
+    const palette = chartTheme?.palette?.length ? chartTheme.palette : ["primary.500"];
+    const pointColor = resolveTokenValue(theme, palette[0] ?? "primary.500");
+    const describedBy = [visibleDescriptionId, assistiveDescriptionId, summaryId]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+    const rootStyle: LunaScatterChartStyle = {
+      ["--luna-scatter-chart-radius" as const]: resolveRadius(chartTheme?.radius, theme),
+      ["--luna-scatter-chart-padding" as const]: resolveSpace(chartTheme?.padding, theme),
+      ["--luna-scatter-chart-gap" as const]: resolveSpace(chartTheme?.gap, theme),
+      ["--luna-scatter-chart-header-gap" as const]: resolveSpace(chartTheme?.headerGap, theme),
+      ["--luna-scatter-chart-legend-gap" as const]: resolveSpace(chartTheme?.legendGap, theme),
+      ["--luna-scatter-chart-height" as const]:
+        resolveHeight(height, theme) ??
+        resolveHeight(chartTheme?.chartHeight, theme),
+      ["--luna-scatter-chart-point-size" as const]:
+        resolveSpace(chartTheme?.pointSize, theme) ?? chartTheme?.pointSize,
+      ["--luna-scatter-chart-bg" as const]:
+        modeTokens?.bg ? resolveTokenValue(theme, modeTokens.bg) : undefined,
+      ["--luna-scatter-chart-border" as const]:
+        modeTokens?.border ? resolveTokenValue(theme, modeTokens.border) : undefined,
+      ["--luna-scatter-chart-shadow" as const]:
+        modeTokens?.shadow
+          ? resolveScaleValue(theme.shadows, modeTokens.shadow) ??
+            resolveTokenValue(theme, modeTokens.shadow)
+          : undefined,
+      ["--luna-scatter-chart-plot-bg" as const]:
+        modeTokens?.plotBg ? resolveTokenValue(theme, modeTokens.plotBg) : undefined,
+      ["--luna-scatter-chart-title-fg" as const]:
+        modeTokens?.titleFg ? resolveTokenValue(theme, modeTokens.titleFg) : undefined,
+      ["--luna-scatter-chart-description-fg" as const]:
+        modeTokens?.descriptionFg ? resolveTokenValue(theme, modeTokens.descriptionFg) : undefined,
+      ["--luna-scatter-chart-axis-text" as const]:
+        modeTokens?.axisText ? resolveTokenValue(theme, modeTokens.axisText) : undefined,
+      ["--luna-scatter-chart-axis-line" as const]:
+        modeTokens?.axisLine ? resolveTokenValue(theme, modeTokens.axisLine) : undefined,
+      ["--luna-scatter-chart-grid" as const]:
+        modeTokens?.grid ? resolveTokenValue(theme, modeTokens.grid) : undefined,
+      ["--luna-scatter-chart-legend-text" as const]:
+        modeTokens?.legendText ? resolveTokenValue(theme, modeTokens.legendText) : undefined,
+      ["--luna-scatter-chart-legend-meta-text" as const]:
+        modeTokens?.legendMetaText ? resolveTokenValue(theme, modeTokens.legendMetaText) : undefined,
+      ["--luna-scatter-chart-state-text" as const]:
+        modeTokens?.stateText ? resolveTokenValue(theme, modeTokens.stateText) : undefined,
+      ["--luna-scatter-chart-current-point-color" as const]: pointColor,
+      ...style
+    };
+
+    return (
+      <section
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-scatter-chart", className])}
+        data-state={state}
+        aria-busy={loading ? "true" : undefined}
+        style={rootStyle}
+      >
+        {title || description ? (
+          <header className="luna-scatter-chart__header">
+            {title ? (
+              typeof title === "string" ? (
+                <LunaText as="h2" variant="title" className="luna-scatter-chart__title">
+                  {title}
+                </LunaText>
+              ) : (
+                <div className="luna-scatter-chart__title">{title}</div>
+              )
+            ) : null}
+            {description ? (
+              typeof description === "string" ? (
+                <LunaText
+                  as="p"
+                  id={visibleDescriptionId}
+                  variant="body-small"
+                  className="luna-scatter-chart__description"
+                >
+                  {description}
+                </LunaText>
+              ) : (
+                <div className="luna-scatter-chart__description" id={visibleDescriptionId}>
+                  {description}
+                </div>
+              )
+            ) : null}
+          </header>
+        ) : null}
+
+        {assistiveDescriptionId ? (
+          <p className="luna-scatter-chart__sr-only" id={assistiveDescriptionId}>
+            {ariaDescription}
+          </p>
+        ) : null}
+
+        {showLegend && state === "ready" ? (
+          <div className="luna-scatter-chart__legend" aria-hidden="true">
+            <span className="luna-scatter-chart__legend-swatch" />
+            <span className="luna-scatter-chart__legend-copy">
+              <span className="luna-scatter-chart__legend-label">{resolveLegendLabel(title)}</span>
+              <span className="luna-scatter-chart__legend-meta">
+                {normalizedData.length} point{normalizedData.length === 1 ? "" : "s"}
+              </span>
+            </span>
+          </div>
+        ) : null}
+
+        <div
+          className="luna-scatter-chart__visual"
+          role="img"
+          aria-label={ariaLabel}
+          aria-describedby={describedBy}
+          aria-roledescription="scatter chart"
+        >
+          {state === "ready" ? (
+            <div className="luna-scatter-chart__frame">
+              <div className="luna-scatter-chart__y-axis" aria-hidden="true">
+                {yTicks.map((tick) => (
+                  <span
+                    className="luna-scatter-chart__y-axis-label"
+                    key={`y-${tick.value}`}
+                    style={{ bottom: `${tick.offset}%` }}
+                  >
+                    {tick.label}
+                  </span>
+                ))}
+              </div>
+
+              <div className="luna-scatter-chart__plot-shell">
+                <div className="luna-scatter-chart__plot-surface">
+                  {showGrid
+                    ? yTicks.map((tick) => (
+                        <span
+                          aria-hidden="true"
+                          className="luna-scatter-chart__grid-line luna-scatter-chart__grid-line--horizontal"
+                          key={`grid-y-${tick.value}`}
+                          style={{ bottom: `${tick.offset}%` }}
+                        />
+                      ))
+                    : null}
+                  {showGrid
+                    ? xTicks.map((tick) => (
+                        <span
+                          aria-hidden="true"
+                          className="luna-scatter-chart__grid-line luna-scatter-chart__grid-line--vertical"
+                          key={`grid-x-${tick.value}`}
+                          style={{ left: `${tick.offset}%` }}
+                        />
+                      ))
+                    : null}
+                  <span
+                    aria-hidden="true"
+                    className="luna-scatter-chart__axis-line luna-scatter-chart__axis-line--x"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="luna-scatter-chart__axis-line luna-scatter-chart__axis-line--y"
+                  />
+                  {plotPoints.map((point, index) => (
+                    <span
+                      aria-hidden="true"
+                      className="luna-scatter-chart__point"
+                      key={point.id ?? `${point.x}-${point.y}-${index}`}
+                      style={{ left: `${point.left}%`, top: `${point.top}%` }}
+                      title={`${point.safeLabel}: x ${formatAxisValue(point.x)}, y ${formatAxisValue(point.y)}`}
+                    />
+                  ))}
+                </div>
+
+                <div className="luna-scatter-chart__x-axis" aria-hidden="true">
+                  {xTicks.map((tick) => (
+                    <span
+                      className="luna-scatter-chart__x-axis-label"
+                      key={`x-${tick.value}`}
+                      style={{ left: `${tick.offset}%` }}
+                    >
+                      {tick.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {state === "loading" ? (
+            <div className="luna-scatter-chart__loading" aria-hidden="true">
+              <div className="luna-scatter-chart__loading-axis">
+                <LunaSkeleton inline width="8" />
+                <LunaSkeleton inline width="10" />
+                <LunaSkeleton inline width="8" />
+                <LunaSkeleton inline width="9" />
+              </div>
+              <div className="luna-scatter-chart__loading-plot">
+                <LunaSkeleton className="luna-scatter-chart__loading-surface" height="100%" shape="block" />
+                <span className="luna-scatter-chart__loading-dot luna-scatter-chart__loading-dot--one" />
+                <span className="luna-scatter-chart__loading-dot luna-scatter-chart__loading-dot--two" />
+                <span className="luna-scatter-chart__loading-dot luna-scatter-chart__loading-dot--three" />
+              </div>
+              <div className="luna-scatter-chart__loading-axis luna-scatter-chart__loading-axis--x">
+                <LunaSkeleton inline width="10" />
+                <LunaSkeleton inline width="8" />
+                <LunaSkeleton inline width="11" />
+                <LunaSkeleton inline width="9" />
+              </div>
+            </div>
+          ) : null}
+
+          {state === "empty" ? (
+            <LunaEmptyState
+              className="luna-scatter-chart__state"
+              framed={false}
+              title="No chart data"
+              description={emptyState}
+            />
+          ) : null}
+
+          {state === "error" ? (
+            <LunaEmptyState
+              className="luna-scatter-chart__state"
+              framed={false}
+              title="Unable to display chart"
+              description={error}
+            />
+          ) : null}
+        </div>
+
+        <p className="luna-scatter-chart__sr-only" id={summaryId}>
+          {createSummary(state, normalizedData, xDomain, yDomain, title, error)}
+        </p>
+      </section>
+    );
+  }
+);

--- a/src/components/luna-scatter-chart/index.ts
+++ b/src/components/luna-scatter-chart/index.ts
@@ -1,0 +1,2 @@
+export { LunaScatterChart } from "./LunaScatterChart";
+export type { LunaScatterChartDatum, LunaScatterChartProps } from "./LunaScatterChart.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1756,6 +1756,46 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    scatterChart: {
+      radius: "1.25rem",
+      padding: "4",
+      gap: "4",
+      headerGap: "2",
+      legendGap: "2",
+      chartHeight: "15rem",
+      pointSize: "0.75rem",
+      palette: ["primary.500"],
+      modes: {
+        light: {
+          bg: "rgba(255, 255, 255, 0.92)",
+          border: "rgba(108, 122, 171, 0.22)",
+          shadow: "inset 0 1px 0 rgba(255, 255, 255, 0.72)",
+          plotBg: "linear-gradient(180deg, rgba(244, 247, 255, 0.94), rgba(255, 255, 255, 0.82))",
+          titleFg: "#46537e",
+          descriptionFg: "#5b688f",
+          axisText: "#5f6d93",
+          axisLine: "rgba(108, 122, 171, 0.42)",
+          grid: "rgba(108, 122, 171, 0.16)",
+          legendText: "#46537e",
+          legendMetaText: "#7380a2",
+          stateText: "#5b688f"
+        },
+        dark: {
+          bg: "rgba(20, 27, 45, 0.92)",
+          border: "rgba(124, 138, 185, 0.34)",
+          shadow: "inset 0 1px 0 rgba(255, 255, 255, 0.04)",
+          plotBg: "linear-gradient(180deg, rgba(26, 35, 58, 0.98), rgba(17, 24, 39, 0.94))",
+          titleFg: "#dbe7ff",
+          descriptionFg: "#9fb2de",
+          axisText: "#8fa3d0",
+          axisLine: "rgba(143, 163, 208, 0.46)",
+          grid: "rgba(143, 163, 208, 0.18)",
+          legendText: "#dbe7ff",
+          legendMetaText: "#9fb2de",
+          stateText: "#b4c4e9"
+        }
+      }
+    },
     wireframe: {
       gap: "4",
       padding: "4",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -371,6 +371,21 @@ export type ThemeModalModeTokens = {
   shadow?: string;
 };
 
+export type ThemeScatterChartModeTokens = {
+  bg?: string;
+  border?: string;
+  shadow?: string;
+  plotBg?: string;
+  titleFg?: string;
+  descriptionFg?: string;
+  axisText?: string;
+  axisLine?: string;
+  grid?: string;
+  legendText?: string;
+  legendMetaText?: string;
+  stateText?: string;
+};
+
 export type ThemeComponents = {
   button?: {
     defaultSize?: string;
@@ -588,6 +603,17 @@ export type ThemeComponents = {
     descriptionFontSize?: string;
     descriptionLineHeight?: string;
     modes?: Partial<Record<ThemeMode, ThemePanelModeTokens>>;
+  };
+  scatterChart?: {
+    radius?: string;
+    padding?: string;
+    gap?: string;
+    headerGap?: string;
+    legendGap?: string;
+    chartHeight?: string;
+    pointSize?: string;
+    palette?: string[];
+    modes?: Partial<Record<ThemeMode, ThemeScatterChartModeTokens>>;
   };
   wireframe?: {
     gap?: string;


### PR DESCRIPTION
Closes #146

storybook-component: luna-scatter-chart

## Summary
Implemented `LunaScatterChart` as a scoped issue slice with component, theming, stories, tests, docs, screenshot metadata, and a changeset. The main work is in [LunaScatterChart.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-scatter-chart/LunaScatterChart.tsx), with theme defaults in [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts), public docs in [LunaScatterChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaScatterChart.md), and visual capture metadata in [luna-scatter-chart.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-scatter-chart.json).

Ran:
- `npm test -- src/components/luna-scatter-chart/LunaScatterChart.test.tsx`
- `npm run build`
- `npm run storybook:build`
- `STORYBOOK_COMPONENT=luna-scatter-chart npm run screenshots:storybook:list`

The screenshot list resolved the expected 8 `luna-scatter-chart` captures. The actual screenshot command also ran, but failed in this sandbox because Playwright could not start the local server on `127.0.0.1:6106` with `EPERM`, so visual capture could not complete here.

I could not create the requested commit because the sandbox denied writes under `.git` (`index.lock: Operation not permitted`).

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`