### PR TITLE
Resolve #147: Add LunaLineChart baseline chart surface

### DIFF
--- a/.changeset/issue-147-luna-line-chart.md
+++ b/.changeset/issue-147-luna-line-chart.md
@@ -1,0 +1,5 @@
+---
+"@liketysplit/react-luna": minor
+---
+
+Add the first-pass `LunaLineChart` primitive with theme-driven styling, Storybook coverage, tests, docs, and screenshot metadata.

--- a/docs/v1/components/LunaLineChart.md
+++ b/docs/v1/components/LunaLineChart.md
@@ -1,0 +1,67 @@
+# LunaLineChart
+
+`LunaLineChart` is the baseline single-series trend chart for `react-luna`.
+
+It owns:
+- ordered single-series line rendering
+- readable x and y axis presentation for sparse and moderately dense data
+- optional legend and grid treatments
+- accessible chart naming and description hooks
+- defined empty, loading, and error states inside the same chart shell
+
+It does not own:
+- multi-series comparison
+- area or mixed-chart rendering
+- generic chart-builder configuration
+- data fetching or retry orchestration
+
+## Props
+
+- `data: Array<{ label: string; value: number }>`
+- `title?: React.ReactNode`
+- `description?: React.ReactNode`
+- `ariaLabel?: string`
+- `ariaDescription?: string`
+- `legendLabel?: React.ReactNode`
+- `showLegend?: boolean`
+- `showGrid?: boolean`
+- `loading?: boolean`
+- `error?: React.ReactNode`
+
+## Contract
+
+- `LunaLineChart` renders a single ordered series only
+- `data` order is preserved exactly; the component does not sort
+- each datum must provide a display `label` and numeric `value`
+- `showLegend` reveals a single-series key; the legend label resolves from `legendLabel`, then string `title`, then `Series`
+- `showGrid` controls horizontal gridlines only
+- point markers render automatically for shorter series and are suppressed for denser ones to avoid clutter
+- `loading` wins over data display and keeps the chart footprint stable
+- `error` renders an error state shell instead of the chart body
+- empty data renders a defined empty state shell
+- `className` and `style` pass through to the root container
+
+## Accessibility
+
+- the rendered chart surface uses `role="img"`
+- accessible naming should come from `ariaLabel`
+- if `ariaLabel` is omitted, a plain string `title` becomes the fallback accessible name
+- `ariaDescription` can provide a chart-specific accessible description
+- a plain string `description` is also linked to the chart when `ariaDescription` is not provided
+
+## Theme Integration
+
+`LunaLineChart` consumes the existing `ThemeProvider` for:
+- chart height, padding, and radius
+- surface and border colors
+- title, description, axis, and legend text colors
+- grid, line, and marker colors
+- marker and line sizing
+- state background and state border treatment
+
+## State Model
+
+- ready: render the line chart body
+- loading: render the loading shell
+- empty: render the empty shell when `data.length === 0`
+- error: render the error shell when `error` is provided

--- a/docs/v1/design/LunaLineChart.md
+++ b/docs/v1/design/LunaLineChart.md
@@ -1,0 +1,48 @@
+# Line Chart Design
+
+This document records the first-pass design direction for `LunaLineChart`.
+
+## Design Stance
+
+- keep the contract intentionally narrow
+- ship one polished single-series chart before adding chart families
+- keep theming first-class across line, axes, legend, markers, and container treatment
+- prefer automatic clutter reduction over exposing extra knobs
+- keep panel and dashboard embedding as a first-order use case
+
+## Decisions So Far
+
+- use an inline SVG surface for deterministic rendering
+- keep x-axis labels ordered and automatically thinned for denser data
+- keep y-axis labels consistent with a small fixed tick count
+- render horizontal gridlines only
+- auto-hide point markers when density rises past the baseline threshold
+- keep the legend optional because there is only one series
+- define loading, empty, and error shells in the primitive instead of leaving them implicit
+
+## Visual Intent Notes
+
+### Surface
+
+- the chart should feel at home inside cards and panels without needing wrapper-specific styling
+- the line remains the visual focal point
+- the container should look finished even when the chart is empty or loading
+
+### Axes
+
+- x-axis labels should stay legible in narrow and moderately dense layouts
+- y-axis labels should support quick scanning without turning into a full analytics grid
+- gridlines stay subtle enough that hiding them remains a valid choice
+
+### Markers
+
+- markers are useful for sparse sequences
+- markers should disappear automatically before they become visual noise
+
+## Build Order
+
+1. define the single-series contract
+2. implement the themed SVG surface and state shells
+3. add Storybook coverage for sparse, dense, narrow, empty, and panel states
+4. add tests for rendering, labeling, legend, and theme behavior
+5. add docs and release metadata

--- a/playwright/storybook/manifests/luna-line-chart.json
+++ b/playwright/storybook/manifests/luna-line-chart.json
@@ -1,0 +1,52 @@
+[
+  {
+    "storyId": "components-lunalinechart--dashboard-panel",
+    "fileName": "luna-line-chart-dashboard-panel",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--dense-data",
+    "fileName": "luna-line-chart-dense-data",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--empty-state",
+    "fileName": "luna-line-chart-empty-state",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--loading-state",
+    "fileName": "luna-line-chart-loading-state",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--narrow-width",
+    "fileName": "luna-line-chart-narrow-width",
+    "backgrounds": [
+      "light"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--playground",
+    "fileName": "luna-line-chart-playground",
+    "backgrounds": [
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "storyId": "components-lunalinechart--sparse-data",
+    "fileName": "luna-line-chart-sparse-data",
+    "backgrounds": [
+      "light"
+    ]
+  }
+]

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,6 +18,7 @@ export * from "./luna-form";
 export * from "./luna-header";
 export * from "./luna-hover-text";
 export * from "./luna-input";
+export * from "./luna-line-chart";
 export * from "./luna-menu";
 export * from "./luna-progress";
 export * from "./luna-slider";

--- a/src/components/luna-line-chart/LunaLineChart.css
+++ b/src/components/luna-line-chart/LunaLineChart.css
@@ -1,0 +1,156 @@
+.luna-line-chart {
+  --luna-line-chart-height: 13.75rem;
+  --luna-line-chart-padding: 1rem;
+  --luna-line-chart-radius: 0.75rem;
+  --luna-line-chart-bg: var(--luna-color-surface, #f1f5f9);
+  --luna-line-chart-border: var(--luna-color-border, #e2e8f0);
+  --luna-line-chart-title-fg: var(--luna-color-foreground, #0f172a);
+  --luna-line-chart-description-fg: var(--luna-color-muted, #64748b);
+  --luna-line-chart-axis-fg: var(--luna-color-foreground, #0f172a);
+  --luna-line-chart-axis-muted-fg: var(--luna-color-muted, #64748b);
+  --luna-line-chart-grid: rgba(148, 163, 184, 0.22);
+  --luna-line-chart-line: #4f46e5;
+  --luna-line-chart-line-width: 3;
+  --luna-line-chart-marker-fill: var(--luna-line-chart-bg);
+  --luna-line-chart-marker-stroke: var(--luna-line-chart-line);
+  --luna-line-chart-marker-size: 4.5;
+  --luna-line-chart-legend-fg: var(--luna-color-foreground, #0f172a);
+  --luna-line-chart-state-bg: rgba(148, 163, 184, 0.08);
+  --luna-line-chart-state-border: rgba(148, 163, 184, 0.26);
+  --luna-line-chart-state-fg: var(--luna-color-foreground, #0f172a);
+  display: grid;
+  gap: 0.75rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.luna-line-chart__header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.luna-line-chart__title {
+  color: var(--luna-line-chart-title-fg);
+  margin: 0;
+}
+
+.luna-line-chart__description {
+  color: var(--luna-line-chart-description-fg);
+  margin: 0;
+}
+
+.luna-line-chart__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--luna-line-chart-legend-fg);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.luna-line-chart__legend-swatch {
+  width: 1.25rem;
+  height: 0.25rem;
+  border-radius: 999px;
+  background: var(--luna-line-chart-line);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.luna-line-chart__surface,
+.luna-line-chart__state {
+  min-width: 0;
+  min-height: var(--luna-line-chart-height);
+  border: 1px solid var(--luna-line-chart-border);
+  border-radius: var(--luna-line-chart-radius);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 32%),
+    var(--luna-line-chart-bg);
+  padding: var(--luna-line-chart-padding);
+}
+
+.luna-line-chart__surface {
+  display: flex;
+}
+
+.luna-line-chart__svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.luna-line-chart__grid-line {
+  stroke: var(--luna-line-chart-grid);
+  stroke-width: 1;
+}
+
+.luna-line-chart__axis-line {
+  stroke: var(--luna-line-chart-border);
+  stroke-width: 1;
+}
+
+.luna-line-chart__axis-label {
+  fill: var(--luna-line-chart-axis-fg);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.luna-line-chart__axis-label--muted {
+  fill: var(--luna-line-chart-axis-muted-fg);
+  font-weight: 500;
+}
+
+.luna-line-chart__line {
+  fill: none;
+  stroke: var(--luna-line-chart-line);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: var(--luna-line-chart-line-width);
+  vector-effect: non-scaling-stroke;
+}
+
+.luna-line-chart__marker {
+  fill: var(--luna-line-chart-marker-fill);
+  stroke: var(--luna-line-chart-marker-stroke);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.luna-line-chart__marker[data-current="true"] {
+  filter: drop-shadow(0 0 10px rgba(99, 102, 241, 0.22));
+}
+
+.luna-line-chart__marker--solo {
+  fill: var(--luna-line-chart-line);
+}
+
+.luna-line-chart__state {
+  display: grid;
+  place-items: center;
+  justify-items: center;
+  gap: 0.5rem;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 40%),
+    var(--luna-line-chart-state-bg);
+  border-color: var(--luna-line-chart-state-border);
+  color: var(--luna-line-chart-state-fg);
+}
+
+.luna-line-chart__state-title,
+.luna-line-chart__state-description {
+  color: var(--luna-line-chart-state-fg);
+}
+
+.luna-line-chart__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/luna-line-chart/LunaLineChart.props.ts
+++ b/src/components/luna-line-chart/LunaLineChart.props.ts
@@ -1,0 +1,22 @@
+import type React from "react";
+
+export type LunaLineChartDatum = {
+  label: string;
+  value: number;
+};
+
+export type LunaLineChartProps = Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "children" | "title"
+> & {
+  data: LunaLineChartDatum[];
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  ariaLabel?: string;
+  ariaDescription?: string;
+  legendLabel?: React.ReactNode;
+  showLegend?: boolean;
+  showGrid?: boolean;
+  loading?: boolean;
+  error?: React.ReactNode;
+};

--- a/src/components/luna-line-chart/LunaLineChart.stories.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LunaPanel } from "../luna-panel";
+import { LunaLineChart } from "./LunaLineChart";
+
+const basicData = [
+  { label: "Mon", value: 42 },
+  { label: "Tue", value: 46 },
+  { label: "Wed", value: 51 },
+  { label: "Thu", value: 49 },
+  { label: "Fri", value: 58 },
+  { label: "Sat", value: 63 },
+  { label: "Sun", value: 61 }
+];
+
+const sparseData = [
+  { label: "Week 1", value: 18 },
+  { label: "Week 2", value: 27 },
+  { label: "Week 3", value: 25 },
+  { label: "Week 4", value: 36 }
+];
+
+const denseData = [
+  { label: "01", value: 14 },
+  { label: "02", value: 17 },
+  { label: "03", value: 16 },
+  { label: "04", value: 20 },
+  { label: "05", value: 23 },
+  { label: "06", value: 25 },
+  { label: "07", value: 24 },
+  { label: "08", value: 29 },
+  { label: "09", value: 33 },
+  { label: "10", value: 31 },
+  { label: "11", value: 36 },
+  { label: "12", value: 38 },
+  { label: "13", value: 42 },
+  { label: "14", value: 39 }
+];
+
+const meta = {
+  title: "Components/LunaLineChart",
+  component: LunaLineChart,
+  args: {
+    data: basicData,
+    title: "Weekly active listeners",
+    description: "Seven-day trend across the current dashboard view.",
+    ariaLabel: "Weekly active listeners line chart"
+  }
+} satisfies Meta<typeof LunaLineChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    showGrid: true,
+    showLegend: true,
+    legendLabel: "Active listeners"
+  }
+};
+
+export const SparseData: Story = {
+  args: {
+    data: sparseData,
+    title: "Monthly check-ins",
+    description: "A short sequence should keep labels and markers fully visible.",
+    ariaLabel: "Monthly check-ins line chart",
+    showLegend: true,
+    legendLabel: "Check-ins"
+  }
+};
+
+export const DenseData: Story = {
+  args: {
+    data: denseData,
+    title: "Intraday request volume",
+    description: "Denser data suppresses point markers to keep the line readable.",
+    ariaLabel: "Intraday request volume line chart",
+    showGrid: true
+  }
+};
+
+export const NarrowWidth: Story = {
+  render: (args) => (
+    <div style={{ width: "18rem" }}>
+      <LunaLineChart {...args} />
+    </div>
+  ),
+  args: {
+    data: basicData,
+    title: "Compact panel trend",
+    description: "The chart should remain readable in a constrained panel width.",
+    ariaLabel: "Compact panel trend line chart",
+    showLegend: true,
+    legendLabel: "Active listeners"
+  }
+};
+
+export const EmptyState: Story = {
+  args: {
+    data: [],
+    title: "No usage yet",
+    description: "The empty state uses the same chart shell and header treatment.",
+    ariaLabel: "Empty usage line chart"
+  }
+};
+
+export const LoadingState: Story = {
+  args: {
+    data: basicData,
+    title: "Syncing trend",
+    description: "Loading keeps the chart footprint stable while data refreshes.",
+    ariaLabel: "Loading trend line chart",
+    loading: true
+  }
+};
+
+export const DashboardPanel: Story = {
+  render: (args) => (
+    <div style={{ width: "min(36rem, 100%)" }}>
+      <LunaPanel
+        title="Operations overview"
+        description="A simple panel embedding for dashboard composition."
+      >
+        <LunaLineChart {...args} />
+      </LunaPanel>
+    </div>
+  ),
+  args: {
+    data: basicData,
+    title: "Queue latency",
+    description: "Smoothed hourly trend for the current deployment window.",
+    ariaLabel: "Queue latency line chart",
+    showLegend: true,
+    legendLabel: "Latency"
+  }
+};

--- a/src/components/luna-line-chart/LunaLineChart.test.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThemeProvider } from "../../theme";
+import type { ThemeProviderProps } from "../../theme/provider";
+import { LunaLineChart } from "./LunaLineChart";
+
+function renderWithTheme(
+  ui: React.ReactElement,
+  themeProps?: Omit<ThemeProviderProps, "children">
+) {
+  return render(<ThemeProvider {...themeProps}>{ui}</ThemeProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+const sparseData = [
+  { label: "Mon", value: 12 },
+  { label: "Tue", value: 18 },
+  { label: "Wed", value: 16 },
+  { label: "Thu", value: 22 }
+];
+
+const denseData = Array.from({ length: 14 }, (_, index) => ({
+  label: `P${index + 1}`,
+  value: 12 + index * 2
+}));
+
+describe("LunaLineChart", () => {
+  it("renders a semantic chart surface for normal data", () => {
+    renderWithTheme(
+      <LunaLineChart
+        ariaLabel="Weekly trend chart"
+        data={sparseData}
+        description="Performance over four points"
+        title="Weekly trend"
+      />
+    );
+
+    const chart = screen.getByRole("img", { name: "Weekly trend chart" });
+
+    expect(chart).toBeInTheDocument();
+    expect(chart.querySelector(".luna-line-chart__line")).toBeInTheDocument();
+    expect(chart.querySelectorAll(".luna-line-chart__marker")).toHaveLength(4);
+  });
+
+  it("renders the empty state when no data is present", () => {
+    renderWithTheme(<LunaLineChart ariaLabel="Empty trend chart" data={[]} />);
+
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Empty trend chart" })).not.toBeInTheDocument();
+  });
+
+  it("suppresses markers for denser data to reduce clutter", () => {
+    renderWithTheme(<LunaLineChart ariaLabel="Dense trend chart" data={denseData} />);
+
+    const chart = screen.getByRole("img", { name: "Dense trend chart" });
+
+    expect(chart.querySelector(".luna-line-chart__line")).toBeInTheDocument();
+    expect(chart.querySelectorAll(".luna-line-chart__marker")).toHaveLength(0);
+  });
+
+  it("renders the legend when requested", () => {
+    renderWithTheme(
+      <LunaLineChart
+        ariaLabel="Requests trend chart"
+        data={sparseData}
+        legendLabel="Requests"
+        showLegend
+      />
+    );
+
+    expect(screen.getByText("Requests")).toBeInTheDocument();
+  });
+
+  it("uses the title as the accessible name when ariaLabel is not provided", () => {
+    renderWithTheme(<LunaLineChart data={sparseData} title="Request trend" />);
+
+    expect(screen.getByRole("img", { name: "Request trend" })).toBeInTheDocument();
+  });
+
+  it("applies theme-driven chart variables", () => {
+    renderWithTheme(
+      <LunaLineChart ariaLabel="Themed chart" data={sparseData} />,
+      {
+        theme: {
+          components: {
+            lineChart: {
+              height: "16",
+              padding: "6",
+              radius: "lg",
+              lineWidth: "5",
+              markerSize: "6",
+              modes: {
+                light: {
+                  line: "accent.500",
+                  axisFg: "neutral.700",
+                  stateBg: "neutral.100"
+                }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    expect(screen.getByText("Mon").closest(".luna-line-chart")).toHaveStyle({
+      "--luna-line-chart-height": "4rem",
+      "--luna-line-chart-padding": "1.5rem",
+      "--luna-line-chart-radius": "0.75rem",
+      "--luna-line-chart-line-width": "5",
+      "--luna-line-chart-marker-size": "6",
+      "--luna-line-chart-line": "#8b5cf6",
+      "--luna-line-chart-axis-fg": "#334155",
+      "--luna-line-chart-state-bg": "#f1f5f9"
+    });
+  });
+});

--- a/src/components/luna-line-chart/LunaLineChart.tsx
+++ b/src/components/luna-line-chart/LunaLineChart.tsx
@@ -1,0 +1,557 @@
+import React from "react";
+import { useTheme } from "../../theme";
+import { resolveScaleValue, resolveTokenValue } from "../../theme/resolve";
+import { LunaSpinner } from "../luna-spinner";
+import { LunaText } from "../luna-text";
+import type { LunaLineChartDatum, LunaLineChartProps } from "./LunaLineChart.props";
+import "./LunaLineChart.css";
+
+type LineChartCssVariable =
+  | "--luna-line-chart-height"
+  | "--luna-line-chart-padding"
+  | "--luna-line-chart-radius"
+  | "--luna-line-chart-bg"
+  | "--luna-line-chart-border"
+  | "--luna-line-chart-title-fg"
+  | "--luna-line-chart-description-fg"
+  | "--luna-line-chart-axis-fg"
+  | "--luna-line-chart-axis-muted-fg"
+  | "--luna-line-chart-grid"
+  | "--luna-line-chart-line"
+  | "--luna-line-chart-line-width"
+  | "--luna-line-chart-marker-fill"
+  | "--luna-line-chart-marker-stroke"
+  | "--luna-line-chart-marker-size"
+  | "--luna-line-chart-legend-fg"
+  | "--luna-line-chart-state-bg"
+  | "--luna-line-chart-state-border"
+  | "--luna-line-chart-state-fg";
+
+type LunaLineChartStyle = React.CSSProperties &
+  Partial<Record<LineChartCssVariable, string | number | undefined>>;
+
+type ChartGeometry = {
+  width: number;
+  height: number;
+  plotLeft: number;
+  plotTop: number;
+  plotWidth: number;
+  plotHeight: number;
+};
+
+type ChartPoint = LunaLineChartDatum & {
+  x: number;
+  y: number;
+};
+
+const warnedMessages = new Set<string>();
+const CHART_GEOMETRY: ChartGeometry = {
+  width: 360,
+  height: 220,
+  plotLeft: 44,
+  plotTop: 18,
+  plotWidth: 300,
+  plotHeight: 166
+};
+
+function warnOnce(message: string) {
+  if (!import.meta.env.DEV || warnedMessages.has(message)) {
+    return;
+  }
+
+  warnedMessages.add(message);
+  console.warn(message);
+}
+
+function toClassName(parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function resolveSpaceValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.spacing, value) ?? value;
+}
+
+function resolveRadiusValue(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveScaleValue(theme.radii, value) ?? value;
+}
+
+function resolveThemeColor(
+  value: string | undefined,
+  theme: ReturnType<typeof useTheme>["theme"]
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  return resolveTokenValue(theme, value);
+}
+
+function resolveNumericString(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isNaN(parsedValue) ? value : String(parsedValue);
+}
+
+function getAccessibleName(
+  ariaLabel: string | undefined,
+  title: React.ReactNode,
+  legendLabel: React.ReactNode
+) {
+  if (ariaLabel) {
+    return ariaLabel;
+  }
+
+  if (typeof title === "string" && title.trim().length > 0) {
+    return title;
+  }
+
+  if (typeof legendLabel === "string" && legendLabel.trim().length > 0) {
+    return legendLabel;
+  }
+
+  warnOnce(
+    "LunaLineChart: provide `ariaLabel` when `title` is not plain text so the chart has an accessible name."
+  );
+  return "Line chart";
+}
+
+function getAccessibleDescription(
+  ariaDescription: string | undefined,
+  description: React.ReactNode
+) {
+  if (ariaDescription) {
+    return ariaDescription;
+  }
+
+  if (typeof description === "string" && description.trim().length > 0) {
+    return description;
+  }
+
+  return undefined;
+}
+
+function getPointX(index: number, count: number, geometry: ChartGeometry) {
+  if (count <= 1) {
+    return geometry.plotLeft + geometry.plotWidth / 2;
+  }
+
+  return geometry.plotLeft + (index / (count - 1)) * geometry.plotWidth;
+}
+
+function getDomain(values: number[]) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  if (min === max) {
+    const padding = Math.max(Math.abs(max) * 0.12, 1);
+    return {
+      min: min - padding,
+      max: max + padding
+    };
+  }
+
+  const padding = Math.max((max - min) * 0.12, 0.5);
+
+  return {
+    min: min - padding,
+    max: max + padding
+  };
+}
+
+function getPointY(value: number, domainMin: number, domainMax: number, geometry: ChartGeometry) {
+  const ratio = (value - domainMin) / (domainMax - domainMin);
+  return geometry.plotTop + geometry.plotHeight - ratio * geometry.plotHeight;
+}
+
+function buildChartPoints(data: LunaLineChartDatum[], geometry: ChartGeometry) {
+  const values = data.map((datum) => datum.value);
+  const domain = getDomain(values);
+  const points = data.map((datum, index) => ({
+    ...datum,
+    x: getPointX(index, data.length, geometry),
+    y: getPointY(datum.value, domain.min, domain.max, geometry)
+  }));
+
+  return {
+    points,
+    domain
+  };
+}
+
+function buildLinePath(points: ChartPoint[]) {
+  return points.map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`).join(" ");
+}
+
+function getYTicks(domainMin: number, domainMax: number, tickCount: number) {
+  if (tickCount <= 1) {
+    return [domainMax];
+  }
+
+  return Array.from({ length: tickCount }, (_, index) => {
+    const ratio = index / (tickCount - 1);
+    return domainMax - ratio * (domainMax - domainMin);
+  });
+}
+
+function getVisibleXTickIndexes(count: number, maxTicks: number) {
+  if (count <= 0) {
+    return [];
+  }
+
+  if (count <= maxTicks) {
+    return Array.from({ length: count }, (_, index) => index);
+  }
+
+  const step = (count - 1) / (maxTicks - 1);
+  const indexes = new Set<number>();
+
+  for (let tickIndex = 0; tickIndex < maxTicks; tickIndex += 1) {
+    indexes.add(Math.round(tickIndex * step));
+  }
+
+  indexes.add(0);
+  indexes.add(count - 1);
+
+  return Array.from(indexes).sort((left, right) => left - right);
+}
+
+function formatAxisValue(value: number, range: number) {
+  if (Math.abs(value) >= 1000) {
+    return new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      maximumFractionDigits: 1
+    }).format(value);
+  }
+
+  if (range < 5) {
+    return value.toFixed(1).replace(/\.0$/, "");
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: range < 20 ? 1 : 0
+  }).format(value);
+}
+
+function getLegendLabel(title: React.ReactNode, legendLabel: React.ReactNode) {
+  if (legendLabel !== undefined && legendLabel !== null) {
+    return legendLabel;
+  }
+
+  if (typeof title === "string" && title.trim().length > 0) {
+    return title;
+  }
+
+  return "Series";
+}
+
+function renderStateBody(
+  state: "loading" | "empty" | "error",
+  error: React.ReactNode | undefined
+) {
+  if (state === "loading") {
+    return (
+      <>
+        <LunaSpinner decorative={false} label="Loading line chart" />
+        <LunaText as="span" variant="label" className="luna-line-chart__state-title">
+          Loading chart
+        </LunaText>
+        <LunaText as="span" variant="body-small" className="luna-line-chart__state-description">
+          Preparing the latest trend points for display.
+        </LunaText>
+      </>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <>
+        <LunaText as="span" variant="label" className="luna-line-chart__state-title">
+          Chart unavailable
+        </LunaText>
+        <div className="luna-line-chart__state-description">
+          {typeof error === "string" ? (
+            <LunaText as="span" variant="body-small">
+              {error}
+            </LunaText>
+          ) : (
+            error
+          )}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <LunaText as="span" variant="label" className="luna-line-chart__state-title">
+        No data yet
+      </LunaText>
+      <LunaText as="span" variant="body-small" className="luna-line-chart__state-description">
+        Add at least one ordered value to render the chart surface.
+      </LunaText>
+    </>
+  );
+}
+
+export const LunaLineChart = React.forwardRef<HTMLElement, LunaLineChartProps>(
+  function LunaLineChart(
+    {
+      ariaDescription,
+      ariaLabel,
+      className,
+      data,
+      description,
+      error,
+      id,
+      legendLabel,
+      loading = false,
+      showGrid = true,
+      showLegend = false,
+      style,
+      title,
+      ...props
+    },
+    ref
+  ) {
+    const reactId = React.useId();
+    const baseId = id ?? `luna-line-chart-${reactId.replace(/:/g, "")}`;
+    const descriptionId =
+      description !== undefined && description !== null ? `${baseId}-description` : undefined;
+    const hiddenDescriptionId = `${baseId}-aria-description`;
+    const { mode, theme } = useTheme();
+    const componentTheme = theme.components.lineChart;
+    const modeTokens = componentTheme?.modes?.[mode];
+    const resolvedAccessibleName = getAccessibleName(ariaLabel, title, legendLabel);
+    const resolvedAccessibleDescription = getAccessibleDescription(ariaDescription, description);
+    const state = loading ? "loading" : error ? "error" : data.length === 0 ? "empty" : "ready";
+    const geometry = CHART_GEOMETRY;
+    const resolvedHeight =
+      resolveSpaceValue(componentTheme?.height, theme) ?? `${geometry.height / 16}rem`;
+    const resolvedPadding = resolveSpaceValue(componentTheme?.padding, theme);
+    const resolvedRadius = resolveRadiusValue(componentTheme?.radius, theme);
+    const resolvedTickCount = Math.max(2, componentTheme?.yTickCount ?? 4);
+    const resolvedMaxXTicks = Math.max(2, componentTheme?.maxXTicks ?? 6);
+    const resolvedMarkerThreshold = Math.max(1, componentTheme?.markerThreshold ?? 12);
+    const resolvedLegendLabel = getLegendLabel(title, legendLabel);
+    const lineWidth = resolveNumericString(componentTheme?.lineWidth) ?? "3";
+    const markerSize = resolveNumericString(componentTheme?.markerSize) ?? "4.5";
+    const chartStyle: LunaLineChartStyle = {
+      ["--luna-line-chart-height" as const]: resolvedHeight,
+      ["--luna-line-chart-padding" as const]: resolvedPadding,
+      ["--luna-line-chart-radius" as const]: resolvedRadius,
+      ["--luna-line-chart-bg" as const]: resolveThemeColor(modeTokens?.bg, theme),
+      ["--luna-line-chart-border" as const]: resolveThemeColor(modeTokens?.border, theme),
+      ["--luna-line-chart-title-fg" as const]: resolveThemeColor(modeTokens?.titleFg, theme),
+      ["--luna-line-chart-description-fg" as const]: resolveThemeColor(
+        modeTokens?.descriptionFg,
+        theme
+      ),
+      ["--luna-line-chart-axis-fg" as const]: resolveThemeColor(modeTokens?.axisFg, theme),
+      ["--luna-line-chart-axis-muted-fg" as const]: resolveThemeColor(
+        modeTokens?.axisMutedFg,
+        theme
+      ),
+      ["--luna-line-chart-grid" as const]: resolveThemeColor(modeTokens?.grid, theme),
+      ["--luna-line-chart-line" as const]: resolveThemeColor(modeTokens?.line, theme),
+      ["--luna-line-chart-line-width" as const]: lineWidth,
+      ["--luna-line-chart-marker-fill" as const]: resolveThemeColor(modeTokens?.markerFill, theme),
+      ["--luna-line-chart-marker-stroke" as const]: resolveThemeColor(
+        modeTokens?.markerStroke,
+        theme
+      ),
+      ["--luna-line-chart-marker-size" as const]: markerSize,
+      ["--luna-line-chart-legend-fg" as const]: resolveThemeColor(modeTokens?.legendFg, theme),
+      ["--luna-line-chart-state-bg" as const]: resolveThemeColor(modeTokens?.stateBg, theme),
+      ["--luna-line-chart-state-border" as const]: resolveThemeColor(
+        modeTokens?.stateBorder,
+        theme
+      ),
+      ["--luna-line-chart-state-fg" as const]: resolveThemeColor(modeTokens?.stateFg, theme),
+      ...style
+    };
+
+    const chart =
+      state === "ready"
+        ? buildChartPoints(data, geometry)
+        : {
+            points: [] as ChartPoint[],
+            domain: { min: 0, max: 0 }
+          };
+    const linePath = chart.points.length > 1 ? buildLinePath(chart.points) : undefined;
+    const showMarkers = chart.points.length > 0 && chart.points.length <= resolvedMarkerThreshold;
+    const yTicks = getYTicks(chart.domain.min, chart.domain.max, resolvedTickCount);
+    const visibleXTickIndexes = getVisibleXTickIndexes(data.length, resolvedMaxXTicks);
+    const valueRange = chart.domain.max - chart.domain.min;
+
+    return (
+      <section
+        {...props}
+        ref={ref}
+        className={toClassName(["luna-line-chart", className])}
+        data-grid={showGrid ? "true" : undefined}
+        data-state={state}
+        style={chartStyle}
+      >
+        {title || description ? (
+          <div className="luna-line-chart__header">
+            {title !== undefined && title !== null ? (
+              typeof title === "string" ? (
+                <LunaText as="h2" variant="label" className="luna-line-chart__title">
+                  {title}
+                </LunaText>
+              ) : (
+                <div className="luna-line-chart__title">{title}</div>
+              )
+            ) : null}
+            {description !== undefined && description !== null ? (
+              typeof description === "string" ? (
+                <LunaText
+                  as="p"
+                  id={descriptionId}
+                  variant="body-small"
+                  className="luna-line-chart__description"
+                >
+                  {description}
+                </LunaText>
+              ) : (
+                <div className="luna-line-chart__description" id={descriptionId}>
+                  {description}
+                </div>
+              )
+            ) : null}
+          </div>
+        ) : null}
+
+        {showLegend ? (
+          <div className="luna-line-chart__legend" aria-hidden="true">
+            <span className="luna-line-chart__legend-swatch" />
+            <span className="luna-line-chart__legend-label">{resolvedLegendLabel}</span>
+          </div>
+        ) : null}
+
+        {resolvedAccessibleDescription ? (
+          <span className="luna-line-chart__sr-only" id={hiddenDescriptionId}>
+            {resolvedAccessibleDescription}
+          </span>
+        ) : null}
+
+        {state === "ready" ? (
+          <div
+            aria-describedby={resolvedAccessibleDescription ? hiddenDescriptionId : descriptionId}
+            aria-label={resolvedAccessibleName}
+            className="luna-line-chart__surface"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              className="luna-line-chart__svg"
+              viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+            >
+              {showGrid
+                ? yTicks.map((tick) => {
+                    const y = getPointY(tick, chart.domain.min, chart.domain.max, geometry);
+                    return (
+                      <line
+                        className="luna-line-chart__grid-line"
+                        key={`grid-${tick}`}
+                        x1={geometry.plotLeft}
+                        x2={geometry.plotLeft + geometry.plotWidth}
+                        y1={y}
+                        y2={y}
+                      />
+                    );
+                  })
+                : null}
+
+              <line
+                className="luna-line-chart__axis-line"
+                x1={geometry.plotLeft}
+                x2={geometry.plotLeft + geometry.plotWidth}
+                y1={geometry.plotTop + geometry.plotHeight}
+                y2={geometry.plotTop + geometry.plotHeight}
+              />
+
+              {yTicks.map((tick) => {
+                const y = getPointY(tick, chart.domain.min, chart.domain.max, geometry);
+                return (
+                  <text
+                    className="luna-line-chart__axis-label"
+                    key={`tick-${tick}`}
+                    textAnchor="end"
+                    x={geometry.plotLeft - 8}
+                    y={y + 4}
+                  >
+                    {formatAxisValue(tick, valueRange)}
+                  </text>
+                );
+              })}
+
+              {visibleXTickIndexes.map((index) => {
+                const point = chart.points[index];
+                return (
+                  <text
+                    className="luna-line-chart__axis-label luna-line-chart__axis-label--muted"
+                    key={point.label}
+                    textAnchor={index === 0 ? "start" : index === data.length - 1 ? "end" : "middle"}
+                    x={point.x}
+                    y={geometry.plotTop + geometry.plotHeight + 24}
+                  >
+                    {point.label}
+                  </text>
+                );
+              })}
+
+              {linePath ? <path className="luna-line-chart__line" d={linePath} /> : null}
+
+              {chart.points.length === 1 ? (
+                <circle
+                  className="luna-line-chart__marker luna-line-chart__marker--solo"
+                  cx={chart.points[0].x}
+                  cy={chart.points[0].y}
+                  r={Number(markerSize) || 4.5}
+                />
+              ) : null}
+
+              {showMarkers
+                ? chart.points.map((point, index) => (
+                    <circle
+                      className="luna-line-chart__marker"
+                      cx={point.x}
+                      cy={point.y}
+                      data-current={index === chart.points.length - 1 ? "true" : undefined}
+                      key={`${point.label}-${point.value}`}
+                      r={Number(markerSize) || 4.5}
+                    />
+                  ))
+                : null}
+            </svg>
+          </div>
+        ) : (
+          <div
+            className="luna-line-chart__state"
+            role={state === "error" ? "alert" : state === "loading" ? "status" : "note"}
+          >
+            {renderStateBody(state, error)}
+          </div>
+        )}
+      </section>
+    );
+  }
+);

--- a/src/components/luna-line-chart/index.ts
+++ b/src/components/luna-line-chart/index.ts
@@ -1,0 +1,2 @@
+export * from "./LunaLineChart";
+export * from "./LunaLineChart.props";

--- a/src/theme/base.ts
+++ b/src/theme/base.ts
@@ -1547,6 +1547,50 @@ export const lunarTheme: Theme = {
         }
       }
     },
+    lineChart: {
+      height: "16",
+      padding: "4",
+      radius: "lg",
+      lineWidth: "3",
+      markerSize: "4.5",
+      maxXTicks: 6,
+      yTickCount: 4,
+      markerThreshold: 12,
+      modes: {
+        light: {
+          bg: "neutral.50",
+          border: "neutral.200",
+          titleFg: "neutral.900",
+          descriptionFg: "neutral.500",
+          axisFg: "neutral.700",
+          axisMutedFg: "neutral.500",
+          grid: "neutral.200",
+          line: "primary.600",
+          markerFill: "neutral.50",
+          markerStroke: "primary.600",
+          legendFg: "neutral.800",
+          stateBg: "neutral.100",
+          stateBorder: "neutral.200",
+          stateFg: "neutral.800"
+        },
+        dark: {
+          bg: "neutral.800",
+          border: "neutral.700",
+          titleFg: "neutral.50",
+          descriptionFg: "neutral.400",
+          axisFg: "neutral.200",
+          axisMutedFg: "neutral.400",
+          grid: "neutral.700",
+          line: "primary.300",
+          markerFill: "neutral.800",
+          markerStroke: "primary.300",
+          legendFg: "neutral.100",
+          stateBg: "neutral.800",
+          stateBorder: "neutral.700",
+          stateFg: "neutral.100"
+        }
+      }
+    },
     input: {
       defaultSize: "md",
       radius: "md",

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -208,6 +208,23 @@ export type ThemeProgressToneTokens = {
   glow?: string;
 };
 
+export type ThemeLineChartModeTokens = {
+  bg?: string;
+  border?: string;
+  titleFg?: string;
+  descriptionFg?: string;
+  axisFg?: string;
+  axisMutedFg?: string;
+  grid?: string;
+  line?: string;
+  markerFill?: string;
+  markerStroke?: string;
+  legendFg?: string;
+  stateBg?: string;
+  stateBorder?: string;
+  stateFg?: string;
+};
+
 export type ThemeInputSizeProfile = {
   minHeight?: string;
   paddingX?: string;
@@ -530,6 +547,17 @@ export type ThemeComponents = {
     sizes?: Record<string, ThemeProgressSizeProfile>;
     modes?: Partial<Record<ThemeMode, ThemeProgressModeTokens>>;
     tones?: Record<string, ThemeProgressToneTokens>;
+  };
+  lineChart?: {
+    height?: string;
+    padding?: string;
+    radius?: string;
+    lineWidth?: string;
+    markerSize?: string;
+    maxXTicks?: number;
+    yTickCount?: number;
+    markerThreshold?: number;
+    modes?: Partial<Record<ThemeMode, ThemeLineChartModeTokens>>;
   };
   input?: {
     defaultSize?: string;


### PR DESCRIPTION
Closes #147

storybook-component: luna-line-chart

## Summary
Implemented `LunaLineChart` as a scoped first-pass single-series chart primitive in [LunaLineChart.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.tsx), with theme-driven axis/line/marker/container tokens added in [base.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/base.ts) and [types.ts](/Users/jordanb/.codex/automations/react-luna/src/theme/types.ts). The contract stays narrow: ordered `{ label, value }` data, accessible naming/description, optional legend and grid, automatic marker suppression for denser series, and defined empty/loading/error states. Storybook, tests, docs, release metadata, and screenshot manifest coverage were added in [LunaLineChart.stories.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.stories.tsx), [LunaLineChart.test.tsx](/Users/jordanb/.codex/automations/react-luna/src/components/luna-line-chart/LunaLineChart.test.tsx), [LunaLineChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/components/LunaLineChart.md), [LunaLineChart.md](/Users/jordanb/.codex/automations/react-luna/docs/v1/design/LunaLineChart.md), [.changeset/issue-147-luna-line-chart.md](/Users/jordanb/.codex/automations/react-luna/.changeset/issue-147-luna-line-chart.md), and [luna-line-chart.json](/Users/jordanb/.codex/automations/react-luna/playwright/storybook/manifests/luna-line-chart.json).

Verification ran:
- `npm test -- src/components/luna-line-chart/LunaLineChart.test.tsx` passed.
- `npm run build` passed.
- `npm run storybook:build` passed.
- `STORYBOOK_COMPONENT=luna-line-chart npm run screenshots:storybook` ran, but failed in this sandbox because Playwright could not bind `127.0.0.1:6106` (`EPERM`). I still confirmed the built Storybook index contains the expected `components-lunalinechart--*` story IDs, so the manifest path is aligned.

I left the existing workflow-status drift untouched to keep this issue scoped. I also could not create the requested step commit because the sandbox denies writing `.git/index.lock`, so the work remains uncommitted in the working tree.

## Verification
- `npm test`
- `npm run build`
- `npm run storybook:build`
- `npm run screenshots:storybook`